### PR TITLE
bc: bignum versus e notation

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2180,7 +2180,9 @@ sub yylex
 	      $type = $FLOAT;
 	  }
 	  if ($line =~ s/^[eE]([-+]*\d+)//) {
-	      $yylval *= 10 ** $1;
+	      my $mult = $bignum ? Math::BigFloat->new('10') : 10;
+	      $mult = $mult ** $1;
+	      $yylval *= $mult;
 	      $type = $FLOAT;
 	  }
 


### PR DESCRIPTION
* When running in bignum mode, bc was truncating the exponent of 10, resulting in a value of infinity
* Be careful to declare the value to be multiplied with prefix number also as bigfloat before doing the ** operation ($yylval already is)
* Now I can type things like 7e10000 and get the result I expect