### PR TITLE
pig: NetBSD compat

### DIFF
--- a/bin/pig
+++ b/bin/pig
@@ -14,28 +14,26 @@ License: perl
 
 # pig - eformatray inputway asway Igpay Atinlay
 use strict;
+
+use File::Basename qw(basename);
+use Getopt::Std qw(getopts);
+
+use constant EX_SUCCESS => 0;
+use constant EX_FAILURE => 1;
+
 $|++;
 
 my $VERSION = '1.0';
+my $Program = basename($0);
 
-END {
-  close STDOUT || die "$0: can't close stdout: $!\n";
-  $? = 1 if $? == 255;  # from die
+sub version {
+  warn "$Program (Erlpay Owerpay Oolstay) $VERSION\n";
+  exit EX_SUCCESS;
 }
 
 sub help {
-  print "$0\n";
-  exit 0;
-}
-
-sub version { print "$0 (Erlpay Owerpay Oolstay) $VERSION\n"; exit 0; }
-
-# options
-while (@ARGV && $ARGV[0] =~ /^[-+]/) {
-  local $_ = shift;
-  /^-[h?]$/    && help();        # terminates
-  /^-v$/       && version();     # terminates
-  die "$0: invalid option -- $_\n";
+  warn "usage: $Program [-v]\n";
+  exit EX_FAILURE;
 }
 
 # Dr. Bronner's top secret pig-latin algorithm!
@@ -51,18 +49,25 @@ sub igpay {
   else {
     /([^aieou]+)(.*)/i;
     $ordway = ($2 || '') . lcfirst $1 . 'ay';
-    $ordway = ucfirst $ordway if $initcaps;
-    $ordway = uc $ordway      if $allcaps;
+    if ($allcaps) {
+       $ordway = uc $ordway;
+    } elsif ($initcaps) {
+       $ordway = ucfirst $ordway;
+    }
   }
   return $ordway;
 }
+
+my %opt;
+getopts('v', \%opt) or help();
+version() if $opt{'v'};
+@ARGV = (); # stdin only
 
 while (<>) {
   s/([A-Z]+)/igpay($1)/gexi;
   print;
 }
-
-exit 0;
+exit EX_SUCCESS;
 
 __END__
 


### PR DESCRIPTION
* Changes are based on testing the NetBSD version of pig
* Print a usage string for bad arguments
* Ignore command arguments instead of implicitly treating them as file arguments
* Remove -h option
* Teach Dr. Bronner a new trick, that uc() can be applied without ucfirst() if $allcaps and $initcaps are both true

%perl pig asd # previously...
Can't open asd: No such file or directory at pig line 62.