### PR TITLE
bc: don't print 0 for a false if-condition

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2533,10 +2533,11 @@ sub exec_stmt
 # IF statement
 
      my $cond = pop @ope_stack;
-     $val = 0;
      if($cond) {
        ($return, $val) = exec_stmt($instr->[1]);
        push(@ope_stack, $val), last INSTR if $return;
+     } else {
+       $val = undef;
      }
 
 #     debug {"IF: $val.\n"};
@@ -2619,7 +2620,6 @@ sub exec_stmt
 # Restore the symbols temporarily pushed in 'a' and 'A' instructions
        debug {"restoring backup: ".Dumper(\@backup_sym_table)};
 
-       my $n;
 #       pop @backup_sym_table;    # The first is undef
        while($var = pop @backup_sym_table) {
 	 debug {"restoring var: ".Dumper($var)};


### PR DESCRIPTION
* perl bc evaluates false "if" as an expression and returns 0, not "null"

>>> if (0 == 1) { a = 1; } 
0

* This doesn't happen if the condition is true
* I observe that if $res==0, the executed statement result ($val) is printed
* In IF-statement code, $val is returned by exec_stmt() if the condition is true
* If the condition is false, $val defaults to zero but this causes an unwanted print later
* Changing the default to undef works for my simple test.bc script
* Reading the code, I see other examples of undef being pushed into ope_stack, so I think this will not corrupt the state
* Also remove unused variable $n found by perlcritic
* Does this look ok?