### PR TITLE
patch: patchfile can be read from stdin

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -1105,7 +1105,11 @@ package
 sub TIEHANDLE {
     my ($class, $file) = @_;
     local *FH;
-    open *FH, '<', $file or return;
+    if ($file eq '-') {
+        *FH = *STDIN;
+    } else {
+        open *FH, '<', $file or return;
+    }
     bless [*FH], $class;
 }
 


### PR DESCRIPTION
* Do what is advertised in POD text
* The following are valid for patching file A from the diff read from stdin...
cat my.diff | perl patch A -
cat my.diff | perl patch A

* For both cases Pushback::TIEHANDLE() was passed a '-' parameter