### PR TITLE
ed: add H command

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -235,6 +235,11 @@ while(<>) {
             &edQuit($NO_QUESTIONS_MODE);
         } elsif ($command eq 'h') {
             print("$Error\n") if (defined $Error);
+        } elsif ($command eq 'H') {
+            $EXTENDED_MESSAGES ^= 1;
+            if ($EXTENDED_MESSAGES && defined $Error) {
+                print "$Error\n";
+            }
         } elsif ($command eq 'n') {
             edPrint(1);
         }
@@ -761,7 +766,7 @@ sub edParse {
                   (([+-])?(\d+))?         # [+]num | -num
                   (([\+]+)|([-^]+))?        # + | -
                 )?
-                 ([acdeEfhinpPqQrswW=])?        # command char
+                 ([acdeEfhHinpPqQrswW=])?        # command char
                  \s*(\S+)?                # argument (filename, etc.)
                  )$/x);
 
@@ -956,10 +961,9 @@ sub edWarn {
     my $msg = shift;
 
     $Error = $msg;
+    print "?\n";
     if ($EXTENDED_MESSAGES) {
         print "$msg\n";
-    } else {
-        print "?\n";
     }
 }
 


### PR DESCRIPTION
* This change was suggested in PR 139
* This version of ed can be started with -v, which enables help mode
* GNU ed also has -v with the same meaning
* -v is not standard but the H command is
* Match behaviour of OpenBSD and GNU ed: H command toggles help mode, but if it is now enabled then print the error
* Regardless of EXTENDED_MESSAGES, errors are saved in edWarn() for the benefit of "h" command
* Also in edWarn(), unconditionally print "?\n" before the error text to match other versions