### PR TITLE
diff: validation for -U and -C

### DIFF
--- a/bin/diff
+++ b/bin/diff
@@ -69,7 +69,7 @@ while ($ARGV[0] =~ /^-/) {
   my $opt = shift;
   last if $opt eq '--';
   if ($opt =~ /^-C(.*)/) {
-    $Context_Lines = $1 || shift;
+    $Context_Lines = checklen($1 || shift);
     $opt_c = 1;
     $Diff_Type = "CONTEXT";
   } elsif ($opt =~ /^-c$/) {
@@ -83,7 +83,7 @@ while ($ARGV[0] =~ /^-/) {
     $opt_f = 1;
     $Diff_Type = "REVERSE_ED";
   } elsif ($opt =~ /^-U(.*)$/) {
-    $Context_Lines = $1 || shift;
+    $Context_Lines = checklen($1 || shift);
     $opt_u = 1;
     $Diff_Type = "UNIFIED";
   } elsif ($opt =~ /^-u$/) {
@@ -191,6 +191,12 @@ sub bag {
   my $msg = shift;
   warn "$Program: $msg\n";
   exit 2;
+}
+
+sub checklen {
+  my $n = shift;
+  return int($n) if ($n =~ m/\A[0-9]+\Z/);
+  bag("Invalid context length '$n'\n$usage");
 }
 
 ########


### PR DESCRIPTION
* The -U option accepts the number -1 but perl dies

perl diff -U -1  A B 
--- A	Sat Oct 28 11:49:12 2023
+++ B	Sat Oct 28 11:49:24 2023
@@ -3104,-1 +3104,-1 @@
Modification of non-creatable array value attempted, subscript -1 at diff line 383.

* For -U 0, output matches GNU diff on my Linux system  (OpenBSD diff also accepts -U 0)
* "-U hello" is interpreted as -U 0 but this should be an error
* Looking at the option parser, -C and -U have the same problem
* Standards document doesn't mention -U, but has wording about -C value being a positive integer[1]
* Follow OpenBSD diff and allow -U 0, but raise error for negative values (same treatment for -C)

1. https://pubs.opengroup.org/onlinepubs/009604499/utilities/diff.html