### PR TITLE
ls: retire invalid ioctl()

### DIFF
--- a/bin/ls
+++ b/bin/ls
@@ -41,6 +41,17 @@ my @perms = qw(--- --x -w- -wx r-- r-x rw- rwx);
 my @ftype = qw(. p c ? d ? b ? - ? l ? s ? ? ?);
 $ftype[0] = '';
 
+sub get_columns {
+  eval {
+    require IO::Tty;
+  } or do {
+    return 80;
+  };
+  my @winsize = IO::Tty::get_winsize(*STDIN);
+  shift @winsize; # lines
+  return shift @winsize; # columns
+}
+
 sub format_mode {
   my $mode = shift;
   my %opts = @_;
@@ -81,7 +92,7 @@ my %Options = ();	# option/flag arguments
 my $SixMonths =		# long listing time if < 6 months, else year
  60*60*24*(365/2);
 my $VERSION = '0.70';	# because we're V7-compatible :)
-my $WinCols = 80;	# window columns of output
+my $WinCols;		# window columns of output
 
 # ------ compensate for lack of getpwuid/getgrgid on some platforms
 eval { my $dummy = ""; $dummy = (getpwuid(0))[0] };
@@ -450,6 +461,7 @@ if ($Options{'f'}) {
 	$Options{'a'} = 1;
 }
 
+$WinCols = get_columns();
 $Attributes = stat(STDOUT);
 if ($Attributes->mode & 0140000) {
 	$Options{'1'} = '1';

--- a/bin/ls
+++ b/bin/ls
@@ -81,14 +81,7 @@ my %Options = ();	# option/flag arguments
 my $SixMonths =		# long listing time if < 6 months, else year
  60*60*24*(365/2);
 my $VERSION = '0.70';	# because we're V7-compatible :)
-my $WinSize = "\0" x 8;	# window size buffer
-my $TIOCGWINSZ =	# get window size via ioctl()
- 0x40087468;		# should be require sys/ioctl.pl,
-			# but that won't exist on all platforms
-my $WinCols = 0;	# window columns of output
-my $WinRows = 0;	# window rows of output
-my $Xpixel = 0;		# window start X
-my $Ypixel = 0;		# window start Y
+my $WinCols = 80;	# window columns of output
 
 # ------ compensate for lack of getpwuid/getgrgid on some platforms
 eval { my $dummy = ""; $dummy = (getpwuid(0))[0] };
@@ -457,12 +450,6 @@ if ($Options{'f'}) {
 	$Options{'a'} = 1;
 }
 
-# ------ get (or guess) window size
-if (ioctl(STDOUT, $TIOCGWINSZ, $WinSize)) {
-	($WinRows, $WinCols, $Xpixel, $Ypixel) = unpack('S4', $WinSize);
-} else {
-	$WinCols = 80;
-}
 $Attributes = stat(STDOUT);
 if ($Attributes->mode & 0140000) {
 	$Options{'1'} = '1';


### PR DESCRIPTION
* The ioctl number assumed for TIOCGWINSZ is non-portable and would only work by accident
* The ioctl() call fails on my system because it is invalid
* Perl Cookbook example has the exact hex constant and mentions it is not portable [1]
* It seems better to remove this construct until it can be replaced with something that works

1. https://www.oreilly.com/library/view/perl-cookbook/1565922433/ch04s19.html