### PR TITLE
Fix issue with NULL filehandle in patch.

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -434,8 +434,8 @@ sub bless {
 
     # Open output file.
     if ($self->{check}) {
-        $self->{o_fh} = \*NULL;     # output filehandle
-        $self->{d_fh} = \*NULL;     # ifdef filehandle
+        $self->{o_fh} = *NULL;     # output filehandle
+        $self->{d_fh} = *NULL;     # ifdef filehandle
     } else {
         local *OUT;
         open OUT, "+> $out" or $self->skip("Couldn't open OUTFILE: $!\n");
@@ -443,7 +443,7 @@ sub bless {
         $|++, select $_ for select OUT;
         $self->{o_fh}   = *OUT;
         $self->{o_file} = $out;
-        $self->{d_fh}   = length $self->{ifdef} ? *OUT : \*NULL;
+        $self->{d_fh}   = length $self->{ifdef} ? *OUT : *NULL;
     }
 
     $self->{'reject-file'} = "$out.rej" unless defined $self->{'reject-file'};


### PR DESCRIPTION
*Rebased from #84*

Currently patch saves an reference to a localized NULL filehandle in the
object hash in its bless() method. But when the bless() method returns
the original value of *NULL is restored (which is empty). Meaning that
when patch later calls apply() and tries to print to the  NULL handle,
we get a warning about trying to print to a closed filehandle.

The correct behavior should be to store a copy of *NULL (not a
reference *NULL)  or to not localize *NULL in the first place..