### PR TITLE
install: ignore directories in source file list

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -258,6 +258,12 @@ sub install_files {
             }
         }
 
+        if (-d $file) {
+            warn "$0: ignoring directory '$file'\n";
+            $Errors++;
+            next;
+        }
+
         if ($opt{C}) {
             if (system "cmp", "-s", $file, $targ) {
                 warn "$0: copy $file $targ\n" if $Debug;


### PR DESCRIPTION
* The normal usage of install(1) copies files to a destination directory
* "install dir1 dir2" makes no sense because the source argument (dir1) is expected to be a regular file
* I observe that an empty file "dir1" is created in dir2 before an error is printed
* Fix this in install_files() which is invoked by default (and for -C option)
* Option -d allows all arguments to be directories; this is handled in install_dirs() and is unchanged
* Patch aligns with GNU install behavior: print a warning and continue copying the next file in list