### PR TITLE
Fixes to the units utility addressing issues #161 (fractions) and #162 (temperature units)

### DIFF
--- a/bin/units
+++ b/bin/units
@@ -80,11 +80,45 @@ sub run {
   my( $class, @args ) = @_; local @ARGV;
 
   my $args = $class->process_args( @args );
+
   $class->read_unittab( $args->{unittabs}[0] );
 
-  $class->input_loop;
+  if (@{ $args->{args} }) {
+    my ($have, $want) = @{ $args->{args} };
+    my $have_hr = $class->unit_have($have);
+    my $want_hr = $class->unit_want($want);
+    my %r = $class->unit_convert($have_hr, $want_hr);
+    print_result(%r);
+  } else {
+    while (1) {
+      print "You have: ";
+      my $have = <>;
+      exit 0 unless $have =~ /\S/;
+      my $have_hr = $class->unit_have($have);
+      next if is_Zero($have_hr->{hu});
+
+      print "You want: ";
+      my $want = <>;
+      exit 0 unless $want =~ /\S/;
+      my $want_hr = $class->unit_want($want);
+      next if is_Zero($want_hr->{wu});
+
+      my %r = $class->unit_convert($have_hr, $want_hr);
+      print_result(%r);
+    }
+  }
 
   exit 0;
+}
+
+sub test {
+    my ($class, $have, $want) = @_;
+
+    $class->read_unittab();
+    my $have_hr = $class->unit_have($have);
+    my $want_hr = $class->unit_want($want);
+    my %r = $class->unit_convert($have_hr, $want_hr);
+    return %r;
 }
 
 sub default_unittabs {
@@ -121,12 +155,12 @@ sub process_args {
       }
     }
 
-    $class->usage() if $USAGE || @args;
+    $class->usage() if $USAGE || @args == 1 || @args > 2;
 
     @unittabs = $class->env_unittabs unless @unittabs;
     @unittabs = $class->default_unittabs unless @unittabs;
 
