### PR TITLE
wc: continue if open() fails

### DIFF
--- a/bin/wc
+++ b/bin/wc
@@ -11,29 +11,30 @@ License: perl
 
 =cut
 
-END {
-    close STDOUT || die "$0: can't close stdout: $!\n";
-    $? = 1 if $? == 255;  # from die
-}
-
-sub usage {
-    warn "$0: @_\n" if @_;
-    print "usage: $0 [-a | [-p] [-l] [-w] [-m] [-c] ] [file1 [file2...]]\n";
-    exit 0;
-}
-
 use strict;
 use locale;
-use File::Basename;
 
-use vars qw($opt %opt);
+use File::Basename qw(basename);
+
+use constant EX_SUCCESS => 0;
+use constant EX_FAILURE => 1;
+
+my $Program = basename($0);
+
+my %opt;
+
+sub usage {
+    warn "$Program: @_\n" if @_;
+    warn "usage: $Program [-a | [-p] [-l] [-w] [-m] [-c] ] [file...]\n";
+    exit EX_FAILURE;
+}
 
 @opt{ qw/? a p l w m c/ } = qw(0 0 0 0 0 0 0);
 
 # The $MacPerl::Version variable should be on if ($^O =~ /MacOS/)
 # this unusual construct gets around -w -Mstrict in other places too.
 if ( $MacPerl::Version && $MacPerl::Version =~ /App/) {
-    $opt = MacPerl::Pick("Which wc option?",
+    my $opt = MacPerl::Pick("Which wc option?",
       "all","default (lwc)",
       "-l (lines)","-w (words)","-c (bytes)",
       "-m (chars)","-p (paragraphs)");
@@ -49,7 +50,6 @@ else {
     while ($ARGV[0] =~ /^-/) {
         $ARGV[0] =~ s/^-//;
         for my $flag (split(//,$ARGV[0])) {
-            usage() if '?' =~ /\Q$flag/;
             usage("unknown flag: `$flag'") unless 'aplwmc' =~ /\Q$flag/;
             warn "$0: `$flag' flag already set\n" if $opt{$flag}++;
         }
@@ -208,7 +208,6 @@ sub wc_fh {
         }
     }
     if ($paras > 1) { $paras--; }
- #   if ($words > 0) { $words--; }
     if ($words > 1) { $words--; }
     $total_paras += $paras;
     $total_lines += $lines; $total_words += $words;
@@ -230,9 +229,17 @@ sub wc_fh {
 
 if (@ARGV) {
     foreach my $filename (@ARGV) {
-        open(FH, '<', $filename) or die "cannot open $filename: $!\n";
-        wc_fh(\*FH, $filename);
-        close(FH);
+        if (-d $filename) {
+            warn "$Program: '$filename' is a directory\n";
+            next;
+        }
+        my $fh;
+        unless (open $fh, '<', $filename) {
+            warn "$Program: '$filename': $!\n";
+            next;
+        }
+        wc_fh($fh, $filename);
+        close $fh;
     }
 } else {
     wc_fh(\*STDIN);
@@ -258,7 +265,7 @@ wc - paragraph, line, word, character, and byte counter
 
 =head1 SYNOPSIS
 
-wc [-a | [-p] [-l] [-w] [-m] [-c] ] [file1 [file2...]]
+    wc [-a | [-p] [-l] [-w] [-m] [-c] ] [file...]
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
* Exit with failure code in usage()
* Tweak usage string: indicate zero or more files with [file...]
* Follow GNU wc: continue processing next argument if open() fails
* Delete old commented code; probably incorrect
* $opt doesn't need to be global because it is only used in the custom "Mac" code block
* Print warning for directory arguments and skip them