### PR TITLE
ed: edge case for "r file" usage

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -664,7 +664,7 @@ sub edEdit {
 
     if ($InsertMode) {
 
-        if ($adrs[0] == $maxline) {
+        if ($maxline != 0 && $adrs[0] == $maxline) {
             push(@lines,@tmp_lines);
             $CurrentLineNum += $tmp_maxline;
         } elsif ($adrs[0] == 0) {


### PR DESCRIPTION
* The r command reads a file, appending its content into the existing buffer
* This is different to e and E which effectively erase the buffer when loading a new file
* r, e and E are all handled by edEdit()
* Test case: start ed with empty buffer then run "r file"
* Problem: the 1st line of file is lost and I get a "newline appended" warning
* When I debug this, $maxline == adrs[0] == 0
* The code which handles address zero should be executed, instead of the code for appending-to-end-of-buffer