### PR TITLE
comm: use strict

### DIFF
--- a/bin/comm
+++ b/bin/comm
@@ -18,10 +18,13 @@ License: public domain
 # 1999 M-J. Dominus (mjd-perl-comm@plover.com)
 # Public domain.
 #
-@COL[1,2,3] = (1,1,1);
+
+use strict;
+
+my @COL = (undef, 1, 1, 1);
 
 if ($ARGV[0] =~ /^-[123]+$/) {
-  $opt = shift;
+  my $opt = shift;
   while ($opt =~ /[123]/g) {
     $COL[$&] = 0;
   }
@@ -36,8 +39,8 @@ open F1, '<', $ARGV[0]
 open F2, '<', $ARGV[1]
   or die "comm: Couldn't open file $ARGV[1]: $!\n";
 
-$r1 = <F1>;
-$r2 = <F2>;
+my $r1 = <F1>;
+my $r2 = <F2>;
 
 while (defined $r1 && defined $r2) {
   if ($r1 eq $r2) {


### PR DESCRIPTION
* Add strict as done in other scripts
* COL[1] is the first element; COL[0] is a placeholder
* For my sample input files, the output is identical compared to previous version
* GNU comm prints a warning if input files are not sorted, but this version doesn't