### PR TITLE
wc: report file arguments as provided

### DIFF
--- a/bin/wc
+++ b/bin/wc
@@ -212,13 +212,11 @@ sub wc_fh {
     $total_paras += $paras;
     $total_lines += $lines; $total_words += $words;
     $total_chars += $chars; $total_bytes += $bytes;
-    $out = do {
-        if (defined($filename)) {
-            sprintf(" %s\n",basename($filename))
-        } else {
-            "\n"
-        }
-    };
+    if (defined $filename) {
+        $out = " $filename\n";
+    } else {
+        $out = "\n";
+    }
     $out = sprintf(" %9u%s",$bytes,$out) if ($opt{'c'});
     $out = sprintf(" %9u%s",$chars,$out) if ($opt{'m'});
     $out = sprintf(" %9u%s",$words,$out) if ($opt{'w'});


### PR DESCRIPTION
* This version of wc was being helpful and printing the basename of each file argument beside each count
* This creates the problem that output is ambiguous when counting lines of files of the same name in different directories
* Issue was noticed when testing against GNU wc

```
perl wc -l old/a new/a | sort -n 
       183 new/a
      3132 old/a
      3315 total
```