### PR TITLE
uuencode: make stdin work again

### DIFF
--- a/bin/uuencode
+++ b/bin/uuencode
@@ -68,27 +68,26 @@ die "XXX: Not reached";
 sub encode($$) {
     my($source, $destination) = @_;
     my $mode;
+    my $input;
 
-    if ($source eq '-' && -t STDIN) {
+    if ($source eq '-') {
 	warn "$0: WARNING: reading from standard input\n";
-    }
-
-    if ($source ne '-') {
+	$input = *STDIN;
+	$mode = 0644;
+    } else {
+	open($input, '<', $source) || die "can't open $source: $!";
 	$mode = (stat($source))[2] & 0666;
     }
+    binmode $input; # winsop
 
-    printf "begin %03o $destination\n", $mode || 0644;
-
-    local *INPUT;
-    open(INPUT, '<', $source) 	|| die "can't open $source: $!";
-    binmode(INPUT);   # winsop
+    printf "begin %03o $destination\n", $mode;
 
     my $block;
-    print pack ("u", $block) while read (INPUT, $block, 45);
+    print pack ("u", $block) while read ($input, $block, 45);
     print "`\n";
     print "end\n";
 
-    close(INPUT)		|| die "can't close $source: $!";
+    close($input) || die "can't close $source: $!";
 }
 
 =encoding utf8


### PR DESCRIPTION
* This uuencode always writes to stdout
* When run with only 1 file argument, read stdin and write to stdout, copying file name into output header
* Reading stdin is broken because we attempt to open literal '-'
* We can't stat() stdin so the output header gets the default permission of 644
* It would be good to add some POD later to explain the usage

perl uuencode B
uuencode: WARNING: reading from standard input
begin 644 B
can't open -: No such file or directory at uuencode line 83.