### PR TITLE
Patch prompt

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -608,7 +608,7 @@ sub backup {
             $ext = $extension;
             $name =~ s/.// or die "Couldn't create a good backup filename.\n";
         }
-        $file = $name . $ext;
+        $file = "$name.$ext";
     }
     $file;
 }

--- a/bin/patch
+++ b/bin/patch
@@ -263,6 +263,9 @@ package
 
 use vars qw/$ERROR/;
 
+use Term::UI;
+use Term::ReadLine;
+
 # Class data.
 BEGIN {
     $ERROR = 0;
@@ -279,14 +282,6 @@ sub throw {
     $@ = join '', @_;
     $@ .= sprintf " at %s line %d\n", (caller)[1..2] unless $@ =~ /\n\z/;
     goto CATCH;
-}
-
-# Prints a prompt message and returns response.
-sub prompt {
-    print @_;
-    local $_ = <STDIN>;
-    chomp;
-    $_;
 }
 
 # Constructs a Patch object.
@@ -354,6 +349,8 @@ sub bless {
     # Get original file to patch...
     my $orig = $self->{origfile};                   # ...from -o
 
+    my $term = Term::ReadLine->new('patch');
+
     unless (defined $orig) {
         $orig = $self->rummage($garbage);           # ...from leading garbage
         if (defined $orig) {
@@ -365,7 +362,10 @@ sub bless {
             );
         } else {
             $self->skip if $self->{force} || $self->{batch};
-            $orig = prompt ('File to patch: ');     # ...from user
+            $orig = $term->get_reply(
+                prompt => 'File to patch:',
+                allow  => sub { -f },
+            );
         }
     }
 
@@ -374,11 +374,13 @@ sub bless {
         -e $orig or $self->skip;
     } else {
         until (-e $orig) {
-            $self->skip unless prompt (
-                'No file found--skip this patch? [n] '
-            ) =~ /^[yY]/;
-            $orig = prompt (
-                'File to patch: '
+            $self->skip if $term->ask_yn(
+                prompt  => 'No file found--skip this patch?',
+                default => 'n',
+            );
+            $orig = $term->get_reply(
+                prompt => 'File to patch:',
+                allow  => sub { -f },
             );
         }
     }
@@ -393,9 +395,11 @@ sub bless {
         $self->note("Patching file $orig using Plan B...\n");
         local $_ = $self->{output};
         $self->skip if -e && not rename $_, $self->backup($_) and
-            $self->{force} || $self->{batch} || prompt (
-                'Failed to backup output file--skip this patch? [n] '
-            ) =~ /^[yY]/;
+            $self->{force} || $self->{batch} ||
+            $term->ask_yn (
+                prompt  => 'Failed to backup output file--skip this patch?',
+                default => 'n',
+            );
         ($in, $out) = ($orig, $self->{output});
     } else {
         $self->note("Patching file $orig using Plan A...\n");
@@ -403,9 +407,11 @@ sub bless {
         if (rename $orig, $back) {
             ($in, $out) = ($back, $orig);
         } else {
-            $self->skip unless $self->{force} || $self->{batch} or prompt (
-                'Failed to backup original file--skip this patch? [n] '
-            ) !~ /^[yY]/;
+            $self->skip unless $self->{force} || $self->{batch} or 
+            !($term->ask_yn(
+                prompt  => 'Failed to backup original file--skip this patch?',
+                default => 'n',
+            ));
             ($in, $out) = ($orig, $orig);
         }
     }
@@ -447,9 +453,11 @@ sub bless {
                 $found++, last if /$prereq/;
             }
             seek IN, 0, 0 or $self->skip("Couldn't seek INFILE: $!\n");
-            $self->skip if not $found and $self->{batch} || prompt (
-                'File does not match "Prereq: $1"--skip this patch? [n] '
-            ) =~ /^[yY]/;
+            $self->skip if not $found and $self->{batch} || 
+            $term->ask_yn(
+                prompt  => 'File does not match "Prereq: $1"--skip this patch?',
+                default => 'n',
+           );
         }
     }
 
@@ -639,6 +647,7 @@ sub apply {
     my @context = map /^[ -](.*)/s, @hunk;
     my $position;
     my $fuzz = 0;
+    my $term = Term::ReadLine->new('patch');
 
     if (@context) {
         # Find a place to apply hunk where context matches.
@@ -669,15 +678,17 @@ sub apply {
                 $self->{reverse_check} = 0;
                 if ($position) {
                     unless ($self->{batch}) {
-                        local $_ = prompt (
-                            'Reversed (or previously applied) patch detected!',
-                            '  Assume -R? [y] '
+                        my $reply = $term->ask_yn(
+                            prompt  => 'Reversed (or previously applied) patch detected! Assume -R?',
+                            default => 'y',
                         );
-                        if (/^[nN]/) {
+                        if (!$reply) {
                             $self->{reverse} = 0;
                             $position = 0;
-                            prompt ('Apply anyway? [n] ') =~ /^[yY]/
-                                or throw 'SKIP...ignore this patch';
+                            $term->ask_yn(
+                                prompt => 'Apply anyway?',
+                                default => 'n',
+                            ) or throw 'SKIP...ignore this patch';
                         }
                     }
                 } else {

--- a/bin/patch
+++ b/bin/patch
@@ -261,10 +261,18 @@ END {
 package
 	Patch; # hide from PAUSE
 
-use vars qw/$ERROR/;
+# with strawberry perl under windows 7 (and likely elsewhere)
+# the default tends to be to use Term::ReadLine::Perl, which
+# doesn't work well on windows. Force it to T::RL::Stub instead
+BEGIN {
+    $ENV{'PERL_RL'} ||= 'stub' if $^O eq 'MSWin32';
+}
+
 
 use Term::UI;
 use Term::ReadLine;
+
+use vars qw/$ERROR/;
 
 # Class data.
 BEGIN {

--- a/bin/patch
+++ b/bin/patch
@@ -87,7 +87,7 @@ tie *PATCH, Pushback => $patchfile or die "Can't open '$patchfile': $!";
 # the PATCH filehandle:  'print PATCH'
 PATCH:
 while (<PATCH>) {
-    if (/^(\s*)(\@\@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? \@\@\n)/) {
+    if (/^(\s*)(\@\@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? \@\@(.*)\n)/) {
         # UNIFIED DIFF
         my ($space, $range, $i_start, $i_lines, $o_start, $o_lines) =
            ($1,     $2,     $3,       $4 || 1,  $5,       $6 || 1);


### PR DESCRIPTION
#30 is somewhat handled with this PR.

 It allows for trailing info in the chunk header, replaces prompt() with [Term::UI](https://metacpan.org/pod/Term::UI), and fixes a bug with backup file creation.

I didn't test what happens with a git diff generated patch file that works over multiple files. I suspect that won't work correctly.

This also helps expose an issue with recovery from an interupted patch process that I'll open a separate issue for.