### PR TITLE
printf: support c-escape \v

### DIFF
--- a/bin/printf
+++ b/bin/printf
@@ -26,6 +26,7 @@ unless (@ARGV) {
 }
 
 my $format = shift;
+$format =~ s/\\v/\x0b/g; # escape \v not available in printf()
 eval qq(printf "$format", \@ARGV);
 die if $@;
 
@@ -43,8 +44,7 @@ B<printf> I<format> [ I<argument> ... ]
 
 The B<printf> command uses the first argument as the format that describes
 how to print the remaining arguments.  Unlike the standard
-printf(1) command, this one uses the Perl version, which means
-that the C<\v> escape is not supported, but various other things are.
+printf(1) command, this one uses the Perl version.
 See L<perlfunc/sprintf> for details.
 
 =head1 RESTRICTIONS


### PR DESCRIPTION
* The perl printf() called in this command does not support the escape \v
* Standard printf command supports \v as part of the format argument... <https://pubs.opengroup.org/onlinepubs/009695299/utilities/printf.html>
* Other C-escapes are supported already in this version: \\ \a \b \t \n \f \r
* Add support for \v by translating format string before printf() is called
* Now we have better POSIX support, and the limitation can be removed from the POD text
