### PR TITLE
od: rename option -s to -j

### DIFF
--- a/bin/od
+++ b/bin/od
@@ -236,7 +236,7 @@ od - dump files in octal and other formats
 
 =head1 SYNOPSIS
 
-B<od.pl> [ I<-abcdfiloxv> ] [ I<-A radix> ]  F<filename>
+B<od.pl> [ I<-abcdfiloxv> ] [I<-j skip_n_bytes>] [ I<-A radix> ]  F<filename>
 
 =head1 DESCRIPTION
 

--- a/bin/od
+++ b/bin/od
@@ -14,12 +14,11 @@ License: perl
 
 use strict;
 use Getopt::Std;
-use vars qw/ $opt_A $opt_b $opt_c $opt_d $opt_f $opt_i $opt_l $opt_o
-$opt_v $opt_x $opt_s /;
+use vars qw/ $opt_A $opt_b $opt_c $opt_d $opt_f $opt_i $opt_j $opt_l $opt_o
+$opt_v $opt_x /;
 
 my ($offset1, $radix, $data, @arr, $len);
-my ($lastline, $upformat, $pffmt, $strfmt, $skip, $ml);
-my $retval;
+my ($lastline, $upformat, $pffmt, $strfmt, $ml);
 local *FH;
 
 my %charescs = (
@@ -60,14 +59,14 @@ my %charescs = (
 $offset1 = 0;
 $lastline = '';
 
-getopts('A:bcdfilovxs:') or help();
+getopts('A:bcdfij:lovx') or help();
     defined $opt_A ? ($radix = $opt_A) : ($radix = 'o');
-    defined $opt_s && ($offset1 = $opt_s);
+    defined $opt_j && ($offset1 = $opt_j);
 
 open(FH, '<', $ARGV[0]) || die "Can't open $ARGV[0] for read: $!";
 
 binmode(FH);
-seek(FH,$offset1,0);
+seek(FH, $offset1, 0) if $offset1;
 
 $opt_o = 1 if ! ($opt_b || $opt_c || $opt_d || $opt_f || $opt_i ||
 		 $opt_l || $opt_o || $opt_x);


### PR DESCRIPTION
* Existing -s option skips bytes at beginning of input
* NetBSD, OpenBSD and GNU versions of od(1) call this option -j because -s indicates something else according to the standard
* We can rename the option for better compatibility with shell scripts (-j is currently free)
* While here, avoid seek() if -j isn't set
* Remove unused variables $retval and $skip

Also see:
https://pubs.opengroup.org/onlinepubs/009696899/utilities/od.html