### PR TITLE
chmod & chown: -- option terminator

### DIFF
--- a/bin/chmod
+++ b/bin/chmod
@@ -46,7 +46,7 @@ my %options;
 while (@ARGV && $ARGV [0] =~ /^-/) {
     my $opt = reverse shift;
     chop $opt;
-    if ($opt eq '-') {shift; last;}
+    last if ($opt eq '-');
     die "Usage" unless $opt =~ /^[RHLP]+$/;
     local $_;
     while (length ($_ = chop $opt)) {

--- a/bin/chown
+++ b/bin/chown
@@ -46,7 +46,7 @@ my %options;
 while (@ARGV && $ARGV [0] =~ /^-/) {
     my $opt = reverse shift;
     chop $opt;
-    if ($opt eq '-') {shift; last;}
+    last if ($opt eq '-');
     die "Usage" unless $opt =~ /^[RHLP]+$/;
     local $_;
     while (length ($_ = chop $opt)) {


### PR DESCRIPTION
* When fixing this previously for chgrp command I failed to notice the same pattern in chmod/chown
* Test1: perl chmod -- 755 new.txt.exe
* Test2: perl chown -- root:root new.txt.exe # run as root