### PR TITLE
diff: output_ed_diff() tweak

### DIFF
--- a/bin/diff
+++ b/bin/diff
@@ -490,9 +490,7 @@ sub output_ed_diff {
 
     if ($block->insert) {
 	my @outlist = @$fileref2[$hunk->{"start2"}..$hunk->{"end2"}];
-	map {s/$/\n/} @outlist; # add \n's
-	print @outlist;
-	print ".\n"; # end of ed 'c' or 'a' command
+	print join("\n", @outlist), "\n.\n"; # '.' signifies end of 'c' or 'a'
     }
 }
 


### PR DESCRIPTION
* Avoid doing s/// in a loop to add trailing newline to each element of outlist
* I checked that output is not changed for -e and -f options