### PR TITLE
grep: directory argument to -f

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -147,6 +147,7 @@ sub parse_args {
     my $no_re = $opt{F} || ($Me =~ /\bfgrep\b/);
 
     if ($opt{f}) {                # -f patfile
+	die("$Me: $opt{f}: is a directory\n") if (-d $opt{f});
 	open PATFILE, '<', $opt{f} or die qq($Me: Can't open '$opt{f}': $!);
 
 				  # make sure each pattern in file is valid


### PR DESCRIPTION
* With -f option grep initially reads PATFILE, which contains one search pattern per line
* Following the previous commit, avoid opening PATFILE if the supplied argument is a directory
* In this case grep will terminate because we have no valid patterns to search based on