### PR TITLE
od: zero-fill input to required byte length

### DIFF
--- a/bin/od
+++ b/bin/od
@@ -118,7 +118,7 @@ close $fh;
 exit 0;
 
 sub octal1 {
-    $upformat = 'c*'; # for -b
+    $upformat = 'C*'; # for -b
     $pffmt = '%.3o ';
     @arr = unpack($upformat,$data);
     $strfmt = $pffmt x $len;
@@ -148,86 +148,52 @@ sub char1 {
 
 sub udecimal {
     $upformat = 'S*'; # for -d
+    $data .= "\0" if ($len & 1); # zero-fill 16 bit input
     $pffmt = '%5u ';
     @arr = unpack($upformat,$data);
-    $strfmt = $pffmt x ($len / 2);
-    my $remainder = $len - ((scalar @arr) * 2);
-    ($remainder) && do {
-	my $offset = $len - $remainder;
-	my $rest = "0" x 32 . substr($data, $offset, $remainder);
-	push @arr, unpack("N", pack("B32", substr($rest, -32)));
-	$strfmt .= '%5u';
-    };
+    $strfmt = $pffmt x (scalar @arr);
 }
 
 sub float {
     $upformat = 'f*'; # for -f
+    my $remain = $len % 4;
+    $data .= "\0" x $remain if ($remain); # zero-fill 32 bit input
     $pffmt = '%6.6e ';
     @arr = unpack($upformat,$data);
     $strfmt = $pffmt x (scalar @arr);
-    my $remainder = $len - ((scalar @arr) * 4);
-    ($remainder) && do {
-	my $offset = $len - $remainder;
-	my $rest = "0" x 32 . substr($data, $offset, $remainder);
-	push @arr, unpack("f", pack("B32", substr($rest, -32)));
-	$strfmt .= '%6.6e';
-    };
 }
 
 sub decimal {
     $upformat = 's*'; # for -i
+    $data .= "\0" if ($len & 1); # zero-fill 16 bit input
     $pffmt = '%5d ';
     @arr = unpack($upformat,$data);
     $strfmt = $pffmt x (scalar @arr);
-    my $remainder = $len - ((scalar @arr) * 2);
-    ($remainder) && do {
-	my $offset = $len - $remainder;
-	my $rest = "0" x 32 . substr($data, $offset, $remainder);
-	push @arr, unpack("N", pack("B32", substr($rest, -32)));
-	$strfmt .= '%5d';
-    };
 }
 
 sub long {
     $upformat = 'L*'; # for -l
+    my $remain = $len % 4;
+    $data .= "\0" x $remain if ($remain); # zero-fill 32 bit input
     $pffmt = '%10ld ';
     @arr = unpack($upformat,$data);
     $strfmt = $pffmt x (scalar @arr);
-    my $remainder = $len - ((scalar @arr) * 4);
-    $remainder && do {
-	my $offset = $len - $remainder;
-	my $rest = "0" x 32 . substr($data, $offset, $remainder);
-	push @arr, unpack("N", pack("B32", substr($rest, -32)));
-	$strfmt .= '%10ld';
-    };
 }
 
 sub octal2 {
     $upformat = 'S*'; # for -o
+    $data .= "\0" if ($len & 1); # zero-fill 16 bit input
     $pffmt = '%.6o ';
     @arr = unpack($upformat,$data);
     $strfmt = $pffmt x (scalar @arr);
-    my $remainder = $len - ((scalar @arr) * 2);
-    ($remainder) && do {
-	my $offset = $len - $remainder;
-	my $rest = "0" x 32 . substr($data, $offset, $remainder);
-	push @arr, unpack("N", pack("B32", substr($rest, -32)));
-	$strfmt .= '%.6o';
-    };
 }
 
 sub hex {
     $upformat = 'S*'; # for -x
+    $data .= "\0" if ($len & 1); # zero-fill 16 bit input
     $pffmt = '%.4x ';
     @arr = unpack($upformat,$data);
     $strfmt = $pffmt x (scalar @arr);
-    my $remainder = $len - ((scalar @arr) * 2);
-    ($remainder) && do {
-	my $offset = $len - $remainder;
-	my $rest = "0" x 32 . substr($data, $offset, $remainder);
-	push @arr, unpack("N", pack("B32", substr($rest, -32)));
-	$strfmt .= '%.4x';
-    };
 }
 
 sub diffdata {


### PR DESCRIPTION
* I noticed that when the number of input bytes is odd, the output of od -x is incorrect
* This was because unpack('S', $data) returns nothing if $data is 1 byte
* Standard od zero-fills the 16 bit number
* The do-remainder-bytes logic is incorrect (tangled web of pack, unpack and substr)
* float() and long() require input to be zero-filled 32-bits
* udecimal(), decimal(), octal2() and hex() require input to be zero-filled 16-bits
* Patch tested on amd64 against GNU od

Original output which uncovered this:
$ perl hexdump test
00000000  c6 f3                                             |..|
$ od -j 1 -x test # gnu od
0000001 00f3
0000002
$ perl od -j 1 -x test
00000001 0001
00000002

Also without -j:
$ xxd in2 
00000000: d8ab 7a                                  ..z
$ perl od -x in2
00000000 abd8 0000
00000003