### PR TITLE
tail -n: 0 versus +0 versus -0

### DIFF
--- a/bin/tail
+++ b/bin/tail
@@ -90,9 +90,18 @@ sub parse_args()
     usage 1, "-f and -r cannot be used together"
         if $opt_f and $opt_r;
 
-    $point = check_number($opt_b), $type = "b" if $opt_b;
-    $point = check_number($opt_c), $type = "c" if $opt_c;
-    $point = check_number($opt_n), $type = "n" if $opt_n;
+    if (defined $opt_b) {
+        $point = check_number($opt_b);
+        $type = 'b';
+    }
+    if (defined $opt_c) {
+        $point = check_number($opt_c);
+        $type = 'c';
+    }
+    if (defined $opt_n) {
+        $point = check_number($opt_n);
+        $type = 'n';
+    }
 
     for (@ARGV) {
         $point = check_number($1), shift @ARGV, last


### PR DESCRIPTION
* I wrote a test harness for tail-zero-lines...
     for opt in '-0' '+0' '-n 0' '-n -0' '-n +0' ; do echo "tail $opt"; perl tail $opt in; done;
* Some cases result in the error: The number cannot be null
* "tail -n 0" is accepted but "tail -n +0" and "tail -n -0" are not
* When debugging I found that check_number() is not called for "tail -n 0" (but it should be)
* check_number() was only called if $opt_b/$opt_c/$opt_n were true
* NB: GNU tail allows -n 0, but raising error in this version is consistent internally, and with "head -n 0"