### PR TITLE
ed: fix CurrentLine for commands j,m,t

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -397,6 +397,7 @@ sub edJoin {
     splice @lines, $start, $adrs[1] - $adrs[0];
     $NeedToSave = 1;
     $UserHasBeenWarned = 0;
+    $CurrentLineNum = $adrs[0];
 }
 
 sub edMove {
@@ -448,6 +449,7 @@ sub edMove {
 
     $NeedToSave = 1;
     $UserHasBeenWarned = 0;
+    $CurrentLineNum = $dst + scalar(@copy)
 }
 
 #
@@ -1233,7 +1235,8 @@ Insert text
 
 =item j
 
-Join a range of lines into a single line
+Join a range of lines into a single line.
+The current address is set to the destination address.
 
 =item l
 
@@ -1241,7 +1244,8 @@ Print lines with escape sequences for non-printable characters
 
 =item m
 
-Move a range of lines to a new address
+Move a range of lines to a new address.
+The current address is set to the last line moved.
 
 =item n
 
@@ -1274,7 +1278,8 @@ Substitute text with a regular expression
 
 =item t
 
-Copy a range of lines to a destination address
+Copy (transfer) lines to a destination address.
+The current address is set to the last line copied.
 
 =item W [FILE]
 


### PR DESCRIPTION
* edJoin() covers the 'j' command; edMove() covers the 'm' and 't' commands
* 'j' joins ones or more lines into a single destination line
* Current line address should be updated for 'j' to the destination address
* e.g. "5,7j" joins lines 6 & 7 to the end of 5, then sets current line to 5 (6 & 7 might no longer be valid addresses)
* 'm' and 't' moves/copies lines to one after the destination address
* Current line address should be updated for 'm' and 't' to the last line moved/copied
* e.g. "7,8m3" moves lines 7 & 8 to line 3+1, then sets the current line to 5 (i.e. the final line being moved)
* Tested against GNU ed