### PR TITLE
paste: '-' is stdin

### DIFF
--- a/bin/paste
+++ b/bin/paste
@@ -13,9 +13,14 @@ License: perl
 
 
 use strict;
-no strict 'refs';
 
-my ($VERSION) = '1.2';
+use File::Basename qw(basename);
+
+use constant EX_SUCCESS => 0;
+use constant EX_FAILURE => 1;
+
+my $Program = basename($0);
+my ($VERSION) = '1.3';
 
 my @fh;
 
@@ -39,13 +44,24 @@ EOF
 	/^-s$/ and do { $dash_ess = 1; next; }
 }
 
-if (@ARGV) {
-	for my $i (0..$#ARGV) {
-		$fh[$i] = "F$i";
-		open($fh[$i], '<', $ARGV[$i]) or die "$0: cannot open $ARGV[$i]";
+if (scalar(@ARGV) == 0) {
+	@ARGV = ('-');
+}
+foreach my $f (@ARGV) {
+	if (-d $f) {
+		warn "$Program: '$f': is a directory\n";
+		exit EX_FAILURE;
 	}
-} else {
-	$fh[0] = \*STDIN;
+	if ($f eq '-') {
+		push @fh, *STDIN;
+	} else {
+		my $fil;
+		unless (open $fil, '<', $f) {
+			warn "$Program: '$f': $!\n";
+			exit EX_FAILURE;
+		}
+		push @fh, $fil;
+	}
 }
 
 if ($dash_ess) {
@@ -105,7 +121,7 @@ paste [-s] [-d list] [file...]
 =head1 DESCRIPTION
 
 Paste combines the corresponding lines of multiple files. Each line of each
-file is printed seperated by tab (or by the characters listed in the -d
+file is printed separated by a tab character (or by the characters listed in the -d
 option).  If no files are specified, stdin is read.
 
 =head2 OPTIONS
@@ -134,8 +150,7 @@ The working of I<paste> is not influenced by any environment variables.
 
 =head1 BUGS
 
-I<paste> has no known bugs, unless you count the use of eval EXPR. Getting
-it to work under 'strict refs' would be nice, too.
+I<paste> has no known bugs, unless you count the use of eval EXPR.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
* "paste -" should behave the same as bare "paste"
* Follow OpenBSD paste: fatal error if one file argument cannot be opened (and for directory arguments)
* Now print error string $! if open() fails
* My expected usage works, ls output in 3 columns: ls -1F | perl paste - - -
* The script works on my system with regular "use strict"
* Small POD changes
* Bump version