### PR TITLE
cut: -b 0 and -f 0 are invalid

### DIFF
--- a/bin/cut
+++ b/bin/cut
@@ -61,14 +61,22 @@ $opt{b} = $opt{c} if defined $opt{c};
 if (defined ($opt{b})) {
 
     my @list = split (/,/, $opt{b});
+    foreach my $item (@list) {
+	if ($item == 0) {
+	    warn "$me: byte positions are numbered from 1\n";
+	    exit EX_FAILURE;
+	}
+    }
 
     while (<>) {
 	chomp;
 
 	foreach my $item (@list) {
 	    my ($start,$end) = split (/-/, $item);
-	    die "$me: invalid byte list\nType '$me' alone for usage.\n"
-		if ($start and $end and $start > $end);  # parameters overlap?
+	    if ($start and $end and $start > $end) {
+		warn "$me: invalid byte list\n";
+		exit EX_FAILURE;
+	    }
 
 	    # change cut's list parameters to substr's parameters
 	    $start--;			   # cut counts from 1, not 0
@@ -92,6 +100,12 @@ if (defined ($opt{b})) {
 elsif (defined ($opt{f})) {
 
     my @list = split (/,/, $opt{f});
+    foreach my $item (@list) {
+	if ($item == 0) {
+	    warn "$me: fields are numbered from 1\n";
+	    exit EX_FAILURE;
+	}
+    }
 
     my $delim = "\t";
     $delim = substr ($opt{d}, 0, 1) if defined $opt{d};
@@ -103,8 +117,10 @@ elsif (defined ($opt{f})) {
 	if (/$delim/) {
 	    foreach my $item (@list) {
 		my ($start,$end) = split (/-/, $item);
-		die "$me: invalid byte list\nType '$me' alone for usage.\n"
-		    if ($start and $end and $start > $end);   # parameters overlap?
+		if ($start and $end and $start > $end) {
+			warn "$me: invalid field list\n";
+			exit EX_FAILURE;
+		}
 
 		# change cut's list parameters to substr's parameters
 		$start--;			   # cut counts from 1, not 0


### PR DESCRIPTION
* cut's -f value can be a comma-separated list of field numbers starting from 1
* The following is valid for selecting x+z: echo 'x:y:z' | perl cut -d ':' -f 1,3
* GNU cut and OpenBSD cut reject 0 as part of a field list so do the same here
* Now -f 0,1 and -f 1,0 will raise an error as expected
* Same treatment for -b 0,1 (bytes also count from 1)
* Style: replace 2 dies with warn+exit