### PR TITLE
ed: consistently handle open() failure

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -508,12 +508,14 @@ sub edWrite {
 
     if ($AppendMode) {
         unless (open(FILE, '>>', $filename)) {
-            edWarn("Unable to open $filename for writing: $!");
+            warn "$filename: $!\n";
+            edWarn('cannot open output file');
             return;
         }
     } else {
         unless (open(FILE, '>', $filename)) {
-            edWarn("Unable to open $filename for writing: $!");
+            warn "$filename: $!\n";
+            edWarn('cannot open output file');
             return;
         }
     }
@@ -576,7 +578,8 @@ sub edEdit {
         return 0;
     }
     unless (open(SOURCE, '<', $filename)) {
-        edWarn("unable to open $filename: $!");
+        warn "$filename: $!\n";
+        edWarn('cannot open input file');
         return 0;
     }
 


### PR DESCRIPTION
* For compatibility with GNU ed and OpenBSD ed, immediately print filename and $! on stderr if open() failed, then save a simpler error message for "h"
* edEdit() opens for reading; edWrite() opens for writing/appending