### PR TITLE
tee: expectation for -n option

### DIFF
--- a/bin/tee
+++ b/bin/tee
@@ -31,7 +31,12 @@ if ($ignore_ints) {
 $SIG{'PIPE'} = 'PLUMBER';
 $mode = $append ? '>>' : '>';
 $fh = 'FH000';
-unless ($nostdout) {
+if ($nostdout) {
+    unless (@ARGV) {
+	warn "$0: file argument must be given with -n\n";
+	exit 1;
+    }
+} else {
     %fh = ('STDOUT', 'standard output'); # always go to stdout
 }
 $| = 1 if $unbuffer;


### PR DESCRIPTION
* This version of tee has a non-standard option -n to disable writing output to stdout
* When using -n without any file arguments, tee reads its input and does nothing
* Reading input has no effect so raise an error instead
* I'm happy to remove the -n option if you prefer