### PR TITLE
expand: don't suppress backspace

### DIFF
--- a/bin/expand
+++ b/bin/expand
@@ -78,12 +78,10 @@ sub do_expand(@)
 	my $curs = 0;
 	for my $c (split //, $line)  {
 
-	    if($c eq "\010") {  # backspace
-		$curs -= 2;
-		$curs = -1 unless $curs >= 0;
-	    }
-
-	    if($c eq "\t") {
+	    if($c eq "\b") {  # backspace
+		print "\b";
+		$curs-- if $curs;
+	    } elsif($c eq "\t") {
 		if(scalar @tabstops > 0) {
 		    if(defined($line_desc{$curs}) ){
 			$incr = $line_desc{$curs};


### PR DESCRIPTION
* The standards document for expand says a backspace character on input is copied to output and the index is decremented[1]
* GNU, OpenBSD and NetBSD versions follow this behaviour
* Perl expand doesn't copy backspace to output, and the index is decremented twice
* Perl unexpand copies backspace to output and decrements the index (we want to follow this)

1. https://pubs.opengroup.org/onlinepubs/007904975/utilities/expand.html