### PR TITLE
ed: command argument validation

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -87,6 +87,7 @@ my $Prompt = undef;             # saved prompt string for -p option
 my $SupressCounts = 0;          # byte counts are printed by default
 my @lines;                      # buffer for file being edited.
 my $command = "";               # single letter command entered by user
+my $commandsuf = "";            # suffix string attached to command
 my @adrs;                       # 1 or 2 line numbers for commands to operate on
 my @args;                       # command arguments (filenames, search patterns...)
 
@@ -450,9 +451,13 @@ sub edSubstitute {
 sub edDelete {
     my($Numlines);
 
-
     $adrs[0] = $CurrentLineNum unless (defined($adrs[0]));
     $adrs[1] = $adrs[0] unless (defined($adrs[1]));
+
+    if ($adrs[0] == 0 || $adrs[1] == 0) {
+        edWarn('invalid address');
+        return;
+    }
 
     my $NumLines = $adrs[1]-$adrs[0]+1;
 
@@ -469,7 +474,10 @@ sub edDelete {
 #
 
 sub edFilename {
-
+    if (length $commandsuf) {
+        edWarn('unexpected command suffix');
+        return;
+    }
 
     if (defined($adrs[0]) or defined($adrs[1])) {
         edWarn("too many addresses for command: $#adrs (@adrs)");
@@ -497,6 +505,10 @@ sub edWrite {
     my($AppendMode) = @_;
     my($filename,$chars);
 
+    if (length $commandsuf) {
+        edWarn('unexpected command suffix');
+        return;
+    }
     $chars = 0;
 
     $adrs[0] = 1 unless (defined($adrs[0]));
@@ -549,6 +561,11 @@ sub edWrite {
 sub edEdit {
     my($QuestionsMode,$InsertMode) = @_;
     my(@tmp_lines,@tmp_lines2,$tmp_maxline,$tmp_chars,$chars);
+
+    if (length $commandsuf) {
+        edWarn('unexpected command suffix');
+        return;
+    }
 
     if ($InsertMode) {
         $adrs[0] = $maxline unless (defined($adrs[0]));
@@ -894,6 +911,8 @@ sub edParse {
     $adrs[0] = &CalculateLine(splice(@fields,1,13));
     $adrs[1] = &CalculateLine(splice(@fields,1,13));
 
+    my @cmd = split /\s+/, $fields[0];
+    $commandsuf = substr $cmd[0], 1;
 
     return 1;
 }


### PR DESCRIPTION
* Standard ed requires a space between "e" command and filename argument
* This version incorrectly interprets "echo" as "e cho", i.e. load file cho
* I also observed that "fun" is interpreted as "f un", but f command also requires a space
* Same with "w" and "W" commands (also expecting a filename argument)
* $fields[0] contains "echo" as entered; characters after 1st are called "command suffix"
* $fields[0] may contains a space, so only use characters before a space
* Also guard for invalid address 0 in edDelete (0 has no special meaning for "d" command)