### PR TITLE
which: expect an argument

### DIFF
--- a/bin/which
+++ b/bin/which
@@ -22,12 +22,15 @@ use constant EX_FAILURE => 1;
 my $Program = basename($0);
 my ($VERSION) = '1.3';
 
-my %opt;
-unless (getopts('a', \%opt)) {
+sub usage {
     warn "$Program version $VERSION\n";
     warn "usage: $Program [-a] filename ...\n";
     exit EX_FAILURE;
 }
+
+my %opt;
+getopts('a', \%opt) or usage();
+@ARGV or usage();
 
 my @PATH = ();
 my $PATHVAR = 'PATH';


### PR DESCRIPTION
* Running "which" without an argument is an error (minimum of one argument is required)
* On my linux system, exit code is 1 and no output is printed
* On OpenBSD a usage string is printed; follow this