### PR TITLE
ed: raise error for opening a directory

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -510,6 +510,11 @@ sub edEdit {
 
     # suck the file into a temp array
 
+    if (-d $filename) {
+        warn "$filename: is a directory\n";
+        edWarn('cannot read input file');
+        return 0;
+    }
     unless (open(SOURCE, '<', $filename)) {
         edWarn("unable to open $filename: $!");
         return 0;


### PR DESCRIPTION
* Avoid calling open() on a directory, which would succeed
* GNU and OpenBSD versions of ed behave consistently if a directory is specified
* Raise error: cannot read input file
* Start ed with an empty buffer
* Also print a helpful message on stderr to indicate the specified file is a directory
* edEdit() is called when opening files (initially from ARGV or via "e" command)