### PR TITLE
tar: raise error for directory argument to -f

### DIFF
--- a/bin/tar
+++ b/bin/tar
@@ -204,6 +204,7 @@ else
 
   if ($opt{'f'})
    {
+    die("Cannot open '$opt{'f'}': is a directory\n") if (-d $opt{'f'});
     open(STDIN, '<', $opt{'f'}) || die "Cannot open $opt{'f'}:$!";
    }
   binmode(STDIN);


### PR DESCRIPTION
* Adding die() for directory argument ensures tar doesn't exit with a success code
* Test command: perl tar -tf .
* Found when testing against GNU tar