### PR TITLE
ed: numbered print command

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -235,6 +235,8 @@ while(<>) {
             &edQuit($NO_QUESTIONS_MODE);
         } elsif ($command eq 'h') {
             print("$Error\n") if (defined $Error);
+        } elsif ($command eq 'n') {
+            edPrint(1);
         }
 
     } else {
@@ -249,6 +251,7 @@ while(<>) {
 #
 
 sub edPrint {
+    my $do_lineno = shift;
 
     $adrs[0] = $CurrentLineNum unless (defined($adrs[0]));
     $adrs[1] = $adrs[0] unless (defined($adrs[1]));
@@ -264,6 +267,7 @@ sub edPrint {
     }
 
     for my $i ($adrs[0]..$adrs[1]) {
+        print "$i\t" if $do_lineno;
         print "$lines[$i]";
     }
 
@@ -757,7 +761,7 @@ sub edParse {
                   (([+-])?(\d+))?         # [+]num | -num
                   (([\+]+)|([-^]+))?        # + | -
                 )?
-                 ([acdeEfhipPqQrswW=])?        # command char
+                 ([acdeEfhinpPqQrswW=])?        # command char
                  \s*(\S+)?                # argument (filename, etc.)
                  )$/x);
 
@@ -1055,6 +1059,10 @@ Display last error
 =item i
 
 Insert text
+
+=item n
+
+Print from buffer with line number prefix
 
 =item P
 


### PR DESCRIPTION
* When viewing text in less(1) and editing with vi(1) I usually enable line numbers
* Standard ed supports the n command [1], which prints a tab after a line number prefix
* Implement the n command by adding a parameter to edPrint()
* Note: "l" is still not implemented but could be a future change to edPrint()

[1]. https://pubs.opengroup.org/onlinepubs/009604599/utilities/ed.html