### PR TITLE
banner: clarify usage

### DIFF
--- a/bin/banner
+++ b/bin/banner
@@ -11,58 +11,21 @@ License: bsd
 
 =cut
 
-
-# * banner - prints large signs
-# * banner [-w#] [-d] [-t] message ...
-
-# This is a translation from C of the BSD banner.c source, which bears the
-# following copyright notice:
-#
-# /*
-#  * Copyright (c) 1980, 1993, 1994
-#  *	The Regents of the University of California.  All rights reserved.
-#  *
-#  * Redistribution and use in source and binary forms, with or without
-#  * modification, are permitted provided that the following conditions
-#  * are met:
-#  * 1. Redistributions of source code must retain the above copyright
-#  *    notice, this list of conditions and the following disclaimer.
-#  * 2. Redistributions in binary form must reproduce the above copyright
-#  *    notice, this list of conditions and the following disclaimer in the
-#  *    documentation and/or other materials provided with the distribution.
-#  * 3. All advertising materials mentioning features or use of this software
-#  *    must display the following acknowledgement:
-#  *	This product includes software developed by the University of
-#  *	California, Berkeley and its contributors.
-#  * 4. Neither the name of the University nor the names of its contributors
-#  *    may be used to endorse or promote products derived from this software
-#  *    without specific prior written permission.
-#  *
-#  * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
-#  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-#  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-#  * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
-#  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-#  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-#  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-#  * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-#  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-#  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-#  * SUCH DAMAGE.
-#  */
-
 use strict;
 require 5.004;
 
-use constant MAXMSG => 1024;
+use File::Basename qw(basename);
+
 use constant DWIDTH => 132;
+use constant EX_SUCCESS => 0;
+use constant EX_FAILURE => 1;
 
-END {
-    close STDOUT || die "$0: can't close stdout: $!\n";
-    $? = 1 if $? == 255;  # from die
+my $Program = basename($0);
+
+sub usage {
+  print "usage: $Program [-w width] [message ...]\n";
+  exit EX_FAILURE;
 }
-
-sub usage { die "usage: $0 [-w width]\n" }
 
 # Character data
 my @data_table;
@@ -70,16 +33,15 @@ my @data_table;
 # Pointers into @data_table for each ASCII char
 my %ascii_to_table;
 
-
 # options
 my $width = DWIDTH;
 while (@ARGV && $ARGV[0] =~ s/^-//) {
   local $_ = shift;
-  /^[h?]$/ && usage();
   if (s/^w//) {
     if    (length) { $width = $_ }
     elsif (@ARGV)  { $width = shift }
-    else           { die "$0: option requires an integer argument -- w\n" }
+    else           { warn "$Program: option requires an integer argument -- w\n";
+                     exit EX_FAILURE; }
     if ($width =~ /\D/ || $width == 0) {
       # the original source silently defaults to 80 cols.
       # I think that's rude.
@@ -107,14 +69,12 @@ else {
 }
 
 # check message
-my $ok = 1;
 while ($message =~ /(.)/g) {
   unless ($ascii_to_table{$1}) {
-    $ok = 0;
-    warn "$0: The character `$1' is not in my character set.\n";
+    warn "$Program: The character `$1' is not in my character set\n";
+    exit EX_FAILURE;
   }
 }
-exit 1 unless $ok;
 
 # print banner
 while ($message =~ /(.)/g) {
@@ -122,7 +82,10 @@ while ($message =~ /(.)/g) {
   my $pc = $ascii_to_table{$1};
   my $term = my $max = my $linen = 0;
   while (!$term) {
-    if ($pc < 0 || $pc > $#data_table) { die "$0: bad pc $pc\n" }
+    if ($pc < 0 || $pc > $#data_table) {
+      warn "$Program: bad pc $pc\n";
+      exit EX_FAILURE;
+    }
     my $x = $data_table[$pc] & 0377;
     if ($x >= 128) {
       ++$term if $x > 192;
@@ -147,7 +110,7 @@ while ($message =~ /(.)/g) {
   }
 }
 
-exit 0;
+exit EX_SUCCESS;
 
 
 BEGIN {
@@ -1118,7 +1081,7 @@ banner - print large banner on printer
 
 =head1 SYNOPSIS
 
-banner [B<-w>I<n>] message ...
+banner [-w width] [message ...]
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
* Remove copyright comment from top of file which is already present in POD
* Remove undocumented -h option; usage is still printed
* Options -d and -t were mentioned incorrectly in a comment (usage string and SYNOPSIS only had -w)
* Update SYNOPSIS and usage to reflect that the message string is optional (user is prompted for a message)
* Immediate exit if character is not found in lookup table
* MAXMSG constant is unused