### PR TITLE
file: incorrect error message

### DIFF
--- a/bin/file
+++ b/bin/file
@@ -167,18 +167,11 @@ for my $file (@ARGV) {
     # the description line.  append info to this string
     my $desc = "$file:";
 
-    # 0) check permission
-    if (! -r $file) {
-        $desc .= " can't read `$file': Permission denied.";
-        print $desc,"\n";
-        next;
-    }
-
     # 1) check for various special files first
     if ($followLinks) {
-        stat($file);
+        stat($file) or die("$F: '$file': $!\n");
     } else {
-        lstat($file);
+        lstat($file) or die("$F: '$file': $!\n");
     }
 
     if (! -f _  or -z _) {


### PR DESCRIPTION
* When running "perl file not.exist", I was getting a permission denied error
* Resolve this by checking for failure of stat() via return value
* For a file that I don't have permission to read, FileHandle->new() will fail and $! will be printed correctly