### PR TITLE
base64: check close() return value

### DIFF
--- a/bin/base64
+++ b/bin/base64
@@ -61,8 +61,14 @@ if (defined $ARGV[0] && $ARGV[0] ne '-') {
 }
 
 $opt{'d'} ? decode() : encode();
-close $in;
-close $out;
+unless (close $in) {
+    warn "$Program: failed to close input: $!\n";
+    exit EX_FAILURE;
+}
+unless (close $out) {
+    warn "$Program: failed to close output: $!\n";
+    exit EX_FAILURE;
+}
 exit EX_SUCCESS;
 
 sub decode {


### PR DESCRIPTION
* Print error message to show user something went wrong
* Exit code will be non-zero, indicating error to scripts