### PR TITLE
Fixed indirect object notation

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -225,7 +225,7 @@ sub extractMember {
 				   oct($attr->[4]), int($attr->[1]));
     }
 
-    my $out = new FileHandle ">$name" or die "$name: $!\n";
+    my $out = FileHandle->new ">$name" or die "$name: $!\n";
     binmode($out);
     $out->print($attr->[6]);
     $out->close();
@@ -244,7 +244,7 @@ sub extractMember {
 # [ undef, $modt, $uid, $gid, $mode, $sz, $data ]
 sub readFile {
     my ($file) = @_;
-    my $in = new FileHandle "< $file" or die "$file: $!\n";
+    my $in = FileHandle->new "< $file" or die "$file: $!\n";
     binmode($in);
 
     # read the data in one swell foop
@@ -271,7 +271,7 @@ sub readAr {
     # names in order in file
     my @Names = ( undef );
 
-    my $arfh = new FileHandle "< $archive" or die "$0: $archive: $!\n";
+    my $arfh = FileHandle->new "< $archive" or die "$0: $archive: $!\n";
     binmode($arfh);
 
     # read magic
@@ -335,11 +335,11 @@ sub writeAr {
 
     my $arfh;
     if (!defined($append)) {
-	$arfh = new FileHandle "> $archive" or die "$0: $archive: $!\n";
+	$arfh = FileHandle->new "> $archive" or die "$0: $archive: $!\n";
 	$arfh->print("!<arch>\n");
     }
     else {
-	$arfh = new FileHandle ">> $archive" or die "$0: $archive: $!\n";
+	$arfh = FileHandle->new ">> $archive" or die "$0: $archive: $!\n";
     }
 
     # loop through each member of the archive and write to filehandle

--- a/bin/ar
+++ b/bin/ar
@@ -225,7 +225,7 @@ sub extractMember {
 				   oct($attr->[4]), int($attr->[1]));
     }
 
-    my $out = FileHandle->new ">$name" or die "$name: $!\n";
+    my $out = FileHandle->new(">$name") or die "$name: $!\n";
     binmode($out);
     $out->print($attr->[6]);
     $out->close();
@@ -244,7 +244,7 @@ sub extractMember {
 # [ undef, $modt, $uid, $gid, $mode, $sz, $data ]
 sub readFile {
     my ($file) = @_;
-    my $in = FileHandle->new "< $file" or die "$file: $!\n";
+    my $in = FileHandle->new("< $file") or die "$file: $!\n";
     binmode($in);
 
     # read the data in one swell foop
@@ -271,7 +271,7 @@ sub readAr {
     # names in order in file
     my @Names = ( undef );
 
-    my $arfh = FileHandle->new "< $archive" or die "$0: $archive: $!\n";
+    my $arfh = FileHandle->new("< $archive") or die "$0: $archive: $!\n";
     binmode($arfh);
 
     # read magic
@@ -335,11 +335,11 @@ sub writeAr {
 
     my $arfh;
     if (!defined($append)) {
-	$arfh = FileHandle->new "> $archive" or die "$0: $archive: $!\n";
+	$arfh = FileHandle->new("> $archive") or die "$0: $archive: $!\n";
 	$arfh->print("!<arch>\n");
     }
     else {
-	$arfh = FileHandle->new ">> $archive" or die "$0: $archive: $!\n";
+	$arfh = FileHandle->new(">> $archive") or die "$0: $archive: $!\n";
     }
 
     # loop through each member of the archive and write to filehandle

--- a/bin/diff
+++ b/bin/diff
@@ -148,7 +148,7 @@ my ($hunk,$oldhunk);
 # Loop over hunks. If a hunk overlaps with the last hunk, join them.
 # Otherwise, print out the old one.
 foreach my $piece (@$diffs) {
-    $hunk = new Hunk ($piece, $Context_Lines);
+    $hunk = Hunk->new($piece, $Context_Lines);
     next unless $oldhunk; # first time through
 
     # Don't need to check for overlap if blocks have no context lines
@@ -203,7 +203,7 @@ sub new {
 # after_diff  - difference due to all hunks including this one
     my ($class, $piece, $context_items) = @_;
 
-    my $block = new Block ($piece); # this modifies $FLD!
+    my $block = Block->new($piece); # this modifies $FLD!
 
     my $before_diff = $File_Length_Difference; # BEFORE this hunk
     my $after_diff = $before_diff + $block->{"length_diff"};

--- a/bin/file
+++ b/bin/file
@@ -101,7 +101,7 @@ GetOptions("m=s",\$magicFile,
 
 # the names of the files are in $fileList.
 if ($fileList) {
-    my $fileListFH = FileHandle->new "< $fileList" or
+    my $fileListFH = FileHandle->new("< $fileList") or
       die "$F: $fileList: $!\n";
     unshift(@ARGV,<$fileListFH>);
     $fileListFH->close();
@@ -129,7 +129,7 @@ print STDERR "Using magic file $magicFile\n" if $checkMagic;
 
 # $MF is the magic file state: [ filehandle, buffered last line, line num ]
 my $MF = [];
-$$MF[0] = FileHandle->new "< $magicFile" or die "$magicFile: $!\n";
+$$MF[0] = FileHandle->new("< $magicFile") or die "$magicFile: $!\n";
 $$MF[1] = undef;
 $$MF[2] = 0;
 readMagicEntry(\@magic,$MF);
@@ -178,7 +178,7 @@ foreach $file (@ARGV) {
     # current file handle.  or undef if checkMagic (-c option) is true.
     my $fh;
 
-    $fh = FileHandle->new "< $file" or die "$F: $file: $!\n" ;
+    $fh = FileHandle->new("< $file") or die "$F: $file: $!\n" ;
 
     # 2) check for script
     if (-x $file && -T _) {

--- a/bin/file
+++ b/bin/file
@@ -101,7 +101,7 @@ GetOptions("m=s",\$magicFile,
 
 # the names of the files are in $fileList.
 if ($fileList) {
-    my $fileListFH = new FileHandle "< $fileList" or
+    my $fileListFH = FileHandle->new "< $fileList" or
       die "$F: $fileList: $!\n";
     unshift(@ARGV,<$fileListFH>);
     $fileListFH->close();
@@ -129,7 +129,7 @@ print STDERR "Using magic file $magicFile\n" if $checkMagic;
 
 # $MF is the magic file state: [ filehandle, buffered last line, line num ]
 my $MF = [];
-$$MF[0] = new FileHandle "< $magicFile" or die "$magicFile: $!\n";
+$$MF[0] = FileHandle->new "< $magicFile" or die "$magicFile: $!\n";
 $$MF[1] = undef;
 $$MF[2] = 0;
 readMagicEntry(\@magic,$MF);
@@ -178,7 +178,7 @@ foreach $file (@ARGV) {
     # current file handle.  or undef if checkMagic (-c option) is true.
     my $fh;
 
-    $fh = new FileHandle "< $file" or die "$F: $file: $!\n" ;
+    $fh = FileHandle->new "< $file" or die "$F: $file: $!\n" ;
 
     # 2) check for script
     if (-x $file && -T _) {

--- a/bin/lock
+++ b/bin/lock
@@ -57,7 +57,7 @@ for ( my $i = 0 ; $i <= $#ARGV ; ++ $i )
 }
 
 local $main::fd_stdin = fileno(STDIN);
-local $main::term = new POSIX::Termios;
+local $main::term = POSIX::Termios->new;
 $main::term->getattr($main::fd_stdin);
 local $main::oterm = $main::term->getlflag();
 local $main::echo = &POSIX::ECHO;

--- a/bin/mail
+++ b/bin/mail
@@ -397,7 +397,7 @@ sub load {
 	while(<MBOX>) {
 		chomp;
 		if (@MESS and /^From /) {
-			my $message=new message;
+			my $message=message->new;
 			$message->load_from_array(@MESS);
 			$message->sequence($start++);
 			push(@{$self->{messages}}, $message);
@@ -406,7 +406,7 @@ sub load {
 		push(@MESS, $_)
 	}
 	if (@MESS) {
-		my $message=new message;
+		my $message=message->new;
 		$message->load_from_array(@MESS);
 		$message->sequence($start++);
 		push(@{$self->{messages}}, $message);
@@ -684,9 +684,9 @@ sub shell {
 }
 sub mail {
 	my($list,$mesgno)=@_;   # Target addresses
-	my $msg=new message;
+	my $msg=message->new;
 	$msg->to($list);    # For whom the message tolls
-	my $editor=new editor;
+	my $editor=editor->new;
 	$editor->mesgno($mesgno);
 	$editor->message($msg);
 	$msg=$editor->edit({ subject => 1});
@@ -694,7 +694,7 @@ sub mail {
 		print "Aborted\n";
 		return;
 	}
-	my $mailer=new mailer;
+	my $mailer=mailer->new;
 	$mailer->send($msg);
 }
 sub replyCC {
@@ -715,11 +715,11 @@ sub replyCC {
 		push(@ccaddrs, @$tc);
 	}
 
-	my $msg=new message;
+	my $msg=message->new;
 	$msg->to(\@replies);    # For whom the message tolls
 	$msg->cc(\@ccaddrs);
 	$msg->subject($subj);
-	my $editor=new editor;
+	my $editor=editor->new;
 	$editor->mesgno(@{$list}[0]);   # Use just the FIRST
 	$editor->message($msg);
 	print "To: ", join(',', @replies), "\n";
@@ -732,7 +732,7 @@ sub replyCC {
 		print "Aborted\n";
 		return;
 	}
-	my $mailer=new mailer;
+	my $mailer=mailer->new;
 	$mailer->send($msg);
 }
 sub reply {
@@ -751,10 +751,10 @@ sub reply {
 		push(@replies, $original->from);
 	}
 
-	my $msg=new message;
+	my $msg=message->new;
 	$msg->to(\@replies);    # For whom the message tolls
 	$msg->subject($subj);
-	my $editor=new editor;
+	my $editor=editor->new;
 	$editor->mesgno(@{$list}[0]);   # Use just the FIRST
 	$editor->message($msg);
 	print "To: ", join(',', @replies), "\n";
@@ -764,7 +764,7 @@ sub reply {
 		print "Aborted\n";
 		return;
 	}
-	my $mailer=new mailer;
+	my $mailer=mailer->new;
 	$mailer->send($msg);
 }
 sub quit {
@@ -791,12 +791,12 @@ sub visual {
 			warn "Invalid message number: $msgno\n";
 			return;
 		}
-		my $tmbox=new mailbox(file => "/tmp/ppt_mail$$");
+		my $tmbox=mailbox->new(file => "/tmp/ppt_mail$$");
 		$tmbox->stuff($message);
 		$tmbox->file("/tmp/ppt_mail$$");
 		$tmbox->write;
 		system("$ENV{VISUAL} /tmp/ppt_mail$$");
-		$tmbox2=new mailbox(file => "/tmp/ppt_mail$$");  # Hope this isn't a leak
+		$tmbox2=mailbox->new(file => "/tmp/ppt_mail$$");  # Hope this isn't a leak
 		print Dumper $tmbox2;
 		$tmbox2->load;
 		print Dumper $tmbox2;
@@ -881,7 +881,7 @@ sub msg_store {
 	my($msgs, $file, $options)=@_;
 
 	print "Saving message...$msgs to $file\n";
-	my $tempbox=new mailbox(file => $file);
+	my $tempbox=mailbox->new(file => $file);
 	foreach my $msg (@$msgs) {
 		$message=$box->messagex($msg);
 		if (! defined $message) {
@@ -960,7 +960,7 @@ sub parse_msg_list {
 #
 sub Interactive {
 	my($file)=@_;
-	$box=new mailbox(file => $file);
+	$box=mailbox->new(file => $file);
 	if (! $box->load ) {
 		print "You have no mail\n";
 		exit;
@@ -1015,12 +1015,12 @@ sub debug {
 	}
 }
 sub Batch {
-	my $message=new message;
+	my $message=message->new;
 	$message->to([@_]);
 	$message->cc([ split(/,/, $opt_c) ]) if ($opt_c);
 	$message->bcc([ split(/,/, $opt_b) ]) if ($opt_b);
 	$message->subject($opt_s) if ($opt_s);
-	my $mailer=new mailer;
+	my $mailer=mailer->new;
 	my @BODY=<STDIN>;
 	chomp(@BODY);
 	$message->add_to_body(@BODY);

--- a/bin/pr
+++ b/bin/pr
@@ -150,7 +150,7 @@ foreach(1..$columns) {
 	push(@COLINFO, &create_col);
 }
 foreach(@ARGV) {
-	my $fh=new FileHandle "$_", "r";
+	my $fh= FileHandle->new "$_", "r";
 	if (! $fh) {
 		next if ($quietskip);
 		die "$0: Can't open $_";

--- a/bin/pr
+++ b/bin/pr
@@ -150,7 +150,7 @@ foreach(1..$columns) {
 	push(@COLINFO, &create_col);
 }
 foreach(@ARGV) {
-	my $fh= FileHandle->new "$_", "r";
+	my $fh= FileHandle->new("$_", "r");
 	if (! $fh) {
 		next if ($quietskip);
 		die "$0: Can't open $_";

--- a/bin/rev
+++ b/bin/rev
@@ -45,7 +45,7 @@ EOF
 elsif (-f $ARGV[0]) {
 
 	if ($debug) {print "\n\nthis is a file\n\n";}
-	my $fh = FileHandle->new "< $ARGV[0]";  # here is the file handle
+	my $fh = FileHandle->new("< $ARGV[0]");  # here is the file handle
 
 	# in case the file handle does not open
     unless (defined ($fh)) {

--- a/bin/rev
+++ b/bin/rev
@@ -45,7 +45,7 @@ EOF
 elsif (-f $ARGV[0]) {
 
 	if ($debug) {print "\n\nthis is a file\n\n";}
-	my $fh = new FileHandle "< $ARGV[0]";  # here is the file handle
+	my $fh = FileHandle->new "< $ARGV[0]";  # here is the file handle
 
 	# in case the file handle does not open
     unless (defined ($fh)) {

--- a/bin/robots
+++ b/bin/robots
@@ -159,7 +159,7 @@ MAIN:
 {
   &Parse_Args();
 
-  $Win = new Curses;
+  $Win = Curses->new;
 
   &Show_Scores()  if($Opts{'s'});
 
@@ -651,7 +651,7 @@ sub Get_Command
       # The is the only way I could get a nice screen redraw
       # for some reason.  If Curses.pm just supported tstp(),
       # I wouldn't have to do this...
-      $Win = new Curses;
+      $Win = Curses->new;
       $chr = $key_redraw;
 
       $Just_Suspended = 1;

--- a/bin/tac
+++ b/bin/tac
@@ -39,7 +39,7 @@ if (defined $opts{separator} && $opts{regex}) {
 
 $opts{files} = \@ARGV;
 
-my $fh = new IO::Tac %opts or die "$0: can't open file: $!\n";
+my $fh =  IO::Tac->new %opts or die "$0: can't open file: $!\n";
 print while <$fh>;
 
 END {

--- a/bin/tac
+++ b/bin/tac
@@ -39,7 +39,7 @@ if (defined $opts{separator} && $opts{regex}) {
 
 $opts{files} = \@ARGV;
 
-my $fh =  IO::Tac->new %opts or die "$0: can't open file: $!\n";
+my $fh =  IO::Tac->new(%opts) or die "$0: can't open file: $!\n";
 print while <$fh>;
 
 END {

--- a/bin/time
+++ b/bin/time
@@ -17,9 +17,9 @@ License: perl
 
 use Benchmark;
 
-$t0 = new Benchmark;
+$t0 = Benchmark->new;
 $rc = system(@ARGV);
-$t1 = new Benchmark;
+$t1 = Benchmark->new;
 $td = timediff($t1,$t0);
 ($real, $child_user, $child_system) = @$td[0,3,4];
 

--- a/bin/whois
+++ b/bin/whois
@@ -37,7 +37,7 @@ while($i = shift) {
 
 $| = 1;
 
-$sock = new IO::Socket::INET(PeerAddr => $host,
+$sock = IO::Socket::INET->new(PeerAddr => $host,
                              PeerPort => 43,
 			     Proto => 'tcp');
 


### PR DESCRIPTION
Fixed 11 files so the program uses the preferred syntax instead of indirect object notation. Issue #73 