### PR TITLE
sum: incorrect CRC output

### DIFF
--- a/bin/sum
+++ b/bin/sum
@@ -96,6 +96,7 @@ sub crc32 {
 	my($crc) = my($len) = 0;
 	my($buf,$num,$i);
 	my($buflen) = 4096; # buffer is "4k", you can up it if you want...
+	my $MASK32 = 0xffffffff;
 
 	# crctable/crc32 alg converted from openbsd's cksum program ...
 	my(@crctable) = (
@@ -154,18 +155,20 @@ sub crc32 {
 	);
 
 	while($num = sysread $fh, $buf, $buflen) {
-		for($len = ($len+$num)&0xffffffff, $i = 0; $i<$num; $i++) {
+		for($len = ($len + $num) & $MASK32, $i = 0; $i < $num; $i++) {
 			$crc = ($crc << 8 ^ $crctable[$crc >> 24 ^ ord(substr $buf, $i, 1)])
-					& 0xffffffff;
+					& $MASK32;
 		}
 	}
 
 	my($rlen) = $len; # for reporting ...
 	for(;$len!=0;$len>>=8) { # MSB first
 		$crc = (($crc << 8) ^ $crctable[($crc >> 24) ^ ($len&0xff)])
-				& 0xffffffff;
+				& $MASK32;
 	}
-	return $num,~$crc,$rlen;
+	$crc = ~$crc;
+	$crc &= $MASK32;
+	return $num, $crc, $rlen;
 }
 
 sub help {


### PR DESCRIPTION
* My version of perl is 64 bit, but this version of sum assumes perl numbers are only 32 bits
* The CRC value is calculated correctly, but in the return statement the bits in $crc are inverted with ~, causing sign to extend up to 64 bits on my system
* Correct this by explicitly masking off 32 bits before return
* Now the crc printed agrees with the crc on my OpenBSD system

Verification process on OpenBSD:
echo hallo > hallo
echo hello > hello
cksum hallo hello # reference crc output
perl sum -o0 hallo hello # our version