### PR TITLE
dc: stop reading stdin too much

### DIFF
--- a/bin/dc
+++ b/bin/dc
@@ -48,8 +48,9 @@ License:
 eval 'exec /usr/local/bin/perl -S $0 ${1+"$@"}'
 	if $running_under_some_shell;
 
-push @ARGV, "-";
-
+if (scalar(@ARGV) == 0) {
+    push @ARGV, "-";
+}
 $_ = "|P|K0|I10|O10|?";
 
 for (;;) {


### PR DESCRIPTION
* When no file argument is given, stdin is read
* When a file argument is given, run it and exit
* I noticed that after running "perl dc test.dc", dc would hang waiting for stdin