### PR TITLE
Fixes for bin/robots

### DIFF
--- a/bin/robots
+++ b/bin/robots
@@ -150,8 +150,10 @@ my($key_r_re) = "[$key_ur$key_r$key_dr]"; # movement right
 #
 # Globals
 #
-
-use vars qw($LINES $COLS); # From Curses.pm(?)
+BEGIN {
+	import Curses;
+}
+# use vars qw($LINES $COLS); # From Curses.pm(?)
 
 MAIN:
 {

--- a/bin/robots
+++ b/bin/robots
@@ -34,8 +34,8 @@ BEGIN {
 		warn <<"HERE";
 $0 requires the Perl Curses module!
 HERE
+		exit;
 		}
-	exit;
 	}
 
 


### PR DESCRIPTION
The block checking for the Curses module was always calling exit, so bin/robots never ran;  correcting that, bin/robots was not importing Curses constants, instead using package globals created with use vars which were unset.
