### PR TITLE
tail: warn for directory args

### DIFF
--- a/bin/tail
+++ b/bin/tail
@@ -380,8 +380,13 @@ sub handle_args($$$)
     my @dirs;
 
     for my $f (@$files_) {
-        if(-d $f) {
-             push @dirs, $f;
+        if (-d $f) {
+            if ($opt_f) {
+                push @dirs, $f;
+            } else {
+                warn "$me: '$f' is a directory\n";
+                $rc = EX_FAILURE;
+            }
         } else {
             push @files, $f;
         }


### PR DESCRIPTION
* The -f mode of tail calls tail_f(), passing file & directory arguments as separate params
* By default handle_args() loops over Files list, not Dirs list, so directory arguments were silently ignored
* Make the default case follow GNU tail: print a warning for each directory argument, and exit with error code when arguments are done