### PR TITLE
mail: forbid directory for -f FILE

### DIFF
--- a/bin/mail
+++ b/bin/mail
@@ -390,8 +390,17 @@ sub load {
 
 	print "Loading the mailfile ", $self->file, "\n";
 	my $start=1;
-	if (! defined $self->file) { die "No mailbox specified in class\n"; }
-	open(MBOX, '<', $self->file) || return;
+	unless (defined $self->file) {
+		die "No mailbox specified\n";
+	}
+	if (-d $self->file) {
+		warn $self->file . ": is a directory\n";
+		return;
+	}
+	unless (open MBOX, '<', $self->file) {
+		warn $self->file . ": cannot open: $!\n";
+		return;
+	}
 	$self->size(-s $self->file);
 	my @MESS=();
 	while(<MBOX>) {
@@ -1033,7 +1042,7 @@ USAGE
 if (@ARGV) {   # Assume batch-mode
 	Batch(@ARGV);
 } else {
-	if ($opt_f) {
+	if (defined $opt_f) {
 		Interactive($opt_f);
 	} else {
 		if (exists $ENV{MAIL}) {


### PR DESCRIPTION
* The default mbox file is $HOME/mbox but -f can set a different file
* A directory is no a valid mbox file so raise an error when first loading a mailbox, not when saving it (below)
* Defer to mailbox::load() for directory check, so we can catch same error for $ENV{MAIL} passed to Interactive()
* Print error description $! as a hint to the user if open() fails for the mbox
* While here, fix truth check which prevented the file '0' from being loaded (default mbox used instead)

```
perl mail -f .
Loading the mailfile .
Mail [0.02 Perl] [linux]
Invalid message number: 1
> q
Failed to write to .: Is a directory
```