### PR TITLE
printf: standard meaning of %c

### DIFF
--- a/bin/printf
+++ b/bin/printf
@@ -27,6 +27,7 @@ unless (@ARGV) {
 
 my $format = shift;
 $format =~ s/\\v/\x0b/g; # escape \v not available in printf()
+$format =~ s/\%c/\%\.1s/g; # standard printf: %c == 1st char
 eval qq(printf "$format", \@ARGV);
 die if $@;
 


### PR DESCRIPTION
* Standard printf command interprets %c in format string as: first character of string
* FreeBSD manual says: "first byte" to make it obvious we're not talking about multi-byte characters
* OpenBSD manual says: "first character"
* HP-UX manual says: "first character" <https://nixdoc.net/man-pages/HP-UX/man1/printf.1.html>
* Support standard %c in this version by translating %c to %.1s which truncates the string argument
* I compared output of (perl printf 'watch out %c%c' one two) against GNU printf and bash built-in printf