### PR TITLE
ed: newline append versus 'r' command

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -707,7 +707,7 @@ sub edEdit {
     }
     if (substr($tmp_lines[-1], -1, 1) ne "\n") {
         $tmp_lines[-1] .= "\n";
-        $chars++;
+        $tmp_chars++;
         print "Newline appended\n";
     }
 

--- a/bin/ed
+++ b/bin/ed
@@ -657,7 +657,7 @@ sub edWrite {
 
 sub edEdit {
     my($QuestionsMode,$InsertMode) = @_;
-    my(@tmp_lines,@tmp_lines2,$tmp_chars,$chars);
+    my(@tmp_lines, @tmp_lines2, $tmp_chars, $chars, $fh);
 
     if ($InsertMode) {
         if (defined $adrs[1]) {
@@ -681,14 +681,12 @@ sub edEdit {
         return 1;
     }
 
-    # suck the file into a temp array
-
     if (-d $filename) {
         warn "$filename: is a directory\n";
         edWarn('cannot read input file');
         return 0;
     }
-    unless (open(SOURCE, '<', $filename)) {
+    unless (open $fh, '<', $filename) {
         warn "$filename: $!\n";
         edWarn('cannot open input file');
         return 0;
@@ -698,12 +696,20 @@ sub edEdit {
     $tmp_chars = 0;
     $chars = 0;
 
-    while (<SOURCE>) {
-        push(@tmp_lines,$_);
+    while (<$fh>) {
+        push @tmp_lines, $_;
         $tmp_chars += length;
     }
-
-    close(SOURCE);
+    unless (close $fh) {
+        warn "$filename: $!\n";
+        edWarn('cannot close input file');
+        return 0;
+    }
+    if (substr($tmp_lines[-1], -1, 1) ne "\n") {
+        $tmp_lines[-1] .= "\n";
+        $chars++;
+        print "Newline appended\n";
+    }
 
     # now that we've got it, figure out what to do with it
 
@@ -744,12 +750,6 @@ sub edEdit {
         $NeedToSave = 0;
         $UserHasBeenWarned = 0;
         $CurrentLineNum = maxline();
-    }
-
-    if ($lines[maxline()] !~ /\n$/) {
-        $lines[maxline()] .= "\n";
-        $chars++;
-        print "Newline appended\n";
     }
 
     print "$chars\n" unless ($SupressCounts);


### PR DESCRIPTION
* ed requires that all lines in its buffer are terminated with "\n"
* ed attempts to append a "\n" if it is missing on the last line of input
* The existing append logic in edEdit() was observed to only work for 'E' and 'e' commands, but not 'r'
* With E/e the entire buffer is destroyed and replaced with the content from the new file
* The append logic would then check the final line in buffer *after* the buffer was replaced (this worked ok)
* The 'r' command inserts the file content to any position within the existing buffer (e.g. 0r to insert to beginning of buffer)
* Checking for missing newline at end of buffer doesn't work if the data is inserted at a different location in buffer
* More general fix: check final line of tmp_lines list before it is applied to the buffer
* To test, construct a file 'in' with a missing newline at end, then read it into the beginning of buffer (initiated from file 'in2')
```
%hd in
00000000  68 65 6c 6c 6f 0a 67 6f  6f 64 62 79 65           |hello.goodbye|
0000000d
%perl ed in2
4595
P
*1,5n
1	#!/usr/bin/perl
2	
3	=begin metadata
4	
5	Name: awk
*0r in
Newline appended
13
*1,5n
1	hello
2	goodbye
3	#!/usr/bin/perl
4	
5	=begin metadata
*Q
```