### PR TITLE
which returns directory paths

### DIFF
--- a/bin/which
+++ b/bin/which
@@ -100,21 +100,30 @@ foreach my $command (@ARGV) {
     }
 
     foreach my $dir (@PATH) {
+        my $path = $dir . $file_sep . $command;
+
+        if (-d $path) {
+            next;
+        }
         if ($^O eq 'MacOS') {
-            if (-e "$dir$file_sep$command") {
-                print "$dir$file_sep$command\n";
+            if (-e $path) {
+                print "$path\n";
                 next COMMAND unless $opt{'a'};
             }
         }
         else {
-            if (-x "$dir$file_sep$command") {
-                print "$dir$file_sep$command\n";
+            if (-x $path) {
+                print "$path\n";
                 next COMMAND unless $opt{'a'};
             }
         }
         foreach my $ext (@PATHEXT) {
-            if (-x "$dir$file_sep$command$ext") {
-                print "$dir$file_sep$command$ext\n";
+            my $pathext = $path . $ext;
+            if (-d $pathext) {
+                next;
+            }
+            if (-x $pathext) {
+                print "$pathext\n";
                 next COMMAND unless $opt{'a'};
             }
         }


### PR DESCRIPTION
* The following output is incorrect because the results all refer to directories

$ perl which . .. /
/usr/local/sbin/.
/usr/local/sbin/..
/usr/local/sbin//

* The command "which" is supposed to find files available to execute, not directories
* Resolve this by adding explicit directory check before checking "-x $path"
* Style: declare path variables to make code simpler to read