### PR TITLE
test: improve error message

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -96,7 +96,7 @@ my %TEST_OPS = (
     '-B'   =>    sub { -B $_[0] },
     '-L'   =>    sub { -l $_[0] },
     '-O'   =>    sub { -O $_[0] },
-    '-G'   =>    sub { bad_arg "'-G' - operator not supported", 0 },
+    '-G'   =>    sub { bad_arg("'-G' - operator not supported") },
     '-R'   =>    sub { -R $_[0] },
     '-S'   =>    sub { -S $_[0] },
     '-T'   =>    sub { -T $_[0] },
@@ -126,7 +126,7 @@ my %TEST_OPS = (
     ## File comparisons
     '-nt'  =>    sub { -M $_[0] < -M $_[1] },
     '-ot'  =>    sub { -M $_[0] > -M $_[1] },
-    '-ef'  =>    sub { bad_arg "'-ef' - operator not supported", 0 },
+    '-ef'  =>    sub { bad_arg("'-ef' - operator not supported") },
 );
 
 ## Apply a test operator to the given arguments
@@ -511,5 +511,4 @@ escaped from any special shell interpretation.
 L<sh>, L<find>
 
 =cut
-
 


### PR DESCRIPTION
* Make all calls to bad_arg() consistently pass a single param
* Passing extra param of 0 here causes 0 to appear in the error message, which is confusing
* I checked that the exit code is still 2, i.e. param2 did not modify exit code