### PR TITLE
echo: emit newline by default

### DIFF
--- a/bin/echo
+++ b/bin/echo
@@ -23,6 +23,7 @@ sub run {
     my ( $self, @args ) = @_;
 
     unless (@args) {
+        print "\n";
         exit 0;
     }
 


### PR DESCRIPTION
* Portability text[1]: "If there are no arguments, only the newline is written"
* The code avoids doing join() on empty list so print the newline in the existing empty-args check
* Tested against echo on Ubuntu and OpenBSD

1. https://pubs.opengroup.org/onlinepubs/009604599/utilities/echo.html