### PR TITLE
pr: validate -o COUNT

### DIFF
--- a/bin/pr
+++ b/bin/pr
@@ -109,7 +109,7 @@ while (@ARGV && $ARGV[0] =~ /^-(.+)/ && (shift, ($_ = $1), 1)) {
 
     if (s/^o//) {
 	warn "-o option already used" if $offsetspaces;
-	$offsetspaces=shift;
+	$offsetspaces = checknum(shift);
 	redo OPTION;
     }
 
@@ -232,9 +232,15 @@ USAGE
 	exit EX_FAILURE;
 }
 
-#
-# FUNCTIONS
-#
+sub checknum {
+	my $n = shift;
+	if (length($n) == 0 || $n !~ m/\A[0-9]+\Z/) {
+		warn "$Program: invalid number: '$n'\n";
+		exit EX_FAILURE;
+	}
+	return int($n);
+}
+
 sub create_col  {
 	my($col)=@_;
 


### PR DESCRIPTION
* Raise an error if count doesn't look like a number, instead of silently accepting it
* Support for a + number prefix could be added if you like (GNU pr accepts it)
* Count of zero is accepted as before; this means no offset