### PR TITLE
hexdump: print offset at end of input

### DIFF
--- a/bin/hexdump
+++ b/bin/hexdump
@@ -68,7 +68,7 @@ sub dumper {
         $str =~ s/[^[:print:]]/./g;
         printf "%-51s|%s|\n", $hex, $str;
     }
-    $adr += 16;
+    $adr += scalar @chars;
     undef @chars;
 }
 
@@ -134,6 +134,12 @@ sub xd {
         dofile();
     }
     dumper(); # odd bytes at end
+
+    if ($opt{'c'}) {
+        printf "%07lx\n", $adr;
+    } else {
+        printf "%08lx\n", $adr;
+    }
 }
 
 getopts('cn:rs:u', \%opt)


### PR DESCRIPTION
* For better compatibility with GNU and OpenBSD versions of hexdump, print a line at end of input with the final offset
* This happens for both canonical hex and -c mode
* This behaviour is already supported in our version of od command too
* Since the final line of input dumped might be <16 bytes, this summary line makes it trivial to see the total number