### PR TITLE
rev: accept "?" as a file

### DIFF
--- a/bin/rev
+++ b/bin/rev
@@ -18,7 +18,7 @@ $|++;
 
 my ($VERSION) = '1.3';
 
-if (scalar(@ARGV) == 0 || ( $ARGV[0] ne '?' && $ARGV[0] !~ m/^-/ ) ) {
+if (scalar(@ARGV) == 0 || $ARGV[0] !~ m/^-/) {
 	while (<>) {
 		chomp;
 		my $r = reverse($_);
@@ -37,7 +37,7 @@ Reverses lines of the named file or the text input on STDIN
 
 Options:
 	--version:  Print version number, then exit.
-	--help || -h || ? :     Print usage, then exit;
+	--help || -h:     Print usage, then exit;
 
 EOF
 	exit 1;
@@ -69,7 +69,7 @@ I<rev> accepts the following options:
 
 =over 4
 
-=item  --help || -h || ?
+=item  --help || -h
 
 Print a short help message, then exits.
 

--- a/t/rev/rev.t
+++ b/t/rev/rev.t
@@ -53,9 +53,9 @@ subtest "version" => sub {
 	like $output, qr/\Q$command\E \d+\.\d+/, "shows version message";
 	};
 
-subtest "version" => sub {
+subtest "help" => sub {
 
-	foreach my $arg ( '-h', '--help', '?' ) {
+	foreach my $arg ( '-h', '--help' ) {
 	 	my( $output, $error );
  		my @command = ( $^X, $command, $arg );
   		run3 \@command, undef, \$output, \$error;


### PR DESCRIPTION
* Argument parsing in rev treated "?" as an indication to print usage, but this is not standard behaviour
* GNU rev and OpenBSD rev accept a file called "?" and we could accept it here
* I tested it with: echo hello > \? && perl rev \?