### PR TITLE
pr: accept -- as end of options

### DIFF
--- a/bin/pr
+++ b/bin/pr
@@ -70,6 +70,7 @@ my(@FINFO, @COLINFO);
 OPTION:
 while (@ARGV && $ARGV[0] =~ /^-(.+)/ && (shift, ($_ = $1), 1)) {
     next OPTION unless length;
+    last if ($_ eq '-');
 
     # Lousy options
     if (s/^[ei]//) {
@@ -148,7 +149,6 @@ if (! $column_sep) {
 #
 # Initialize file and column structures
 #
-my @files;
 my $pageno=$startpageno;
 
 foreach(1..$columns) {
@@ -349,6 +349,8 @@ sub printpage {
 	@COLINFO=();
 	foreach(1..$columns) { push(@COLINFO, &create_col); }
 }
+
+__END__
 
 =pod
 


### PR DESCRIPTION
* GNU pr and OpenBSD pr use getopt(), so I can write "pr -- -a" to input a file called "-a"
* This version treats -- as an invalid option, and prints usage
* Add -- to option parser for better compatibility; possibly in future it can switch over to regular getopt
* Remove unused variable @files; found by perlcritic