### PR TITLE
mail: raise error for message id 0

### DIFF
--- a/bin/mail
+++ b/bin/mail
@@ -947,11 +947,10 @@ sub parseargs {
 sub parse_msg_list {
 	my($list, $current)=@_;
 
+	$list =~ s/^\s+//g;
+	$list =~ s/\s$//g;
+	return [ $current ] if (length($list) == 0);
 
-	$list=~s/^\s+//g;  $list=~s/\s$//g;
-	if (! $list) {
-		return([ $current ]);
-	}
 	# Get ugly.
 	my @list=();
 	foreach my $stuff (split(/[, ]+/, $list)) {


### PR DESCRIPTION
* Entering a message range including zero is correctly treated as an error (Ma==mail)

Me: perl mail
Me: 0-0
Ma: Invalid message specification, 0 (Should Not Happen) at mail line 478, <STDIN> line 1.

* Entering a message ID of zero directly does not raise an error

Me: 0
Ma: Message: 1
Ma:
Ma: Status: RO
Ma: 
Ma: Status: RO

* Message ID zero is invalid so we should raise an error here (OpenBSD mail raises an error for this)
* Why does 0 get translated magically to 1?
* Debugging shows messagex() is called with num=0 for input "0-0", and num=1 for input "0"
* parseargs() return $cmd="p 0" and arg1 list with only element of 1 (so parseargs is at fault)
* parse_msg_list() gets param of list=" 0" and strips spaces, then takes early return (current id was 1, explaining why 0 becomes 1)
* The early return is intended for a blank line, to select the current message id
* Changing truth check to length check allows code to progress into the loop; this catches the error for "0" as expected