### PR TITLE
grep: -r set without -r being set

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -229,7 +229,6 @@ sub parse_args {
     $opt{1}   += $opt{'s'} && !$opt{c};     # that's a one
 
     @ARGV = ($opt{r} ? '.' : '-') unless @ARGV;
-    $opt{r} = 1 if !$opt{r} && grep(-d, @ARGV) == @ARGV;
 
     $match_code  = '';
     $match_code .= 'study;' if @patterns > 5; # might speed things up a bit
@@ -283,8 +282,7 @@ FILE: while (defined ($file = shift(@_))) {
 
 	    }
 	    if (!$opt->{r}) {
-		warn "$Me: \"$file\" is a directory, but no -r given\n"
-		    if $opt->{T};
+		warn "$Me: \"$file\" is a directory\n";
 		next FILE;
 	    }
 	    unless (opendir(DIR, $file)) {


### PR DESCRIPTION
* Standard grep does not recursively search a directory unless -r option is given
* This version of grep has code that infers -r based on ARGV, which doesn't follow expected behaviour of other greps
* The "is a directory" warning is printed by GNU grep, so remove the check for trace option (-T) in our code