### PR TITLE
bc: auto init of simple variables

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -1730,17 +1730,13 @@ $count++;
 
    } elsif($_ eq 'v') {
 
-# Variable value
+# Variable value : initialized to 0
 # '*' is reserved for internal variables
 
      my $name = $instr->[1];
      unless (defined($sym_table{$name})
 	     and $sym_table{$name}{'type'} eq 'var') {
-       print STDERR "$name: undefined variable\n";
-       $return = 3;
-       @ope_stack = ();
-       @stmt_list=();
-       YYERROR;
+       $sym_table{$name}{'value'} = 0;
      }
      push(@ope_stack, $sym_table{$name}{'value'});
      next INSTR;


### PR DESCRIPTION
$ bc -v
bc 1.07.1
Copyright 1991-1994, 1997, 1998, 2000, 2004, 2006, 2008, 2012-2017 Free Software Foundation, Inc. $ bc -q
x
0
y++
0
y
1

Same behavour is seen for -s (standard posix) flag; variables can be operated on before being assigned. Also for the Gavin Howard version of bc (below).

$ bc.gavin -v
bc.gavin 6.2.4
Copyright (c) 2018-2023 Gavin D. Howard and contributors ...
$ bc.gavin -s
>>> x
0
>>> y += 2
>>> y
2
>>> z++
0
>>> z
1
>>> quit

This version of bc raises an error for regular variables but not for arrays.

$ perl bc 
ary[0] = 123
123
ary[1]
0
var0
var0: undefined variable

Also see:
https://pubs.opengroup.org/onlinepubs/009696799/utilities/bc.html
"Simple identifiers and array elements are named expressions; they have an initial value of zero and an initial scale of zero."