### PR TITLE
tee: null mode param passed to open()

### DIFF
--- a/bin/tee
+++ b/bin/tee
@@ -42,7 +42,7 @@ if ($nostdout) {
 $| = 1 if $unbuffer;
 
 for (@ARGV) {
-    if (!open($fh, (/^[^>|]/ && $mode), $_)) {
+    if (!open($fh, $mode, $_)) {
 	warn "$0: cannot open $_: $!\n"; # like sun's; i prefer die
 	$status++;
 	next;


### PR DESCRIPTION
* Sometimes tee fails to open a file for writing because of a confusing filename guard regex

  echo yo | perl tee  . '|o|'
tee: cannot open .: Is a directory
Unknown open() mode '' at tee line 45.

* '|o|' is a valid filename on my system if it is quoted like this
* GNU tee doesn't complain about this usage (aside from complaining about the directory argument '.')
* $mode is already determined based on -a option
* Making decisions based on the filename seems incorrect so just simplify open()