### PR TITLE
expr: logical-or operator is backwards

### DIFF
--- a/bin/expr
+++ b/bin/expr
@@ -37,7 +37,7 @@ sub num($) {
 # table of operators
 my @global_ops = (
     # logical or
-    { 	"|" => sub { $_[0] unless $_[1]; }
+    { 	"|" => sub { $_[0] or $_[1]; }
     },
     # logical and
     { 	"&" => sub { ($_[0] && $_[1]) ? $_[0] : 0; },


### PR DESCRIPTION
* Patch previously submitted via email
* When arg1 is 0 or null, operator '|' is expected to return arg2
* Reference behaviour from expr on my Ubuntu system...

$ /usr/bin/expr '' '|' 22
22
$ /usr/bin/expr 0 '|' 3
3
$ /usr/bin/expr -1 '|' 0
-1