### PR TITLE
touch: support directories

### DIFF
--- a/bin/touch
+++ b/bin/touch
@@ -71,7 +71,7 @@ else {
 foreach my $file (@ARGV) {
 
     # Check if the file exists. If not, create it.
-    unless (-f $file) {
+    unless (-e $file) {
         next if $no_create;
         local *FILE;
         require Fcntl;  # Import


### PR DESCRIPTION
* When file argument exists and is a directory, touch incorrectly decides it needs to call sysopen() to create a file
```
%mkdir dir1 
%perl touch dir1 
touch: dir1: Is a directory
```
* The problem appears to be the -f operator matching regular files and not directories
* Exists operator -e seems more correct; patched version updates timestamp on directory as expected...
```
%ls -ld old
drwxr-xr-x 2 hi hi 4096 Oct 19 22:18 old
%perl touch old
%ls -ld old
drwxr-xr-x 2 hi hi 4096 Nov 15 22:32 old
```