### PR TITLE
bc: integer precision problem with -b mode

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2164,11 +2164,10 @@ sub yylex
 
           # number, is it integer or float?
 	  if ($line =~ s/^(\d+)//) {
-	      $yylval = 0 + ($char.$1);
-	      $yylval = Math::BigFloat->new($yylval) if $bignum;
+	      my $str = $char . $1;
+	      $yylval = $bignum ? Math::BigFloat->new($str) : int($str);
           } else {
-	      $yylval = 0 + $char;
-	      $yylval = Math::BigFloat->new($yylval) if $bignum;
+	      $yylval = $bignum ? Math::BigFloat->new($char) : int($char);
 	  }
 	  $type = $INT;
 


### PR DESCRIPTION
* Previous bignum code was not correct because digit information was lost before conversion to BigFloat object
* Digits after the decimal point didn't seem to be affected though
* This version works better for me

bc -y # old
123384888888888888888888888888888888888888888888888812 123384888888889000000000000000000000000000000000000000

1.234448888888888888888888888888888888888888888888887 1.234448888888888888888888888888888888888888888888887

bc -y # new
123384888888888888888888888888888888888888888888888812 123384888888888888888888888888888888888888888888888812