### PR TITLE
bc: runtime error eats too much input

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2611,7 +2611,7 @@ sub exec_stmt
        print STDERR "No function $name has been defined\n";
        @ope_stack = (0);
        $return = 3;
-       YYERROR;
+       last INSTR;
      }
 
      if($sym_table{$name}{type} eq 'builtin') {


### PR DESCRIPTION
* In interactive bc, calling an undefined function does not cause a fatal error but an error is printed
* YYERROR() is called in this situation, but it seems to break something
* It appears that input tokens past the end of current statement are eaten by YYERROR
* I observed this:

ME> x = hey(1) + 2
BC> No function hey() has been defined
ME> x
ME> x
BC> 0
ME> quit

* After the error bc ignores the first time I type x (but when I ask again it politely answers)
* Replacing YYERROR with "last INSTR" causes bc to jump past the final instruction in the current statement
* Instructions in the subsequent statement are not destroyed
* With this patch, the statement after the error is executed as I expect (this matches GNU bc)

ME> x = 5
BC> 5
ME> y = heh(6) + 7
BC> No function heh() has been defined
ME> x
BC> 5
ME> y
BC> 0
ME> quit