### PR TITLE
Fallback to system("cls") on Windows

### DIFF
--- a/bin/clear
+++ b/bin/clear
@@ -30,7 +30,11 @@ eval {
 	$cl = $terminal->Tputs('cl', 1);
 };
 
-print $cl;
+if ($cl eq "" && $^O eq 'MSWin32') {
+    system 'cls';
+} else {
+    print $cl;
+}
 
 
 =head1 NAME


### PR DESCRIPTION
For #46.

Using Term::Cap may not work on Windows (at least with Strawberry Perl), in which case, use the use the system "cls" command.
