### PR TITLE
arithmetic: make expected prompt appear

### DIFF
--- a/bin/arithmetic
+++ b/bin/arithmetic
@@ -119,7 +119,10 @@ while ($questions < QUESTIONS) {
     LOOP: {
         print "$left $operator $right = ";
         chomp ($guess = <>);
-        print "Please type a number.\n", redo if $guess =~ /\D/;
+        if ($guess =~ /\D/) {
+            print "Please type a number.\n";
+            redo;
+        }
     }
 
     if ($guess == $answer) {
@@ -152,7 +155,7 @@ sub report {
                          "$hours hour", "$minutes minute", "$seconds second") ||
                        "no time at all!";
 
-    print "\nYou had $correct answers correct, our of $questions. ",
+    print "\nYou had $correct answers correct, out of $questions. ",
             "It took you $time.\n";
 
     exit $warnings;
@@ -242,4 +245,3 @@ and sell this program (and any modified variants) in any way you wish,
 provided you do not restrict others from doing the same.
 
 =cut
-


### PR DESCRIPTION
* On my system, "Please type a number" message is never displayed for bad input
* Looking at the code, I see two statements (print and redo) separated by comma
* This patch makes the Please prompt appear
* While here, fix a typo in summary report