### PR TITLE
colrm: add validation

### DIFF
--- a/bin/colrm
+++ b/bin/colrm
@@ -14,31 +14,57 @@ License: perl
 
 use strict;
 
-$0 =~ s(.*/)();
-my $usage = "usage: $0 [startcol endcol]\n";
-my ($startcol, $endcol);
+use File::Basename qw(basename);
 
-# I could be more clever, but this will run faster
+my $Program = basename($0);
 
 if (@ARGV > 2) {
-	die $usage;
+	die "usage: $Program [startcol [endcol]]\n";
 } elsif (@ARGV == 0) {
 	print while(<>);
 } elsif (@ARGV == 1) {
-	$startcol = (shift() - 1);
-	while (<>) {
-		print substr $_, 0, $startcol;
+	my $startcol = getarg();
+	while (my $line = <>) {
+		chomp $line;
+		my $len = length $line;
+		if ($startcol > $len) {
+			print $line;
+		} else {
+			print substr $line, 0, $startcol - 1;
+		}
 		print "\n";
 	}
 } elsif (@ARGV == 2) {
-	$startcol = (shift() - 1);
-	$endcol = (shift() - 1);
-	while (<>) {
-		chomp;
-		substr($_, $startcol, $endcol) = '';
+	my $startcol = getarg();
+	my $endcol = getarg();
+	if ($startcol > $endcol) {
+		die "$Program: bad range: $startcol,$endcol\n";
+	}
+	while (my $line = <>) {
+		chomp $line;
+		my $len = length $line;
+		if ($startcol > $len) {
+			print $line;
+		} else {
+			print substr $line, 0, $startcol - 1;
+			print substr $line, $endcol;
+		}
 		print "$_\n";
 	}
 }
+exit;
+
+sub getarg {
+	my $n = shift @ARGV;
+	if (!defined($n)) {
+		die "$Program: missing argument\n";
+	}
+	if ($n =~ m/\D/ || $n == 0) {
+		die("$Program: invalid column number '$n'\n");
+	}
+	return $n;
+}
+
 
 =head1 NAME
 
@@ -61,9 +87,6 @@ If both I<startcol> and I<endcol> are provided, removes all columns from
 I<startcol> to I<endcol>, inclusive.
 
 If neither is provided, acts just like B<cat>.
-
-If I<firstcol> is greater than I<lastcol>, or the arguments aren't numeric,
-it pretends it heard no arguments at all, just like the Linux version.
 
 =head1 OPTIONS AND ARGUMENTS
 

--- a/bin/colrm
+++ b/bin/colrm
@@ -16,10 +16,14 @@ use strict;
 
 use File::Basename qw(basename);
 
+use constant EX_SUCCESS => 0;
+use constant EX_FAILURE => 1;
+
 my $Program = basename($0);
 
 if (@ARGV > 2) {
-	die "usage: $Program [startcol [endcol]]\n";
+	warn "usage: $Program [startcol [endcol]]\n";
+	exit EX_FAILURE;
 } elsif (@ARGV == 0) {
 	print while(<>);
 } elsif (@ARGV == 1) {
@@ -38,7 +42,8 @@ if (@ARGV > 2) {
 	my $startcol = getarg();
 	my $endcol = getarg();
 	if ($startcol > $endcol) {
-		die "$Program: bad range: $startcol,$endcol\n";
+		warn "$Program: bad range: $startcol,$endcol\n";
+		exit EX_FAILURE;
 	}
 	while (my $line = <>) {
 		chomp $line;
@@ -52,15 +57,17 @@ if (@ARGV > 2) {
 		print "$_\n";
 	}
 }
-exit;
+exit EX_SUCCESS;
 
 sub getarg {
 	my $n = shift @ARGV;
 	if (!defined($n)) {
-		die "$Program: missing argument\n";
+		warn "$Program: missing argument\n";
+		exit EX_FAILURE;
 	}
-	if ($n =~ m/\D/ || $n == 0) {
-		die("$Program: invalid column number '$n'\n");
+	if ($n =~ m/[^0-9]/ || $n == 0) {
+		warn "$Program: invalid column number '$n'\n";
+		exit EX_FAILURE;
 	}
 	return $n;
 }


### PR DESCRIPTION
* Zero was allowed for column number, but it's not valid because we count from one---raise error like BSD version does
* Also, colrm allows negative value arguments; add validation to avoid this
* For ARGV==1, when arg1 > column count, output incorrectly gets another newline appended because the substring is the full string including newline
* For ARGV==2, "colrm 1 1" is supposed to remove only the 1st column but it did nothing
* Also, the substring could be outside the string for "colrm 1000 1000" because input was not validated