### PR TITLE
xargs: default command

### DIFF
--- a/bin/xargs
+++ b/bin/xargs
@@ -51,6 +51,7 @@ while (1) {
 	last if $o{l} and $totlines >= $o{l};
     }
     my @run = @ARGV;
+    push @run, 'echo' unless (@run);
     if ($o{I}) {
 	exit(0) unless length $line;
 	for (@run) { s/\Q$o{I}\E/$line/g; }


### PR DESCRIPTION
* xargs reads command arguments from stdin; however, the utility to run is taken from ARGV
* This code currently assumes utility is the 1st argument read from stdin if nothing is provided in ARGV
* Standard xargs will execute "echo" if ARGV is empty: https://pubs.opengroup.org/onlinepubs/009604599/utilities/xargs.html
* GNU and OpenBSD versions of xargs follow this behaviour; make it the default here too

$ echo 1 2 3 | perl xargs -t 
exec '1', '2', '3'
xargs: 1: No such file or directory