### PR TITLE
xargs: report system() failure

### DIFF
--- a/bin/xargs
+++ b/bin/xargs
@@ -65,7 +65,10 @@ while (1) {
 	@args = ();
     }
     if ($o{t}) { local $" = "', '"; warn "exec '@run'\n"; }
-    system(@run) == 0 or exit($? >> 8);
+    if (system(@run) != 0) {
+	warn "$0: $run[0]: $!\n";
+	exit($? >> 8);
+    }
 }
 
 =encoding utf8


### PR DESCRIPTION
When GNU xargs is given an invalid command to run it prints the command and the error.

$ ls -1 a* | xargs 'cat;ls' 
xargs: cat;ls: No such file or directory

With the above input, this version of xargs fails silently (but correctly). Internally it calls system(LIST) rather than system(STRING), so the intent of the code is to bypass the shell. I think making the error string visible would avoid confusion.