### PR TITLE
declare dependency on App::find2perl

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -111,10 +111,11 @@ my %WriteMakefile = (
 		},
 
 	'PREREQ_PM'     => {
-		'App::a2p'     => '0',
-		'Make'         => '0',
-		'MIME::Parser' => '0',
-		'DB_File'      => '0',
+		'App::a2p'       => '0',
+		'App::find2perl' => '0',
+		'Make'           => '0',
+		'MIME::Parser'   => '0',
+		'DB_File'        => '0',
 		},
 
 	'META_MERGE' => {


### PR DESCRIPTION
`find` command needs `find2perl` which was removed from the perl core in 5.20.