### PR TITLE
fix ed search direction

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -841,17 +841,14 @@ sub CalculateLine {
         } elsif (defined($searchadr)) {
 
             $pattern = $searchadr;
-            $pattern =~ s/\/$//;
-            $pattern =~ s/^\///;
+            $pattern =~ s/[\?\/]$//;
+            $pattern =~ s/^[\?\/]//;
 
-
-            if ($wholesearch =~ /^\/.*\/$/) {
+            if ($wholesearch =~ /^\?/) {
+                $myline = edSearchBackward($pattern);
+            } else {
                 $myline = edSearchForward($pattern);
-                } else {
-                    $myline = edSearchBackward($pattern);
-                }
-
-#            $command = "";
+            }
         }
     }
 


### PR DESCRIPTION
* When search is written as /hex ed finds the last match (i.e. searches backwards)
* When search is written as /hex/ ed searches forwards
* These two cases should be identical (trailing slash may be be omitted in search)
* Searching backwards should be indicated by the ?hex not /hex
* Trailing "?" is also optional for backwards search, i.e. ?hex is also ?hex?
* The fix is to strip leading and trailing question marks from $pattern

$ fgrep -n hex in | head -n 1
5:Name: hexdump
$ fgrep -n hex in | tail -n 1
216:No support for multi-byte hex display, or plain hex output.

$ ed -p 'ME>' in # GNU
4875
ME>/hex
Name: hexdump
ME>n
5	Name: hexdump
ME>q

# before patch
$ perl ed in
in
4875
/hex
No support for multi-byte hex display, or plain hex output.
n
216	No support for multi-byte hex display, or plain hex output.
q
$ perl ed in
in
4875
/hex/
Name: hexdump
5
Name: hexdump

# after patch
$ perl ed in
in
4875
?hex 
No support for multi-byte hex display, or plain hex output.
200

?hex?
An odd number of hex digits on a line results in an error. 
1
#!/usr/bin/perl
/hex
Name: hexdump
q