### PR TITLE
wump: simplify S list init

### DIFF
--- a/bin/wump
+++ b/bin/wump
@@ -30,14 +30,30 @@ my $I = uc(<>); chomp($I); 			#20 INPUT I$
                                   		#35 GOTO 80  (what's this for?)
 
 # 80 REM *** SET UP CAVE (DODECAHEDRAL NODE LIST) ***
-my ($J, $K);
-my @S;						#85 DIM S(20,3)
-my @temp; while (<DATA>) {chomp;push @temp, (split(",",$_))}
-for my $J (1..20) { 				#90 FOR J=1 TO 20
-    for my $K (1..3) {				#95 FOR K=1 TO 3
-        $S[$J][$K] = shift(@temp);		#100 READ S(J,K)
-    }						#105 NEXT K
-}						#110 NEXT J
+my @S = (
+    [ undef ],
+    [ undef,  2,  5,  8 ],
+    [ undef,  1,  3, 10 ],
+    [ undef,  2,  4, 12 ],
+    [ undef,  3,  5, 14 ],
+    [ undef,  1,  4,  6 ],
+    [ undef,  5,  7, 15 ],
+    [ undef,  6,  8, 17 ],
+    [ undef,  1,  7,  9 ],
+    [ undef,  8, 10, 18 ],
+    [ undef,  2,  9, 11 ],
+    [ undef, 10, 12, 19 ],
+    [ undef,  3, 11, 13 ],
+    [ undef, 12, 14, 20 ],
+    [ undef,  4, 13, 15 ],
+    [ undef,  6, 14, 16 ],
+    [ undef, 15, 17, 20 ],
+    [ undef,  7, 16, 18 ],
+    [ undef,  9, 17, 19 ],
+    [ undef, 11, 18, 20 ],
+    [ undef, 13, 16, 19 ],
+);
+
 sub fna {int(rand() * 20) + 1}			#135 DEF FNA(X)=INT(20*RND(1))+1
 sub fnb {int(rand() * 3) + 1}			#140 DEF FNB(X)=INT(3*RND(1))+1
 sub fnc {int(rand() * 4) + 1}			#145 DEF FNC(X)=INT(4*RND(1))+1
@@ -269,7 +285,7 @@ sub shoot {
 ###############
 # 935 REM *** MOVE WUMPUS ROUTINE ***
 sub move_wumpus {
-    $K = &fnc;					# 940 K=FNC(0)
+    my $K = fnc();				# 940 K=FNC(0)
     unless ($K==4) { 				# 945 IF K=4 THEN 955
         $L[2] = $S[$L[2]][$K] 			# 950 L(2)=S(L(2),K)
     }
@@ -339,11 +355,8 @@ exit; 						# 1150 END
 #120 DATA 5,7,15,6,8,17,1,7,9,8,10,18,2,9,11
 #125 DATA 10,12,19,3,11,13,12,14,20,4,13,15,6,14,16
 #130 DATA 15,17,20,7,16,18,9,17,19,11,18,20,13,16,19
-__DATA__
-2,5,8,1,3,10,2,4,12,3,5,14,1,4,6
-5,7,15,6,8,17,1,7,9,8,10,18,2,9,11
-10,12,19,3,11,13,12,14,20,4,13,15,6,14,16
-15,17,20,7,16,18,9,17,19,11,18,20,13,16,19
+
+__END__
 
 =pod
 


### PR DESCRIPTION
* Convert S list init code into data declarations
* $J and $K aren't intended to be global because functions declare their own $J/$K
* move_wumpus() was an exception to this but it does not require a global $K
* S and nested arrays are accessed from element 1, so element 0 is blank