### PR TITLE
ls: too many totals

### DIFF
--- a/bin/ls
+++ b/bin/ls
@@ -308,6 +308,7 @@ UNDEFSTAT
 sub List {
 	my $Name = shift;	# directory name
 	my $Options = shift;	# options/flags hashref
+	my $is_dir = shift;
 	my $Expand = shift;	# do 1 level of dir expansion,
 				# for "ls DIRNAME"
 	my $Attributes = "";	# entry attributes hashref
@@ -344,12 +345,12 @@ sub List {
 
 	# ------ print directory name if -R
 	if (exists($Options->{'R'})) {
-		print "$Name:\n";
+		print "$Name:\n" if $is_dir;
 	}
 
 	# ----- print total in blocks if -s or -l
 	if (exists($Options->{'l'}) || exists($Options->{'s'})) {
-		print "total $TotalBlocks\n";
+		print "total $TotalBlocks\n" if $is_dir;
 	}
 
 	# ------ sort entry list
@@ -402,7 +403,7 @@ sub List {
 			 $Attributes->{$Entry}->mode & 0040000) {
 				$Path = File::Spec->canonpath(File::Spec->catdir($Name,$Entry));
 				@Dirs = DirEntries(\%Options, $Path);
-				List($Path, \%Options, 0, @Dirs);
+				List($Path, \%Options, 1, 0, @Dirs);
 			}
 		}
 	}
@@ -498,7 +499,7 @@ if ($Attributes->mode & 0140000) {
 
 # ------ current directory if no arguments
 if ($#ARGV < 0) {
-	List('.', \%Options, 0, DirEntries(\%Options, "."));
+	List('.', \%Options, 1, 0, DirEntries(\%Options, "."));
 
 # ------ named files/directories if arguments
 } else {
@@ -517,7 +518,7 @@ if ($#ARGV < 0) {
 	}
 	for my $Arg (Order(\%Options, \%Attributes, @Files)) {
 		$First = 0;
-		List($Arg, \%Options, 0,
+		List($Arg, \%Options, 0, 0,
 		 DirEntries(\%Options, $Arg));
 	}
 	for my $Arg (@Dirs) {
@@ -529,7 +530,7 @@ if ($#ARGV < 0) {
 			$First = 0;
 			print "$Arg:\n" if ($ArgCount > 0);
 		}
-		List($Arg, \%Options, 0,
+		List($Arg, \%Options, 1, 0,
 		 DirEntries(\%Options, $Arg));
 	}
 }


### PR DESCRIPTION
* File arguments are split into two lists: Dirs and Files
* Two separate loops call List(), first for Files list then for Dirs
* "perl ls -lR a a/a" was printing a "total" line twice, once (correctly) for dir "a" then (incorrectly) for regular file "a/a"
* Directory name line "a/a:" was also being printed for argument "a/a" but it is not a directory (see below output)
* Fix this by passing a new param to List() to tell it whether the entry being listed is a directory
```
%perl ls -lR a a/a # old output
a/a:
total 176
-rwxr-xr-x   1 pi       pi           88214 Nov 21 10:20 a/a

a:
total 224
-rwxr-xr-x   1 pi       pi           88214 Nov 21 10:20 a
drwxr-xr-x   2 pi       pi            4096 Dec  1 19:32 b
-rw-r--r--   1 pi       pi           20480 Nov 20 04:02 new.tar

a/b:
total 8
-rw-r--r--   1 pi       pi               3 Dec  1 19:32 new
```