### PR TITLE
bc: filename 0 is not special

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2031,7 +2031,8 @@ last switch;
 $mathlib=0;
 sub command_line()
 {
-  while ($f = shift(@ARGV)) {
+  while (@ARGV) {
+    my $f = shift @ARGV;
     if ($f eq '-b') {
       use Math::BigFloat;
       $bignum = 1;
@@ -2068,7 +2069,9 @@ sub next_file
     $cur_file="main::DATA";
     return 1;
 
-  } elsif($file = shift(@file_list)) {
+  }
+  if (@file_list) {
+    my $file = shift @file_list;
 
     debug { "reading from $file\n" };
 


### PR DESCRIPTION
* bc accepts file argument 0 even if it does not exist
* It appears the code was incorrectly doing a truth test on the argument list, resulting in stdin being read
* The same problem existed when selecting the next element from @file_list
* Patched version raises an error that "0" is not found