### PR TITLE
fish: set $Getopt::Std::STANDARD_HELP_VERSION to true

### DIFF
--- a/bin/fish
+++ b/bin/fish
@@ -11,6 +11,7 @@ License: perl
 
 use strict;
 use Getopt::Std;
+$Getopt::Std::STANDARD_HELP_VERSION = 1;
 
 my( @DECK, @PLAYERS_HAND, @COMPUTERS_HAND, @BOOKS, %BOOKS);
 my(@HIS_PAST_GUESSES, @MY_PAST_GUESSES);


### PR DESCRIPTION
According to the Getopt::Std manpage, it is strongly recommended to
set this variable.

Without this option, calling "fish --version" does not do the right
thing --- a user expects either that the version is printed, or that
the option is unknown and the call fails.

See also https://github.com/plicease/Shell-Config-Generate/issues/10
where this showed up as a problem.