### PR TITLE
install: raise error for no destination arg

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -235,6 +235,9 @@ sub install_files {
     my $dst = pop @ARGV;
     my $dir = -d $dst;
 
+    if (scalar(@ARGV) == 0) {
+        die "$0: missing destination file operand after '$dst'\n";
+    }
     if (!$dir and @ARGV > 1) {
         die "$0: $dst is not a directory\n", usage;
     }


### PR DESCRIPTION
* This version of install does not raise an error if the destination argument is missing
* In install_files() the last element of ARGV is taken to be the destination; this is not quite correct if only one element is given
* When [original] ARGV=0 (install), usage is printed and install_files() is never called
* When ARGV=1 (install src), we don't know where to copy the file to
* When ARGV=2 (install src dst), the destination can be a directory or the name of the new file
* When ARGV>2 (install src1 src2... dst), multiple files are copied with their original name, and the final argument must be a directory