### PR TITLE
arithmetic: terminate on end-of-file

### DIFF
--- a/bin/arithmetic
+++ b/bin/arithmetic
@@ -118,7 +118,11 @@ while ($questions < QUESTIONS) {
     # Keep trying till we get something that's a number.
     LOOP: {
         print "$left $operator $right = ";
-        chomp ($guess = <>);
+        $guess = <>;
+        if (!defined($guess)) {
+            report();
+        }
+        chomp $guess;
         if ($guess =~ /\D/) {
             print "Please type a number.\n";
             redo;
@@ -143,7 +147,7 @@ while ($questions < QUESTIONS) {
     $questions ++;
 }
 
-$SIG {INT} -> ();  # Terminates.
+report();
 
 sub report {
     my $seconds = time - $start;
@@ -182,8 +186,8 @@ If B<arithmetic> thinks your answer is not a number, it will
 respond with B<Please type a number!> and repeat the exercise.
 
 After 20 questions, B<arithmetic> will tell you how many exercises you
-answered correctly, and how much time it took. Interrupting the game
-triggers the same reports; the game is then terminated.
+answered correctly, and how much time it took.
+You can quit at any time by typing the interrupt or end-of-file character.
 
 If you answer an exercise incorrectly, B<arithmetic> will remember the
 numbers involved, and favour those over others.

--- a/bin/arithmetic
+++ b/bin/arithmetic
@@ -220,8 +220,7 @@ The working of B<arithmetic> is not influenced by any environment variables.
 
 =head1 BUGS
 
-This implementation of B<arithmetic> does not respect the end of file
-character.
+None known.
 
 =head1 REVISION HISTORY
 


### PR DESCRIPTION
* Allow arithmetic to be terminated by either interrupt (ctrl+c) or end-of-file (ctrl+d)
* Previously eof was ignored
* Refer to C code [1]: fgets() returns NULL at end of file, causing final report to be printed
* Also the C comment: Keep looping until the correct answer is given, or until EOF or interrupt is typed
* Update POD to mention end-of-file
* Style: at end of 20 questions, call report() directly instead of via signal handler


1. https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/games/arithmetic/arithmetic.c