### PR TITLE
basename: '/' handling is broken

### DIFF
--- a/bin/basename
+++ b/bin/basename
@@ -15,7 +15,7 @@ License: perl
 use strict;
 use File::Basename;
 
-my ($VERSION) = '1.2';
+my ($VERSION) = '1.3';
 
 unless (@ARGV == 1 || @ARGV == 2) {
     $0 = basename ($0);
@@ -30,7 +30,20 @@ if (@ARGV == 2) {
     $ARGV [1] = quotemeta $ARGV [1] unless $ARGV [1] =~ s{^/(.*)/$}{$1};
 }
 
-print +(fileparse @ARGV) [0], "\n";
+my $path = shift;
+if (!length($path)) {
+    print "\n";
+    exit;
+}
+$path =~ s/\/+/\//g;  # "///" -> "/"
+if ($path eq '/') {
+    print "/\n";
+    exit;
+}
+$path =~ s/\/\Z//;  #  "a/" -> "a"
+my @parsed = fileparse($path);
+my $name = shift @parsed;
+print $name, "\n";
 
 __END__
 
@@ -38,7 +51,7 @@ __END__
 
 =head1 NAME
 
-basename - print the basename of a file
+basename - remove directory and suffix from filenames
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
* Despite what the pod text said, this version was not compatible with the OpenBSD version
* Paths ending in one or more '/' were not handled correctly
* Standard basename treats consecutive slashes as one, and ignores training slash
* fileparse() doesn't understand trailing slash so strip it first
* Basename of empty string is empty string; print newline to match other versions
* Basename of '/ is '/'
* Bump version number

/ -> /
/// -> /
a -> a
a/b -> b
a/b/ -> b
a/b/////////c/// -> c