### PR TITLE
strings: better validation

### DIFF
--- a/bin/strings
+++ b/bin/strings
@@ -61,11 +61,18 @@ getopts( 'afon:t:' ) or die $usage;
 
 $opt_n ||= 4;
 $opt_t ||= 'o' if $opt_o;
-if ( $opt_t )
-{
-    $opt_t =~ /[dox]/ or die $usage;
-    $offset_format = "\%07$opt_t ";
+
+if ($opt_O) {
+    $opt_t = 'o';
+} elsif (defined $opt_t) {
+    my %EXPECT = (
+        'd' => 1,
+        'o' => 1,
+        'x' => 1,
+    );
+    die($usage) unless $EXPECT{$opt_t};
 }
+$offset_format = "\%07$opt_t ";
 
 # Consider all graphic characters plus space and tab to be printable.
 # Escape all punctuation characters out of paranoia.
@@ -76,6 +83,7 @@ $chunksize = 4096; # whatever
 
 for my $filename ( @ARGV )
 {
+    die("'$filename' is a directory\n") if (-d $filename);
     open( IN, '<', $filename ) or die "Can't open $filename: $!\n";
     binmode IN;
     $offset = 0;

--- a/bin/strings
+++ b/bin/strings
@@ -60,9 +60,7 @@ use Getopt::Std;
 getopts( 'afon:t:' ) or die $usage;
 
 $opt_n ||= 4;
-$opt_t ||= 'o' if $opt_o;
-
-if ($opt_O) {
+if ($opt_o) {
     $opt_t = 'o';
 } elsif (defined $opt_t) {
     my %EXPECT = (


### PR DESCRIPTION
* Option -t expects a single letter, but this version accepted stupid things like -t bedding
* $offset_format is only used if $opt_t is set; default usage does not print offset
* Directory arguments were silently failing; now print an error message for them
