### PR TITLE
pr: support stdin

### DIFF
--- a/bin/pr
+++ b/bin/pr
@@ -154,18 +154,26 @@ my $pageno=$startpageno;
 foreach(1..$columns) {
 	push(@COLINFO, &create_col);
 }
-foreach(@ARGV) {
-	if (-d $_) {
-		warn "$Program: '$_' is a directory\n";
-		exit EX_FAILURE;
+if (scalar(@ARGV) == 0) {
+	@ARGV = ('-');
+}
+foreach my $file (@ARGV) {
+	my $fh;
+	if ($file eq '-') {
+		$fh = *STDIN;
+	} else {
+		if (-d $file) {
+			warn "$Program: '$file' is a directory\n";
+			exit EX_FAILURE;
+		}
+		$fh = FileHandle->new($file, 'r');
+		if (! $fh) {
+			next if ($quietskip);
+			warn "$Program: Can't open '$file': $!\n";
+			exit EX_FAILURE;
+		}
 	}
-	my $fh= FileHandle->new("$_", "r");
-	if (! $fh) {
-		next if ($quietskip);
-		warn "$Program: Can't open '$_': $!\n";
-		exit EX_FAILURE;
-	}
-	push(@FINFO, {  name  => $_,
+	push(@FINFO, {  name  => $file,
 			handle=> $fh,
 			lineno=> 0,
 			});


### PR DESCRIPTION
* Standards document for pr mentions no arguments and '-' argument means we read from stdin[1]
* GNU pr and OpenBSD pr follow this
* A filename is not printed in page header for stdin

1. https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pr.html