### PR TITLE
tail: check_number() too forgiving

### DIFF
--- a/bin/tail
+++ b/bin/tail
@@ -55,12 +55,12 @@ my $block_size = 512;
 sub check_number($)
 {
     my $opt = shift;
-    if ($opt =~ /\+(\d+)$/) {
-    return $1+0;
-    } elsif      ($opt =~ /-?(\d+)$/) {
-    return -($1+0);
+    if ($opt =~ m/\A\+(\d+)\Z/) {
+        return $1+0;
+    } elsif ($opt =~ m/\A\-?(\d+)\Z/) {
+        return -($1+0);
     } else {
-    usage(1);
+        usage(1, "invalid number '$opt'");
     }
 }
 


### PR DESCRIPTION
* Numbers can optionally be given with '-' or '+' prefix
* The number validation function allows numbers with leading garbage (regex match was only on end of string)
* These values were accepted: aaa1 +aaa1 -aaa1
* We can pass a helpful error message to usage() to indicate which argument was rejected
* Style: indent check_number()
* Tested this by passing numbers to -n option