### PR TITLE
bc: remove support for evaluating perl expressions

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -1150,14 +1150,6 @@ if ($yyn == 80) {
 { $yyval = $yyvs[$yyvsp-0];
 last switch;
 } }
-if ($yyn == 81) {
-#line 442 "bc.y"
-{
-		  push_instr('&', $yyvs[$yyvsp-0]);
-		  $yyval = 1;
-
-last switch;
-} }
 if ($yyn == 82) {
 #line 448 "bc.y"
 {
@@ -2032,13 +2024,6 @@ $count++;
 				value => $code };
      $return = 3;
      push(@ope_stack, 1); # whatever
-     next INSTR;
-
-   } elsif($_ eq '&') {
-
-# Evaluating a Perl instruction
-     $res = eval $instr->[1];
-     push(@ope_stack, "\nresult of eval: $res");
      next INSTR;
 
    } elsif($_ eq 'S') {

--- a/bin/bc
+++ b/bin/bc
@@ -560,7 +560,7 @@ $YYMAXTOKEN=294;
 "expr : ident PPP",
 "expr : ident MMM",
 "expr : '+' expr",
-"expr : '&' STRING",
+undef, # "expr : '&' STRING", # removed feature but we didn't want to disturb sequence
 "expr : IDENT '=' expr",
 "expr : IDENT '[' expr ']' '=' expr",
 "expr : ident",


### PR DESCRIPTION
The bc language has the operator '&&' but not '&'. This version of bc has a grammar extension &"STRING" which calls eval().

$ perl bc 
":)"
:)
& "syscall 23,45"
Segmentation fault (core dumped)

bc can be run under "perl -d" for debugging so the extension seems undesirable.