### PR TITLE
chgrp: '--' option terminator

### DIFF
--- a/bin/chgrp
+++ b/bin/chgrp
@@ -37,7 +37,7 @@ my %options;
 while (@ARGV && $ARGV [0] =~ /^-/) {
     my $opt = reverse shift;
     chop $opt;
-    if ($opt eq '-') {shift; last;}
+    last if ($opt eq '-');
     usage() unless $opt =~ /^[RHLP]+$/;
     local $_;
     while (length ($_ = chop $opt)) {


### PR DESCRIPTION
* chgrp does not use getopt() but it had code to handle the special argument '--' which indicates the end of options
* The handling of '--' was incorrect because ARGV list is already shfted into $opt, but the non-option argument after '--' was shifted too
* With this patch I can do: perl chgrp -- user0 dir1/
* Found this when testing against GNU chgrp
* Later, switching chgrp to getopt() could be investigated