### PR TITLE
tail: continue on error

### DIFF
--- a/bin/tail
+++ b/bin/tail
@@ -26,12 +26,16 @@ License: perl
 
 $| = 1;
 
+use strict;
+
+use File::Basename qw(basename);
 use Getopt::Long;  # because of some special handling on numeric options
 
-use strict;
+use constant EX_SUCCESS => 0;
+use constant EX_FAILURE => 1;
+
 use vars qw($opt_b $opt_c $opt_f $opt_h $opt_n $opt_r);
 
-use File::Basename;
 my $me = basename $0;
 
 sub usage($;$)
@@ -360,6 +364,7 @@ sub handle_INT()
 sub handle_args($$$)
 {
     my ($point, $type, $files_) = @_;
+    my $rc = EX_SUCCESS;
 
     # Expand the directories (but not the sub-directories)
     my @files;
@@ -382,10 +387,11 @@ sub handle_args($$$)
         # do not die if the file does not exist, when -f is used
         next if(!-e $file and ($opt_f or $me eq "xtail"));
 
-        open FH, '<', $file
-        or do { print STDERR
-                "Couldn't open $file for reading: $!\n";
-                exit 1 };
+        unless (open FH, '<', $file) {
+            warn "$me: Couldn't open '$file': $!\n";
+            $rc = EX_FAILURE;
+            next;
+        }
 
         # Do not print the tail of the files if we are using xtail
         unless($me eq "xtail") {
@@ -405,13 +411,11 @@ sub handle_args($$$)
         print_tail \*STDIN, "stdout", $point, $type;
         # Ignore the -f option
     }
-
+    return $rc;
 }
 
 my ($point, $type, $files) = parse_args();
-handle_args($point, $type, $files);
-
-exit 0;
+exit handle_args($point, $type, $files);
 
 __END__
 


### PR DESCRIPTION
* Behave like head; print a warning if a file argument can't be opened then proceed to the next argument
* Exit with failure code if an argument failed to open
* Issue noticed when testing against GNU tail