### PR TITLE
xargs: standard loop termination

### DIFF
--- a/bin/xargs
+++ b/bin/xargs
@@ -84,9 +84,14 @@ while (1) {
 	@args = ();
     }
     if ($o{t}) { local $" = "', '"; warn "exec '@run'\n"; }
-    if (system(@run) != 0) {
-	warn "$0: $run[0]: $!\n";
-	exit($? >> 8);
+    my $rc = system @run;
+    if ($rc == -1) {
+	warn "$Program: $run[0]: $!\n";
+	exit EX_FAILURE;
+    }
+    if ($rc && $rc >> 8 == 255) {
+	warn "$Program: $run[0]: exited with status 255\n";
+	exit EX_FAILURE;
     }
 }
 


### PR DESCRIPTION
* Standard xargs does not terminate for all error exit codes [1], only for exit code 255 returned by the command
* system() returns -1 if the command couldn't be started, so also treat that as a fatal error
* With patch applied, match the behaviour of GNU xargs for the following cases
* case1: don't terminate ls-loop if first file wasn't found

echo a b | perl xargs -n 1 ls -1
a
ls: cannot access 'b': No such file or directory

* case2: terminate xargs for command l which doesn't exist, system() returned -1

echo a | perl xargs l
xargs: l: No such file or directory

* case3: terminate xargs for command returning 255 (dummy example)

echo a | perl xargs perl -e'exit 255'
xargs: perl: exited with status 255

1. https://pubs.opengroup.org/onlinepubs/9699919799/utilities/xargs.html