### PR TITLE
od: sign-extension fix for octal output

### DIFF
--- a/bin/od
+++ b/bin/od
@@ -192,7 +192,7 @@ sub long {
 }
 
 sub octal2 {
-    $upformat = 's*'; # for -o
+    $upformat = 'S*'; # for -o
     $pffmt = '%.6o ';
     @arr = unpack($upformat,$data);
     $strfmt = $pffmt x (scalar @arr);


### PR DESCRIPTION
* Previous commit fixed hex2(): hex output of -x command option
* I failed to notice that the same problem exists for (default) octal output in octal2(), so apply the same fix

Incorrect output was:
$ perl od -j 10 /dev/urandom | head -n 2 
00000012 063771 012764 007563 1777777777777777745631 1777777777777777746222 1777777777777777747524 1777777777777777766742 1777777777777777715623  00000032 011060 074550 1777777777777777743154 065570 037100 1777777777777777754620 026025 036643