### PR TITLE
mail can't write to mbox

### DIFF
--- a/bin/mail
+++ b/bin/mail
@@ -425,13 +425,10 @@ sub write {
 	my $self=shift;
 	my $wa=shift;
 
-	$of=">" . $self->file;
-	if (exists $$wa{append} ) {
-		$of=">$of";
-	}
+	my $mode = exists $$wa{append} ? '>>' : '>';
 	my $alt_msg="\"" . $self->file . "\" ";
 	$alt_msg.=(-e $self->file)?"[Appended]":"[New File]";
-	if (! open(MBOX, '<', $of )) {
+	if (!open(MBOX, $mode, $self->file)) {
 		warn "Failed to write to ", $self->file, ": $!\n";
 		return;
 	}


### PR DESCRIPTION
* When issuing quit command (q) I was seeing the error: Failed to write to /home/ranch/mbox: No such file or directory
* Something was wrong because the file did exist
* The error message printed $self->file but the path opened was $of, which had a prepended ">"
* Possibly this is a hangover from previously switching to 3-argument form of open()