-    { unittabs => \@unittabs }
+    { unittabs => \@unittabs, args => \@args }
 }
 
 sub read_unittab {
@@ -152,54 +186,121 @@ sub read_unittab {
   $class->read_defs( $name, $fh );
 }
 
-sub input_loop {
-  my( $class ) = @_;
+sub unit_have {
+  my ($class, $have) = @_;
 
-  for (;;) {
-    print "You have: ";
-    my $have = <>;
-    trim($have);
-    if ($have =~ s/^\s*\#\s*//) {
-      if ($class->definition_line($have)) {
-        print "Defined.\n";
-      } else {
-        print "Error: $PARSE_ERROR.\n";
-      }
-      next;
+  trim($have);
+
+  # my $is_negative = 0;
+  # if ($have =~ /^[-]/) {
+    # $is_negative = 1;
+    # $have =~ s/^[-]//;  # remove minus sign
+  # }
+
+  # my $is_quantified = $have =~ /^[\d.]+/;
+
+  if ($have =~ s/^\s*\#\s*//) {
+    if ($class->definition_line($have)) {
+      print "Defined.\n";
+    } else {
+      print "Error: $PARSE_ERROR.\n";
     }
-    exit 0 unless $have =~ /\S/;
-    my $hu = $class->parse_unit($have);
-    if (is_Zero($hu)) {
+    return;
+  }
+  return unless $have =~ /\S/;
+
+  my $hu = $class->parse_unit($have);
+
+  if (is_Zero($hu)) {
+    print $PARSE_ERROR, "\n";
+    return;
+  }
+
+  # return { have => $have, hu => $hu, neg => $is_negative, quan => $is_quantified };
+  { have => $have, hu => $hu };
+}
+
+sub unit_want {
+    my ($class, $want) = @_;
+
+    trim($want);
+    return unless $want =~ /\S/;
+
+    my $wu = $class->parse_unit($want);
+
+    if (is_Zero($wu)) {
       print $PARSE_ERROR, "\n";
-      redo;
     }
-    my $wu;
-    my $want;
-    for (;;) {
-      print "You want: ";
-      $want = <>;
-      trim($want);
-      redo unless $want =~ /\S/;
-      $wu = $class->parse_unit($want);
-      if (is_Zero($wu)) {
-        print $PARSE_ERROR, "\n";
-      } else {
-        last;
-      }
-    }
+
+    { want => $want, wu => $wu };
+}
+
+sub unit_convert {
+    my ($class, $have_hr, $want_hr ) = @_;
+
+    my $have = $have_hr->{have};
+    my $hu = $have_hr->{hu};
+    # my $is_negative = $have_hr->{neg};
+    # my $is_quantified = $have_hr->{quan};
+
+    my $want = $want_hr->{want};
+    my $wu = $want_hr->{wu};
+
+    # debug_t('have unit', dumper($hu));
+    # debug_t('want unit', dumper($wu));
+
+    # my $is_temperature = 0;
+    # $is_temperature++ if $hu->{Temperature};
+    # $is_temperature++ if $wu->{Temperature};
+
+    # my $quot
+        # = $is_temperature == 2
+        # ? undef
+        # : unit_divide($hu, $wu);
+
     my $quot = unit_divide($hu, $wu);
+
+    my %retval;
+
+    # if ($is_temperature == 2) {
+        # # we have temperature units
+        # $have =~ s/^[-]?[\d.]*\s*//;
+        # my $v = $hu->{'_'};
+        # $v *= -1 if $is_negative;
+        # $v  =  0 if not $is_quantified;
+        # my $k
+            # = exists $hu->{hof}
+            # ? $hu->{hof}->{to}->($v)
+            # : $v;
+        # my $t
+            # = exists $wu->{hof}
+            # ? $wu->{hof}->{from}->($k)
+            # : $k;
+        # %retval = ( type => 'temperature', v => $v, have => $have, t => $t, want => $want );
+    # }
     if (is_dimensionless($quot)) {
       my $q = $quot->{_};
       my $p = 1/$q;
-      printf "\t* %.6g\n\t/ %.6g\n", $q, $p;
-    } else {
-      print
-        "conformability (Not the same dimension)\n",
-        "\t", $have, " is ", text_unit($hu), "\n",
-        "\t", $want, " is ", text_unit($wu), "\n",
-        ;
+      %retval = ( type => 'dimless', q => $q, p => $p);
     }
-  }
+    else {
+      %retval = ( type=> 'error', msg =>
+        "conformability (Not the same dimension)\n" .
+        "\t" . $have . " is " . text_unit($hu) . "\n" .
+        "\t" . $want . " is " . text_unit($wu) . "\n"
+        );
+    }
+
+    return %retval;
+}
+
+sub print_result {
+    my (%r) = @_;
+    printf "\t%.6g %s is %.6g %s\n", $r{v}, $r{have}, $r{t}, $r{want}
+        if $r{type} eq 'temperature';
+    printf "\t* %.6g\n\t/ %.6g\n", $r{q}, $r{p}
+        if $r{type} eq 'dimless';
+    print $r{msg} if $r{type} eq 'error';
 }
 
 ################################################################
@@ -302,8 +403,8 @@ sub unit_multiply {
 
 sub unit_divide {
   my ($a, $b) = @_;
-  die "Division by zero error" if $b->{_} == 0;
   my $r = {%$a};
+  die "Division by zero error" if $b->{_} == 0;
   $r->{_} /= $b->{_};
   for my $u (keys %$b) {
     next if $u eq '_';

--- a/bin/units
+++ b/bin/units
@@ -734,7 +734,7 @@ sub lex {
   my $N = '(?:\d+\.\d+|\d+|\.\d+)(?:[eE][-+]?\d+)?';
 
   my @t = split /(
-                   (?: \*{3} | \*.\* | !.! ) # Special 'new unit' symbol
+                   (?: \*.\* | !.! ) # Special 'new unit' symbol
                 |  [()*-]                    # Symbol
                 |  \s*(?:\/|\bper\b)\s*      # Division
                 |  (?:$N\|$N)                # Fraction

--- a/bin/units
+++ b/bin/units
@@ -24,9 +24,9 @@ our $VERSION = '1.01';
 
 BEGIN {
     require Data::Dumper;
-	sub dumper { Data::Dumper->new([@_])->Indent(1)->Sortkeys(1)->Terse(1)->Useqq(1)->Dump }
+	sub dumper { Data::Dumper->new([@_])->Indent(1)->Sortkeys(1)->Terse(1)->Useqq(1)->Deparse(1)->Dump }
 
-	foreach my $letter ( qw( d p o l ) ) {
+	foreach my $letter ( qw( d p o l t ) ) {
 	  no strict 'refs';
 	  my $env_var = uc( "UNITS_DEBUG_$letter" );
 	  my( $debugging ) = grep { defined and length } ( $ENV{$env_var}, $ENV{UNITS_DEBUG}, 0 );
@@ -191,13 +191,13 @@ sub unit_have {
 
   trim($have);
 
-  # my $is_negative = 0;
-  # if ($have =~ /^[-]/) {
-    # $is_negative = 1;
-    # $have =~ s/^[-]//;  # remove minus sign
-  # }
+  my $is_negative = 0;
+  if ($have =~ /^[-]/) {
+    $is_negative = 1;
+    $have =~ s/^[-]//;  # remove minus sign
+  }
 
-  # my $is_quantified = $have =~ /^[\d.]+/;
+  my $is_quantified = $have =~ /^[\d.]+/;
 
   if ($have =~ s/^\s*\#\s*//) {
     if ($class->definition_line($have)) {
@@ -216,8 +216,7 @@ sub unit_have {
     return;
   }
 
-  # return { have => $have, hu => $hu, neg => $is_negative, quan => $is_quantified };
-  { have => $have, hu => $hu };
+  return { have => $have, hu => $hu, neg => $is_negative, quan => $is_quantified };
 }
 
 sub unit_want {
@@ -231,8 +230,7 @@ sub unit_want {
     if (is_Zero($wu)) {
       print $PARSE_ERROR, "\n";
     }
-
-    { want => $want, wu => $wu };
+    return { want => $want, wu => $wu };
 }
 
 sub unit_convert {
@@ -240,45 +238,43 @@ sub unit_convert {
 
     my $have = $have_hr->{have};
     my $hu = $have_hr->{hu};
-    # my $is_negative = $have_hr->{neg};
-    # my $is_quantified = $have_hr->{quan};
+    my $is_negative = $have_hr->{neg};
+    my $is_quantified = $have_hr->{quan};
 
     my $want = $want_hr->{want};
     my $wu = $want_hr->{wu};
 
-    # debug_t('have unit', dumper($hu));
-    # debug_t('want unit', dumper($wu));
+    debug_t('have unit', dumper($hu));
+    debug_t('want unit', dumper($wu));
 
-    # my $is_temperature = 0;
-    # $is_temperature++ if $hu->{Temperature};
-    # $is_temperature++ if $wu->{Temperature};
+    my $is_temperature = 0;
+    $is_temperature++ if $hu->{Temperature};
+    $is_temperature++ if $wu->{Temperature};
 
-    # my $quot
-        # = $is_temperature == 2
-        # ? undef
-        # : unit_divide($hu, $wu);
-
-    my $quot = unit_divide($hu, $wu);
+    my $quot
+        = $is_temperature == 2
+        ? undef
+        : unit_divide($hu, $wu);
 
     my %retval;
 
-    # if ($is_temperature == 2) {
-        # # we have temperature units
-        # $have =~ s/^[-]?[\d.]*\s*//;
-        # my $v = $hu->{'_'};
-        # $v *= -1 if $is_negative;
-        # $v  =  0 if not $is_quantified;
-        # my $k
-            # = exists $hu->{hof}
-            # ? $hu->{hof}->{to}->($v)
-            # : $v;
-        # my $t
-            # = exists $wu->{hof}
-            # ? $wu->{hof}->{from}->($k)
-            # : $k;
-        # %retval = ( type => 'temperature', v => $v, have => $have, t => $t, want => $want );
-    # }
-    if (is_dimensionless($quot)) {
+    if ($is_temperature == 2) {
+        # we have temperature units
+        $have =~ s/^[-]?[\d.]*\s*//;
+        my $v = $hu->{'_'};
+        $v *= -1 if $is_negative;
+        $v  =  0 if not $is_quantified;
+        my $k
+            = exists $hu->{hof}
+            ? $hu->{hof}->{to}->($v)
+            : $v;
+        my $t
+            = exists $wu->{hof}
+            ? $wu->{hof}->{from}->($k)
+            : $k;
+        %retval = ( type => 'temperature', v => $v, have => $have, t => $t, want => $want );
+    }
+    elsif (is_dimensionless($quot)) {
       my $q = $quot->{_};
       my $p = 1/$q;
       %retval = ( type => 'dimless', q => $q, p => $p);
@@ -345,22 +341,27 @@ sub definition_line {
   my ($class, $line) = @_;
   my ($name, $data) = split /\s+/, $line, 2;
   my $value = $class->parse_unit($data);
-
+  debug_t("$name => $data") if $data =~ /^\{\s/;
   my $rc = do {
-       if (is_Zero($value))        { undef                              }
+    if ($data =~ /^\{\s/) {
+        my $hof = eval $data;   # hash of functions
+        +{ $name => { _ => 1, hof => $hof, Temperature => 1 } }
+    }
+    elsif (is_Zero($value))        { undef                              }
     elsif (is_fundamental($value)) { +{ $name => {_ => 1, $name => 1} } }
     else                           { +{ $name => $value               } }
   };
 
   unless( defined $rc ) {
-    warn "Parse error: $PARSE_ERROR.  Skipping.\n";
+    $line =~ s/\s+/ => /;
+    warn "Parse error: $PARSE_ERROR in $line.  Skipping.\n";
     $rc = {};
   }
 
   return $rc;
 }
 
-sub trim {
+sub trim {              # note that trim() is a L-value sub
   $_[0] =~ s/\#.*$//;;
   $_[0] =~ s/\s+$//;
   $_[0] =~ s/^\s+//;
@@ -368,7 +369,9 @@ sub trim {
 
 sub Zero () { +{ _ => 0 } }
 
-sub is_Zero { $_[0]{_} == 0 }
+# here we guard the zero test by first checking to see
+# if we're dealing with a temperature
+sub is_Zero { !$_[0]{Temperature} && !$_[0]{_} }
 
 sub unit_lookup {
   my ($name) = @_;
@@ -465,7 +468,7 @@ sub text_unit {
   my (@pos, @neg);
   my $c = $u->{_};
   for my $k (sort keys %$u) {
-    next if $k eq '_';
+    next if $k eq '_' or $k eq 'hof';
     push @pos, $k if $u->{$k} > 0;
     push @neg, $k if $u->{$k} < 0;
   }
@@ -1097,8 +1100,10 @@ NOTE: This does not handle the Gnu units format (https://www.gnu.org/software/un
 
 The units program converts quantities expressed in various scales to their
 equivalents in other scales.  The units program can only handle multiplicative
-or affine scale changes.  It works interactively by prompting the user for
-input:
+or affine scale changes (except for temperature).  It works in one of
+two ways.  If given two units as command line arguments, it reports
+the conversion.  Otherwise, it operates interactively by prompting the user
+for inputs:
 
     % units
     You have: meters
@@ -1121,9 +1126,13 @@ input:
         * 1.27
         / 0.78740157
 
-    You have: 85 degF
-    You want: degC
-        29.444444
+    You have: 98.6 F
+    You want: C
+        98.6 F is 37 C
+
+    You have: -40 C
+    You want: F
+        -40 C is -40 F
 
 Powers of units can be specified using the '^' character as shown in the
 example, or by simple concatenation: 'cm3' is equivalent to 'cm^3'.
@@ -1174,15 +1183,18 @@ exists and you do not supply your own file, this program uses internal
 data.
 
 A unit is specified on a single line by giving its name and an equivalence.  Be
-careful to define new units in terms of old ones so that a reduction leads to
-the primitive units which are marked with '!' characters.  The units program
-will not detect infinite loops that could be caused by careless unit
-definitions.
+careful to define new units in terms of old ones so that reductions leads to
+primitive units.  Primitive (a.k.a. fundamental) units are defined
+with a string of three characters which begin and end with '*' or '!'.
+Note that the units program will not detect infinite loops that could be
+caused by careless unit definitions.
 
-Comments in the unit definition file begin with a '/' character at
-the beginning of a line.
+Comments in the unit definition file begin with a '/' or '#' character at
+the beginning of a line.  Once the parser has successfully parsed a
+unit name and it's definition, the remainder of the line is ignored.
+This makes it safe to incude in-line comments.
 
-Prefixes are defined in the same was as standard units, but with a
+Prefixes are defined in the same way as standard units, but with a
 trailing dash at the end of the prefix name.  If a unit is not found even
 after removing trailing 's' or 'es', then it will be checked against the
 list of prefixes.  Prefixes will be removed until a legal base unit is
@@ -1190,18 +1202,38 @@ identified.
 
 Here is an example of a short units file that defines some basic units.
 
-    m         !a!
-    sec       !b!
-    micro-    1e-6
-    minute    60 sec
-    hour      60 min
-    inch      0.0254 m
-    ft        12 inches
-    mile      5280 ft
+    m           !a!
+    sec         ***
+    Temperature ***
+    micro-      1e-6
+    minute      60 sec
+    hour        60 min
+    inch        0.0254 m
+    ft          12 inches
+    mile        5280 ft
+
+If a "Temperature" dimension is defined in the units table, then
+you can define various temperature scales as units by specifying
+the code needed to convert the unit to or from Kelvin.
+The built-in units table has definitions for Kelvin (K), Celsius (C),
+Fahrenheit (F) and Rankine (R).
+
+The code consists of a perl hash containing the keys 'to' and 'from'.
+The values are the subroutine definitions necessary to convert a
+value from Kelvin to the specified unit, or to Kelvin from the the
+specified unit.  See the built-in unit table for examples.
+
+A temperature unit entered at "You have" without any constant
+preceding it will default to zero units.  This is in contrast to
+non-temperature units, where a bare unit name is assumed to mean 1
+unit.  Also, for temperatures only, negative constants are allowed.
+This enables, for example, a conversation between -40C and F.
 
 =head1 AUTHOR
 
 Mark-Jason Dominus, C<< <mjd-perl-units@plover.com> >>
+
+Temperature support by Gary Puckering, C<< <jgpuckering@rogers.com> >>
 
 Currently maintained in https://github.com/briandfoy/PerlPowerTools
 
@@ -1223,6 +1255,15 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 =cut
 
 __END__
+
+# Notes (from Gary Puckering)
+#  1.  The comment indicator is "/" at the start of a line
+#  2.  However, the parser ignores trailing unrecognized trailing tokens
+#      and so # seems to be an effective in-line comment indicator
+#  3.  Temperature entries in version 1.034 and prior caused parsing errors
+#  4.  Temperature support has now been added, and the entries have been updated
+#  5.  If you have your own units file and it has temperatures, you'll need to update it
+
 # dimensions
 m                     ***
 kg                    ***
@@ -1232,7 +1273,7 @@ candela               ***
 radian                ***
 bit                   ***
 erlang                ***
-K                     ***
+Temperature           ***
 
 # constants
 
@@ -1288,13 +1329,18 @@ mg                    milligram
 metricton             kilokg
 
 # Temperature
-# addition and subtraction doesn't work yet
-F                     K - 459.67
-degF                  F
-C                     K - 273.15
-degC                  C
-# The is U+004B and U+212A
-K                     K
+C                     { to => sub { $_[0] + 273.15 }, from => sub { $_[0] - 273.15 } }
+F                     { to => sub { ( $_[0] + 459.67 ) * 5/9 }, from => sub { $_[0] * 9/5 - 459.67 } }
+R                     { to => sub { $_[0] * 5/9 }, from => sub { $_[0] * 9/5 } }
+K                     Temperature
+Celsius               C
+Fahrenheit            F
+Kelvin                K
+Rankine               R
+celsius               C
+fahrenheit            F
+kelvin                K
+rankine               R
 
 # Avoirdupois
 
@@ -1510,7 +1556,6 @@ jeroboam              4|5 gal
 karat                 1|24
 kcal                  kilocal
 kcalorie              kilocal
-kelvin                degC
 kev                   1e+3 e-volt
 key                   kg
 khz                   1e+3 /sec
@@ -1576,7 +1621,6 @@ quartersection        1|4 mi2
 quintal               100 kg
 quire                 25
 rad                   100 erg/gm
-rankine               1.8 kelvin
 ream                  500
 registerton           100 ft3
 rehoboam              156 floz
@@ -1625,4 +1669,10 @@ water                 .22491|2.54 kg/m2-sec2
 wey                   40 bu
 weymass               252 lb
 Xunit                 1.00202e-13m
-k                     1.38047e-16 erg/degC
+
+# The following entry looks like it might be the Boltzmann constant?
+# If so, then it is incorrect.  It should be 1.3807e-16 erg/degK.  In
+# any event, the temperature logic doesn't support mixed affine/linear 
+# reductions.
+# - Gary Puckering
+// k                     1.38047e-16 erg/degC

--- a/bin/units
+++ b/bin/units
@@ -1084,7 +1084,7 @@ units - conversion program
 		* 2.54
 		/ 0.393701
 
-	% units -f /path/to/unittab
+	% units [-f /path/to/unittab] [want_unit have_unit]
 
 =head1 OPTIONS
 

--- a/bin/units
+++ b/bin/units
@@ -633,8 +633,8 @@ sub lex {
                    (?: \*{3} | \*.\* | !.! ) # Special 'new unit' symbol
                 |  [()*-]                    # Symbol
                 |  \s*(?:\/|\bper\b)\s*      # Division
-                |  ($N\|$N)                  # Fraction
-                |  $N    # Decimal number
+                |  (?:$N\|$N)                # Fraction
+                |  $N                        # Decimal number
                 |  \d+                       # Integer
                 |  [A-Za-z_][A-Za-z_.]*      # identifier
                 |  \s+                       # White space

--- a/bin/units
+++ b/bin/units
@@ -271,7 +271,7 @@ sub is_Zero { $_[0]{_} == 0 }
 
 sub unit_lookup {
   my ($name) = @_;
-  debug_l( "Looking up unit `$name'" );
+  debug_l( "Looking up unit '$name'" );
   return $unittab{$name} if exists $unittab{$name};
   if ($name =~ /s$/) {
     my $shortname = $name;
@@ -280,7 +280,7 @@ sub unit_lookup {
   }
   my ($prefix, $rest) = ($name =~ /^($PREF-?)(.*)/o);
   unless ($prefix) {
-    $PARSE_ERROR = "Unknown unit `$name'";
+    $PARSE_ERROR = "Unknown unit '$name'";
     return Zero;
   }
   my $base_unit = unit_lookup($rest); # Recursive
@@ -611,7 +611,7 @@ sub parse_unit {
 
       debug_p( "Post-reduction state is $STATE." );
 
-      # Now look for `goto' actions
+      # Now look for 'goto' actions
       my $goto = $actions[$STATE]{$result_type};
       unless ($goto && $goto->[0] eq 'goto') {
         die "No post-reduction goto in state $STATE for $result_type.\n";
@@ -630,7 +630,7 @@ sub lex {
   my $N = '(?:\d+\.\d+|\d+|\.\d+)(?:[eE][-+]?\d+)?';
 
   my @t = split /(
-                   (?: \*{3} | \*.\* | !.! ) # Special `new unit' symbol
+                   (?: \*{3} | \*.\* | !.! ) # Special 'new unit' symbol
                 |  [()*-]                    # Symbol
                 |  \s*(?:\/|\bper\b)\s*      # Division
                 |  ($N\|$N)                  # Fraction
@@ -666,7 +666,7 @@ sub token_value {
        if( $token =~ /^([()*\/-]|\s*\bper\b\s*)$/ ) { $token }
     elsif( $token =~ /(\d+)\|(\d+)/ ) {
       if( $2 == 0 ) {
-        ABORT("Zero denominator in fraction `$token'");
+        ABORT("Zero denominator in fraction '$token'");
         return 0;
       }
       $1/$2;
@@ -1113,7 +1113,7 @@ This program is copyright (c) M-J. Dominus (1996, 1999).
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
 Foundation; either version 2 of the License, or (at your option) any later
-version, or under Perl's `Artistic License'.
+version, or under Perl's 'Artistic License'.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A

--- a/t/units.t
+++ b/t/units.t
@@ -51,6 +51,53 @@ sub run_tests {
     is rnd($got{q}), rnd(1/12);
     is rnd($got{p}), 12;
 
+    # affine dimension tests, returing type => 'temperature'
+
+    %got = PerlPowerTools::units::test($class, 'K','K');
+    is rnd($got{t}), 0;
+
+    %got = PerlPowerTools::units::test($class, 'K','C');
+    is rnd($got{t}), -273.15;
+
+    %got = PerlPowerTools::units::test($class, 'K','R');
+    is rnd($got{t}), 0;
+
+    %got = PerlPowerTools::units::test($class, 'C','K');
+    is rnd($got{t}), 273.15;
+
+    %got = PerlPowerTools::units::test($class, 'R','K');
+    is rnd($got{t}), 0;
+
+    %got = PerlPowerTools::units::test($class, 'C','K');
+    is rnd($got{t}), 273.15;
+
+    %got = PerlPowerTools::units::test($class, 'C','F');
+    is rnd($got{t}), 32;
+
+    %got = PerlPowerTools::units::test($class, '0C','F');
+    is rnd($got{t}), 32;
+
+    %got = PerlPowerTools::units::test($class, '100 C','F');
+    is rnd($got{t}), 212;
+
+    %got = PerlPowerTools::units::test($class, '-40 C','F');
+    is rnd($got{t}), -40;
+
+    %got = PerlPowerTools::units::test($class, '98.6F','C');
+    is rnd($got{t}), 37;
+
+    # ice/salt mixture
+
+    %got = PerlPowerTools::units::test($class, '255.37K','C');
+    is rnd($got{t}), -17.78;
+
+    %got = PerlPowerTools::units::test($class, '-17.78C','F');
+    ok rnd($got{t}) < 0.00001;
+
+    # water boils at STP
+    %got = PerlPowerTools::units::test($class, '99.9836 C','K');
+    is rnd($got{t}), 373.134;
+
     return;
 }
 

--- a/t/units.t
+++ b/t/units.t
@@ -1,0 +1,59 @@
+#!/usr/bin/perl
+
+# units.t - test for script units
+
+use strict;
+use warnings;
+
+use Test::More tests => 28;
+
+use FindBin;
+
+run_tests();
+
+sub run_tests {
+    my ( $progname, $argv_ar ) = @_;
+
+    require $FindBin::Bin . '/../bin/units';
+
+    my %got;
+    my $rounded;
+
+    my $class = 'PerlPowerTools::units';
+
+    # linear dimension tests, returning type => 'dimless'
+
+    %got = PerlPowerTools::units::test($class, 'm','m');
+    is rnd($got{p}), 1;
+    is rnd($got{q}), 1;
+
+    %got = PerlPowerTools::units::test($class, 'm','cm');
+    is rnd($got{p}), 0.01;
+    is rnd($got{q}), 100;
+
+    %got = PerlPowerTools::units::test($class, 'meters','feet');
+    is rnd($got{q}), 3.28084;
+    is rnd($got{p}), 0.3048;
+
+    %got = PerlPowerTools::units::test($class, 'cm3','gallons');
+    is rnd($got{q}), 0.000264172;
+    is rnd($got{p}), 3785.41;
+
+    %got = PerlPowerTools::units::test($class, 'meters/s','furlongs/fortnight');
+    is rnd($got{q}), 6012.88;
+    is rnd($got{p}), 0.00016631;
+
+    %got = PerlPowerTools::units::test($class, '1|2 in','cm');
+    is rnd($got{q}), 1.27;
+    is rnd($got{p}), 0.787402;
+
+    %got = PerlPowerTools::units::test($class, 'month','year');
+    is rnd($got{q}), rnd(1/12);
+    is rnd($got{p}), 12;
+
+    return;
+}
+
+sub rnd {
+    sprintf '%.6g', $_[0];
+}


### PR DESCRIPTION
This sequence of commits addresses the above-noted issues.  From earliest to latest, here's what they include:

1. Replace backticks in six places where they were (likely inadvertently) paired with apostrophes.  Now they match.
2. Fix issue #161 "units script produces incorrect results for definitions that include a fractional factor" by adding non-capturing group directive to the Fraction pattern in sub lex.
3. Add a test script and restructure units to support (a) calling from a test script, (b) returning as a hash when testing; and (c) supporting a non-interactive mode when two units are given as command-line arguments.
4. Implement support for temperature conversions; add a new debug mode (T for temperature); revise temperature definitions in the DATA table; update the POD; add test cases for temperature units.
5. In sub lex, eliminate a redundant subpattern in the "Special 'new unit' symbol" split subpattern.
6. Document the optional units command line arguments in the synopsis.

I've run the test script my local environment (Windows 11) and they pass in both Windows and Ubuntu.  Interactive testing worked for me too.