### PR TITLE
rm: ignore directory arg unless -r is set

### DIFF
--- a/bin/rm
+++ b/bin/rm
@@ -46,7 +46,6 @@ use Getopt::Std;
 
 # Command line arguments, and other variables.
 use vars qw( $opt_i $opt_f $opt_r $opt_R $opt_P );
-my $arg = 0;
 
 # Get the options.
 getOptions();
@@ -64,17 +63,16 @@ sub processFile()
 {
     my  ( $fileName )= @_;
 
-    # See if the file is a directory.
-    if ( ( -d $fileName ) && ( $opt_r || $opt_R ))
+    if (-d $fileName)
     {
-	# Remove a directory recursively.
+	if (!$opt_r && !$opt_R)
+	{
+	    warn "$0: cannot remove '$fileName': is a directory\n";
+	    return;
+	}
 	removeDirectory( $fileName );
     }
-    elsif ( ( -d $fileName ) && !( $opt_r || $opt_R ) && (!$opt_i ))
-    {
-	rmdir( $fileName );
-    }
-    elsif( -f $fileName )
+    else
     {
 	removeFile( $fileName );
     }


### PR DESCRIPTION
* When I compare rm with and without -r, rmdir() appears to be called without -r
* I run... mkdir dir0; touch dir0/file0; perl rm dir0 # rmdir() fails becuse dir0 is not empty
* Standard rm should not remove a directory without the -r flag
* GNU rm and OpenBSD rm print a warning to stderr to indicate the directory argument is being ignored; follow this
* Global variable $arg is unused