### PR TITLE
ed: save buffer on hang-up signal

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -68,7 +68,6 @@ License: gpl
 #        - Create regression test suite...test against "real" ed.
 #        - add a "-e" flag to allow it to be used in sed(1) like fashion.
 #        - add buffer size limitations for strict compatability
-#        - Save buffer on SIGHUP (meaningless on Windoz ?)
 #        - discard NULS, chars after \n
 #        - refuse to read non-ascii files
 #        - Add BSD/GNU extentions
@@ -106,6 +105,17 @@ $NO_QUESTIONS_MODE = 0;
 
 $VERSION = "0.2";
 
+$SIG{HUP} = sub {
+    if ($NeedToSave) {
+        my $fh;
+        if (open $fh, '>', 'ed.hup') {
+            shift @lines;
+            print {$fh} join('', @lines);
+            close $fh;
+        }
+    }
+    exit 1;
+};
 #
 # Parse command line ...
 #


### PR DESCRIPTION
* Saving the buffer is useful at least for Unix-like systems
* Internal commands, e.g. "d" (edDelete), set $NeedToSave to indicate the buffer has changed
* No need to save the buffer if it was not modified since the input file was loaded
* The filename ed.hup is used by GNU ed and OpenBSD ed for the saved buffer