### PR TITLE
tac fails to read a file

### DIFF
--- a/bin/tac
+++ b/bin/tac
@@ -191,7 +191,7 @@ sub get_lines {
         # record separator has been broken across two chunks.
         my $file = *$self->{files}[0];
         CHUNK: {
-            my $tell = tell $fh;
+            my $tell = sysseek $fh, 0, 1;
             unless ($tell > $size) {
                 sysseek $fh, 0, 0       or confess "Bad seek on [$file]: $!";
                 sysread $fh, $_, $tell  or confess "Bad read on [$file]: $!";


### PR DESCRIPTION
* tac successfully reads from stdin when run with no file argument
* GNU tac accepts file argument of '-' for stdin but ppt version does not
* I get an error when reading from a file: perl tac tac

Bad read on [ARRAY(0x1a04270)]:  at tac line 197.
	IO::Tac::get_lines(IO::Tac=GLOB(0x19ef4b8)) called at tac line 150
	IO::Tac::READLINE(IO::Tac=GLOB(0x19ef4b8)) called at tac line 43

* When debugging this I found that $tell is set to zero, then in the tell() perldoc manual it explains that tell() doesn't work with sysopen()
* Calling sysread with size of zero was invalid
* Replacing tell() with sysseek() call fixes the problem on my system