### PR TITLE
od -x: incorrect hex output

### DIFF
--- a/bin/od
+++ b/bin/od
@@ -206,7 +206,7 @@ sub octal2 {
 }
 
 sub hex {
-    $upformat = 's*'; # for -x
+    $upformat = 'S*'; # for -x
     $pffmt = '%.4x ';
     @arr = unpack($upformat,$data);
     $strfmt = $pffmt x (scalar @arr);


### PR DESCRIPTION
When reading from urandom device, od appears to extend the 16-bit numbers it formats.

$ od -x /dev/urandom | head -n 1    # GNU od for reference
0000000 cdb9 326b daef 219e 3d2b e438 2d33 a52e
$ perl od -x /dev/urandom | head -n 1 
00000000 ffffffffffffeb2c fffffffffffff038 71e6 ffffffffffff9244 fffffffffffffde4 fffffffffffff8e9 18d0 ffffffffffffab76 

hex() is called for each line of output (name overlaps with built-in hex() function). When I debug this I note that @arr is a list of signed 16 bit numbers. The format $strfmt passed to printf() looks like '%.4x %.4x %.4x %.4x %.4x %.4x %.4x %.4x '. printf() is happy printing negative hex numbers but @arr should be unsigned. Switching unpack's format argument from signed to unsigned fixes the problem on my system.