### PR TITLE
cp: copy many files at once

### DIFF
--- a/bin/cp
+++ b/bin/cp
@@ -42,8 +42,14 @@ sub run {
 	$PerlPowerTools::cp::error_fh  = $settings->{error_fh}  if exists $settings->{error_fh};
 	$PerlPowerTools::cp::output_fh = $settings->{output_fh} if exists $settings->{output_fh};
 
-	my( $opts, $source, $destination ) = process_arguments(@args);
+	my( $opts, @files) = process_arguments(@args);
+	my $destination = pop @files;
+
 	return EX_USAGE unless defined $opts;
+	unless (@files) {
+		warn "$0: missing file operand\n";
+		return EX_USAGE;
+		}
 
 	my @unix_like = qw(darwin freebsd linux);
 	if( grep { $^O eq $_ } @unix_like and in_path('cp') ) {
@@ -51,28 +57,31 @@ sub run {
 		# it doesn't.
 		my @command = 'cp';
 		push @command, map { "-$_" } grep { $opts->{$_} } qw(i f p v );
-		push @command, $source, $destination;
+		push @command, @files, $destination;
 
 		my $rc = system { $command[0] } @command;
 		return $rc;
 		}
 	else {
 		require File::Copy;
-		$destination = catfile( $destination, basename($source) ) if -d $destination;
-		print { output_fh() } "$source -> $destination\n" if $opts->{v};
-		if( -e $destination and $opts->{i} and ! $opts->{f} ) {
-			my $answer = prompt( "overwrite $destination? (y/n [n])", 'n' );
-			unless( $answer =~ m/\A\s*y/i ) {
-				print { error_fh() } "not overwritten";
-				return EX_FAILURE;
+		my $err = 0;
+		foreach my $source (@files) {
+			my $catdst = catfile( $destination, basename($source) ) if -d $destination;
+			print { output_fh() } "$source -> $catdst\n" if $opts->{v};
+			if( -e $catdst and $opts->{i} and ! $opts->{f} ) {
+				my $answer = prompt( "overwrite $catdst? (y/n [n])", 'n' );
+				unless( $answer =~ m/\A\s*y/i ) {
+					print { error_fh() } "not overwritten";
+					return EX_FAILURE;
+					}
 				}
+			$err = 1 if (File::Copy::copy($source, $catdst) == 0);
 			}
-		my $rc = File::Copy::copy( $source, $destination );
-		return $rc == 0 ? EX_FAILURE : EX_SUCCESS;
+		return $err ? EX_FAILURE : EX_SUCCESS;
 		}
 
 	return EX_FAILURE;
-	};
+	}
 
 sub in_path {
 	my( $command ) = @_;
@@ -167,5 +176,4 @@ Copyright © 2023 brian d foy. All rights reserved.
 You may use this program under the terms of the Artistic License 2.0.
 
 =cut
-
 


### PR DESCRIPTION
* Multiple source files can be given before a destination
* Some of what process_arguments() returns was being thrown away
* For case where system() is called, cp command can handle all files at once
* For case where File::Copy::copy() is called, introduce a loop because it can't handle a list of source files
* Exit early if insufficient file arguments are provided: 0 (cp), 1 (cp srcfile)