### PR TITLE
fix exit status

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -82,7 +82,7 @@ else {
     install_files();
 }
 
-exit $Errors == 0 ? 0 : 1;
+exit($Errors == 0 ? 0 : 1);
 
 sub modify_file {
     my($path,$mode,$st) = @_;

--- a/bin/patch
+++ b/bin/patch
@@ -247,7 +247,7 @@ if (ref $patch eq 'Patch') {
 }
 
 $patch->note("done\n");
-exit $patch->error ? 1 : 0;
+exit($patch->error ? 1 : 0);
 
 END {
     close STDOUT || die "$0: can't close stdout: $!\n";


### PR DESCRIPTION
`exit` has higher precedence than `?:` and `==`, so `exit $Errors == 0 ? 0 : 1` parses as `(exit $Errors) == 0 ? 0 : 1`, which is not what was intended.