### PR TITLE
head versus directories

### DIFF
--- a/bin/head
+++ b/bin/head
@@ -31,7 +31,7 @@ unless (getopts('n:', \%opt)) {
 my $count;
 if (defined $opt{'n'}) {
     $count = $opt{'n'};
-    if ($count =~ m/\D/) {
+    if ($count =~ m/\D/a) {
         warn "$Program: invalid number '$count'\n";
         exit EX_FAILURE;
     }

--- a/bin/head
+++ b/bin/head
@@ -13,32 +13,66 @@ License: perl
 
 
 use strict;
-use Getopt::Std;
 
+use File::Basename qw(basename);
+use Getopt::Std qw(getopts);
+
+use constant EX_SUCCESS => 0;
+use constant EX_FAILURE => 1;
+
+my $Program = basename($0);
 my ($VERSION) = '1.3';
 
 my %opt;
-getopts('n:', \%opt) or die("usage: $0 [-n count] [files ...]\n");
-
-my $count = (defined $opt{'n'}) ? $opt{'n'} : 10;
-
-die "invalid number `$count'\n" if $count =~ /\D/;
+unless (getopts('n:', \%opt)) {
+    warn "usage: $Program [-n count] [file ...]\n";
+    exit EX_FAILURE;
+}
+my $count;
+if (defined $opt{'n'}) {
+    $count = $opt{'n'};
+    if ($count =~ m/\D/) {
+        warn "$Program: invalid number '$count'\n";
+        exit EX_FAILURE;
+    }
+    if ($count == 0) {
+        warn "$Program: count is too small\n";
+        exit EX_FAILURE;
+    }
+} else {
+    $count = 10;
+}
 
 @ARGV = '-' unless @ARGV;
+my $err = 0;
+my $sep = 0;
 
 foreach my $file (@ARGV) {
     my ($fh, $is_stdin);
     if ($file eq '-') {
         $fh = *STDIN;
         $is_stdin = 1;
+    } else {
+        if (-d $file) {
+            warn "$Program: '$file' is a directory\n";
+            $err++;
+            next;
+        }
+        unless (open $fh, '<', $file) {
+            warn "$Program: $file: $!\n";
+            $err++;
+            next;
+        }
     }
-    if (!$is_stdin && !open($fh, '<', $file)) {
-        warn "$0: $file: $!\n";
-        next;
-    }
+
     if (scalar(@ARGV) > 1) {
         my $fname = $is_stdin ? 'standard input' : $file;
-        print "==> $fname <== \n";
+        if ($sep == 0) {
+            $sep = 1;
+        } else {
+            print "\n";
+        }
+        print "==> $fname <==\n";
     }
     foreach (1 .. $count) {
         my $line = <$fh>;
@@ -47,7 +81,7 @@ foreach my $file (@ARGV) {
     }
     close($fh) unless $is_stdin;
 }
-
+exit ($err ? EX_FAILURE : EX_SUCCESS);
 
 __END__
 


### PR DESCRIPTION
* No need to validate $count if the default value is used
* Raise an error for -n 0
* Reject directory arguments
* Proceed to next argument if an argument failed to process; exit with failure code when arguments are done
* compat1: print empty line before title line of next file (except for 1st file)
* compat2: don't print a space afer "<==" in title line