### PR TITLE
pr: incorrect looping with -l

### DIFF
--- a/bin/pr
+++ b/bin/pr
@@ -231,6 +231,10 @@ sub create_col  {
 	my($col)=@_;
 
 	my $pagelen=$length-($trailerlength*2);
+	if ($pagelen <= 0) {
+		$trailer = 0;
+		$pagelen = 1;
+	}
 	if($doublespace) {
 		$pagelen=($pagelen%2 == 0)?$pagelen/2:int($pagelen/2)+1;
 	}
@@ -337,7 +341,7 @@ sub printpage {
 			print $numbering;
 			print $numberchar if ($number);
 
-			if (!$column_sep) {
+			if (!$column_sep && $trailer) {
 				$pfmt="%-${colwidth}s";
 				printf("$pfmt", $$column{text}[$line-1]{text});
 			} else {


### PR DESCRIPTION
* pr enters a strange loop for certain -l values...
```
%perl pr -l 10 ed
...
Sat Nov 25 08:56:55 2023  Page 526462
...
Sat Nov 25 08:56:55 2023  Page 526463
...
Sat Nov 25 08:56:55 2023  Page 526464
...
Sat Nov 25 08:56:55 2023  Page 526465
...
Sat Nov 25 08:56:55 2023  Page 526466
...
Sat Nov 25 08:56:55 2023  Page 526467
^C
```
* In create_col(), $pagelength is set to zero for -l 10 because $trailerlength constant is 5
* After studying GNU pr manual, if -l value is 10 or less we assume -t and don't do any formatting of output
* When investigating this I discovered printf() should not occur for "perl pr -t file" (GNU pr copies input to output)