### PR TITLE
id: uid 0 is valid

### DIFF
--- a/bin/id
+++ b/bin/id
@@ -34,12 +34,14 @@ my($user,$pw,$uid,$gid,$tp);
 
 if ( @ARGV ) { # user specified
 	($user,$pw,$uid,$gid) = getpwnam $ARGV[0];
-	($user,$pw,$uid,$gid) = getpwuid $ARGV[0] unless ( $uid );
-	die "id: $ARGV[0]: No such user\n" unless ( $uid );
+	if (!defined($uid) && $ARGV[0] =~ m/\A[0-9]+\Z/) {
+		($user,$pw,$uid,$gid) = getpwuid $ARGV[0];
+	}
+	die "id: $ARGV[0]: No such user\n" unless (defined $uid);
 }
 
 if ( $opt_u ) { # print uid
-	$tp = ($uid)?$uid:($opt_r)?$<:$>;
+	$tp = defined $uid ? $uid : $opt_r ? $< : $>;
 	$tp = scalar getpwuid $tp || $tp if ( $opt_n );
 }
 elsif ( $opt_g ) { # print gid


### PR DESCRIPTION
* Problem1: id reports that my root user doesn't exist because the uid is zero
* This is because $uid is undef if getpwnam() fails, but this was treated the same as 0

$ id root
uid=0(root) gid=0(root) groups=0(root),117(lpadmin)
$ perl id root
id: root: No such user

* Problem2: id reports that 'root77' user exists when it does not
* This is because a non-numeric parameter was passed to getpwuid()

$ perl id root77
uid=0(root) gid=0(root) groups=117(lpadmin),0(root)