### PR TITLE
head: support for reading stdin

### DIFF
--- a/bin/head
+++ b/bin/head
@@ -15,57 +15,39 @@ License: perl
 use strict;
 use Getopt::Std;
 
-my ($VERSION) = '1.2';
+my ($VERSION) = '1.3';
 
-END {
-    close STDOUT || die "can't close stdout: $!\n";
-    $? = 1 if $? == 255;  # from die
-}
+my %opt;
+getopts('n:', \%opt) or die("usage: $0 [-n count] [files ...]\n");
 
-my $warnings = 0;
-# Print a usage message on a unknown option.
-# Requires my patch to Getopt::Std of 25 Feb 1999.
-$SIG {__WARN__} = sub {
-    if (substr ($_ [0], 0, 14) eq "Unknown option") {die "Usage"};
-    require File::Basename;
-    $0 = File::Basename::basename ($0);
-    $warnings = 1;
-    warn "$0: @_";
-};
-
-$SIG {__DIE__} = sub {
-    require File::Basename;
-    $0 = File::Basename::basename ($0);
-    if (substr ($_ [0], 0,  5) eq "Usage") {
-        die <<EOF;
-$0 (Perl bin utils) $VERSION
-$0 [-n count] [files ...]
-EOF
-    }
-    die "$0: @_";
-};
-
-# Get the options.
-getopts ('n:', \my %options);
-
-my $count = defined $options {n} ? $options {n} : 10;
+my $count = (defined $opt{'n'}) ? $opt{'n'} : 10;
 
 die "invalid number `$count'\n" if $count =~ /\D/;
 
 @ARGV = '-' unless @ARGV;
 
 foreach my $file (@ARGV) {
-    local *FILE;
-    open FILE, '<', $file or do {
-        $0 =~ s{.*/}{};
+    my ($fh, $is_stdin);
+    if ($file eq '-') {
+        $fh = *STDIN;
+        $is_stdin = 1;
+    }
+    if (!$is_stdin && !open($fh, '<', $file)) {
         warn "$0: $file: $!\n";
         next;
-    };
-    print "==> ${$file eq '-' ? \'standard input' : \$file} <==\n" if @ARGV > 1;
-    my $c = $count;
-    while ($c -- && defined ($_ = <FILE>)) {print}
-    close FILE;
+    }
+    if (scalar(@ARGV) > 1) {
+        my $fname = $is_stdin ? 'standard input' : $file;
+        print "==> $fname <== \n";
+    }
+    foreach (1 .. $count) {
+        my $line = <$fh>;
+        last unless (defined $line);
+        print $line;
+    }
+    close($fh) unless $is_stdin;
 }
+
 
 __END__
 


### PR DESCRIPTION
This version of head treats "head -" the same as "head"; neither option seems to work. 
$ perl head < longfile
head: head: -: No such file or directory

GNU head accepts "head -n 1 - foo -" which will read stdin twice.
Support stdin by conditionally opening a file, being careful not to close stdin in case it appears repeatedly.
Also print usage string (taken from SYNOPSIS) if invalid options are provided.