### PR TITLE
Fix minor Pod typo (RT#15040)

### DIFF
--- a/bin/diff
+++ b/bin/diff
@@ -720,7 +720,7 @@ Algorithm::Diff - Compute `intelligent' differences between two files / lists
 
 =head1 SYNOPSIS
 
-  use Algorithm::Diff qw(diff LCS trverse_sequences);
+  use Algorithm::Diff qw(diff LCS traverse_sequences);
 
   @lcs = LCS(\@seq1, \@seq2, $comparison_function);
 


### PR DESCRIPTION
Hi,

this (laughably) small typo fix for `diff`'s Pod. This is taken for [ppt](https://rt.cpan.org/Public/Bug/Display.html?id=15040)'s bug queue (which's previous CPAN-incarnation for this funky "bag of crack" (in the terms of [mst](http://shadow.cat/blog/matt-s-trout/mstpan-5/):)

This PR is part of my [advent quest](https://questhub.io/realm/perl/quest/547b4202070ccf750d00010e).

Cheers,
Sergey.
