### PR TITLE
ed: allow insert on empty buffer

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -554,13 +554,8 @@ sub edInsert {
 
     $adrs[0] = $CurrentLineNum unless (defined($adrs[0]));
 
-    if (defined($args[1])) {
-        edWarn('Too many addressses');
-        return;
-    }
-
-    if ($adrs[0] == 0 and ($Mode == $INSERT_MODE)) {
-        edWarn("Can't insert before line 0");
+    if (defined($adrs[1])) {
+        edWarn('Too many addresses');
         return;
     }
 
@@ -581,19 +576,17 @@ sub edInsert {
 
     if ($Mode == $INSERT_MODE) {
 
-        if ($adrs[0] == 1) {
-            shift(@lines); # get rid of undefined line
+        shift @lines; # get rid 0 line
+        if ($adrs[0] == 0 || $adrs[0] == 1) {
             unshift(@lines,@tmp_lines);
-            unshift(@lines,undef); # put 0 line back
             $CurrentLineNum = $tmp_maxline;
         } else {
-            shift(@lines); # get rid 0 line
             @tmp_lines2 = splice(@lines,0,$adrs[0]-1);
             unshift(@lines,@tmp_lines);
             unshift(@lines,@tmp_lines2);
             $CurrentLineNum = $adrs[0] + $tmp_maxline - 1;
-            unshift(@lines,undef); # put 0 line back
         }
+        unshift @lines, undef; # put 0 line back
 
     } elsif ($Mode == $APPEND_MODE) {
 


### PR DESCRIPTION
* Standard ed treats the address 0 as valid for both "a" and "i" commands [1]
* The meaning of address 0 is, add text at start of buffer
* When starting ed with no file argument, buffer is empty and current address is 0
* This version of ed accepts "0a" (or just "a") on empty buffer
* "0i" command currently raises error: Can't insert before line 0
* When the buffer is not empty, GNU ed treats 0i the same as 1i
* shift(@lines) in edInsert() is safe if the list is empty, so this patch treats address 0 and 1 the same for $INSERT_MODE (aka "i")

[1]. https://www.gnu.org/software/ed/manual/ed_manual.html#Commands

Existing output for "a":
$ perl ed    # a == 0a
ME: a
ME: hey
ME: .
ME: 1
ED: hey
ME: Q

New output for "i":
$ perl ed    # i == 0i
ME: i
ME: yo
ME: .
ME: 1
ED: yo
ME: Q