### PR TITLE
ed refuses to open filename with a dash

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -123,15 +123,12 @@ if ($opt_v) {
     $EXTENDED_MESSAGES = 1;
 }
 
-print("@ARGV\n") if @ARGV;
-&Usage if ($#ARGV > 1);
-
-while ($_ = shift) {
-    if (/-/) {
-        $SupressCounts = 1;
-    } else {
-        $args[0] = $_;
-    }
+&Usage if scalar(@ARGV) > 1;
+my $fname = shift;
+if ($fname eq '-') {
+    $SupressCounts = 1;
+} else {
+    $args[0] = $fname;
 }
 
 if ($EXTENDED_MESSAGES) {


### PR DESCRIPTION
* This version of ed will open only one file; this could be '-' for stdin
* edEdit() gets a path from $args[0] but we have this strange while-loop with an incorrect regex
* On the surface, the loop sets $SuppressCounts flag for stdin
* The loop also prevents special filename '-' from being assigned to $args[0], so that edEdit() works correctly
* Kill the loop because only one file can be opened, and replace regex
* ed now agrees to open my file named very-important