### PR TITLE
sum: read stdin

### DIFF
--- a/bin/sum
+++ b/bin/sum
@@ -16,9 +16,9 @@ License:
 # An implementation of the 'cksum' utility in Perl.  Written for the Perl
 # Power Tools (PPT) project by Theo Van Dinter (felicity@kluge.net).
 
+use strict;
 use integer;
 use Getopt::Std;
-use strict;
 use vars qw($opt_h $opt_o);
 
 &help unless getopts('ho:');
@@ -33,9 +33,16 @@ $opt_o = 1 unless ( $0 =~ /cksum$/ || defined($opt_o) );
 my($exitval) = 0; # return value
 
 foreach (@ARGV) {
-	open(IN, '<', $_) || die "Can't open file for reading:$!";
+	my $fh;
+	if ($_ eq '-') {
+		$fh = *STDIN;
+	} elsif (!open($fh, '<', $_)) {
+		warn "$0: $_: $!\n";
+		$exitval = 1;
+		next;
+	}
 	my($rval,$crc,$len)=
-		($opt_o==0)?&crc32(\*IN):($opt_o==1)?&sum1(\*IN):&sum2(\*IN);
+		($opt_o==0)?&crc32($fh):($opt_o==1)?&sum1($fh):&sum2($fh);
 	unless ( defined($rval) && ($rval == 0) ) {
 		warn "$0: $_: $!\n";
 		$exitval = 1;
@@ -44,7 +51,7 @@ foreach (@ARGV) {
 
 	# Display output information
 	printf "%lu %lu%s\n",$crc,$len,($_ eq "-")?"":" $_";
-	close(IN);
+	close($fh) if ($_ ne '-');
 }
 
 exit $exitval;


### PR DESCRIPTION
* Implicit stdin when no arguments are provided
* Explicit stdin as '-', on its own or part of file list
* Print error and progress to next file if open() fails (matches GNU sum)