### PR TITLE
date: document %q feature

### DIFF
--- a/bin/date
+++ b/bin/date
@@ -46,14 +46,7 @@ sub munge_tz {
 
 sub posix_tz { POSIX::strftime( '%Z', core_time() ) }
 
-sub quarter {
-    my $mon = ( core_time() )[4] + 1;
-
-       if( $mon <= 3 ) { 1 }
-    elsif( $mon <= 6 ) { 2 }
-    elsif( $mon <= 9 ) { 3 }
-    else               { 4 }
-    }
+sub quarter { int((core_time())[4] / 3) + 1 }
 
 sub run {
 	my $args = shift;
@@ -299,6 +292,8 @@ Show the version and exit
 =item * %p  - AM or PM
 
 =item * %P  - like %p, but lowercase
+
+=item * %q  - quarter of the year (1-4)
 
 =item * %r  - Time in HH(12 hour):MM:SS (AM|PM) format
 


### PR DESCRIPTION
* This version of date supports the non-standard %q specifier which is also supported by GNU date
* OpenBSD date supports a number of POSIX-extension specifiers, but does not have %q
* The value of %q is [1-4]
* Include %q in the POD (it was not mentioned)
* quarter() can be written with no conditions by dividing 12 by 3