### PR TITLE
ed: looping in edPrint()

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -251,7 +251,7 @@ while(<>) {
 sub edPrint {
 
     $adrs[0] = $CurrentLineNum unless (defined($adrs[0]));
-    $adrs[1] = $CurrentLineNum unless (defined($adrs[1]));
+    $adrs[1] = $adrs[0] unless (defined($adrs[1]));
 
     unless ($adrs[1] >= $adrs[0]) {
         edWarn('Second address must be >= first');


### PR DESCRIPTION
* edPrint() is written as a loop from $adrs[0] to $adrs[1]
* When running the command "1p", edPrint() sometimes infers "current line" for $adrs[1]
* When user enters one line address we need to print only that one line
* The correct behaviour for 1p (single addr) is the same as 1,1p (addr range)
* Apply the same fix as done in edDelete; commit 6e411ed92a44ae174ea8e4a92906634d8ccd1ee2
* Example of the incorrect behaviour of 1p after running 1,2p (including trace statements)...

$ perl ed
ME: a
ED: edParse() returns adr( )
ME: aa
ME: bb
ME: cc
ME: dd
ME: .
ME: 1
ED: edParse() returns adr(1 )
ED: aa
ME: 1p
ED: edParse() returns adr(1 )
ED: edPrint() interprets adrs(1 1)
ED: aa
ME: 1,2p
ED: edParse() returns adr(1 2)
ED: edPrint() interprets adrs(1 2)
ED: aa
ED: bb
ME: 1p
ED: edParse() returns adr(1 )
ED: edPrint() interprets adrs(1 2) <------
ED: aa
ED: bb
ME: q