### PR TITLE
fortune: simplify -w flag

### DIFF
--- a/bin/fortune
+++ b/bin/fortune
@@ -672,15 +672,11 @@ sub print_fortune
 {
 	my ($file, $index) = @_;
 
-	my $wait = 0;
-
+	print read_fortune($file, $index);
 	if ($opts{w}) {
 		my $tmp = fortune_length( $file, $index );
-		$wait = int ($tmp/75);
+		sleep(int($tmp/75));
 	}
-
-	print read_fortune( $file, $index );
-	sleep $wait;
 }
 
 # fortune_length


### PR DESCRIPTION
* Calling sleep() is needed only for -w, so this makes the intent easier to follow