### PR TITLE
Doc: more specific description of "cal"

### DIFF
--- a/lib/PerlPowerTools.pm
+++ b/lib/PerlPowerTools.pm
@@ -46,7 +46,7 @@ setting C<INSTALL_BASE> when you run F<Makefile.PL>.
 
 =item bc - An arbitrary precision calculator language
 
-=item cal - member of the Perl Power Tools
+=item cal - display a calendar
 
 =item cat - concatenate and print files.
 


### PR DESCRIPTION
I was just reading the POD and saw "cal" described simply as "member of the Perl Power Tools" which gives little away. This is just a documentation fix to change it to "display a calendar" (which is what my binary cal gives with apropos).

HTH.