### PR TITLE
ed: r command addresses

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -299,7 +299,7 @@ sub maxline {
 
 sub edPrompt {
     if (defined $adrs[0]) {
-        edWarn('Too many addressses');
+        edWarn('Too many addresses');
         return;
     }
     if (defined $args[0]) {
@@ -317,7 +317,7 @@ sub edHelp {
     my $toggle = shift;
 
     if (defined $adrs[0]) {
-        edWarn('Too many addressses');
+        edWarn('Too many addresses');
         return;
     }
     if (defined $args[0]) {
@@ -622,18 +622,11 @@ sub edWrite {
     }
     $RememberedFilename = $filename;
 
-    if ($AppendMode) {
-        unless (open $fh, '>>', $filename) {
-            warn "$filename: $!\n";
-            edWarn('cannot open output file');
-            return;
-        }
-    } else {
-        unless (open $fh, '>', $filename) {
-            warn "$filename: $!\n";
-            edWarn('cannot open output file');
-            return;
-        }
+    my $mode = $AppendMode ? '>>' : '>';
+    unless (open $fh, $mode, $filename) {
+        warn "$filename: $!\n";
+        edWarn('cannot open output file');
+        return;
     }
 
     for my $line (@lines[$adrs[0]..$adrs[1]]) {
@@ -667,14 +660,12 @@ sub edEdit {
     my(@tmp_lines,@tmp_lines2,$tmp_chars,$chars);
 
     if ($InsertMode) {
+        if (defined $adrs[1]) {
+            $adrs[0] = $adrs[1];
+        }
         if (!defined($adrs[0])) {
             $adrs[0] = maxline();
         }
-        if (defined($args[1])) {
-            edWarn('Too many addressses');
-            return;
-        }
-
     } else {
         if (defined($adrs[0]) or defined($adrs[1])) {
             edWarn("too many addresses for command: $#adrs (@adrs)");
@@ -868,7 +859,7 @@ sub edQuit {
     my($QuestionMode) = @_;
 
     if (defined $adrs[0]) {
-        edWarn('Too many addressses');
+        edWarn('Too many addresses');
         return;
     }
     if (defined($args[0])) {


### PR DESCRIPTION
* edEdit() handles the commands 'e', 'E' and 'r' ($InsertMode indicates 'r')
* "E filename" and "e filename" replace the entire buffer with the file; specifying an address is invalid
* "r" pastes a file into the current buffer; "r" can optionally have one or two addresses
* Two-address "r" just uses the 2nd address, i.e. "1,2r file" is the same as "2r file" (paste file after line 2)
* The old code that checked $args[1] wasn't correct
* tidy1: edWrite(): make file mode a parameter to open()
* tidy2: the same error message typo appeared a few times