### PR TITLE
chown: show filename in error message

### DIFF
--- a/bin/chown
+++ b/bin/chown
@@ -14,31 +14,21 @@ License: perl
 
 use strict;
 
+use File::Basename qw(basename);
+
+use constant EX_SUCCESS => 0;
+use constant EX_FAILURE => 1;
+
+my $Program = basename($0);
 my ($VERSION) = '1.2';
 
-my $warnings = 0;
+my $rc = EX_SUCCESS;
 
-# Print a usuage message on a unknown option.
-# Requires my patch to Getopt::Std of 25 Feb 1999.
-$SIG {__WARN__} = sub {
-    if (substr ($_ [0], 0, 14) eq "Unknown option") {die "Usage"};
-    require File::Basename;
-    $0 = File::Basename::basename ($0);
-    $warnings = 1;
-    warn "$0: @_";
-};
-
-$SIG {__DIE__} = sub {
-    require File::Basename;
-    $0 = File::Basename::basename ($0);
-    if (substr ($_ [0], 0,  5) eq "Usage") {
-        die <<EOF;
-$0 (Perl bin utils) $VERSION
-$0 [-R [-H | -L | -P]] user[:group] file [files ...]
-EOF
-    }
-    die "$0: @_";
-};
+sub usage {
+    warn "$Program (Perl bin utils) $VERSION\n";
+    warn "usage: $Program [-R [-H | -L | -P]] user[:group] file [files ...]\n";
+    exit EX_FAILURE;
+}
 
 # Get the options.
 # We can't use Getopts, as the order is important.
@@ -47,34 +37,38 @@ while (@ARGV && $ARGV [0] =~ /^-/) {
     my $opt = reverse shift;
     chop $opt;
     last if ($opt eq '-');
-    die "Usage" unless $opt =~ /^[RHLP]+$/;
+    usage() unless $opt =~ /^[RHLP]+$/;
     local $_;
     while (length ($_ = chop $opt)) {
         /R/ && do {$options {R} = 1; next};
-        die "Usage" unless $options {R};
+        usage() unless $options{R};
         /H/ && do {$options {L} = $options {P} = 0; $options {H} = 1; next};
         /L/ && do {$options {H} = $options {P} = 0; $options {L} = 1; next};
         /P/ && do {$options {H} = $options {L} = 0; $options {P} = 1; next};
     }
 }
 
-die "Usage" unless @ARGV > 1;
-
 my $mode = shift;
+usage() unless @ARGV;
 
 my ($owner, $group) = split /:/ => $mode, 2;
 
-defined (my $uid = getpwnam $owner) or die "$owner is an invalid user\n";
+my $uid = getpwnam $owner;
+unless (defined $uid) {
+    warn "$Program: invalid user: '$owner'\n";
+    exit EX_FAILURE;
+}
 my $gid;
-
 if (defined $group) {
-    defined ($gid = getgrnam $group) or die "$group is an invalid group\n";
+    $gid = getgrnam $group;
+    unless (defined $gid) {
+        warn "$Program: invalid group: '$group'\n";
+        exit EX_FAILURE;
+    }
 }
 
 my %ARGV;
 %ARGV = map {$_ => 1} @ARGV if $options {H};
-
-sub modify_file;
 
 if (exists $options {R}) {
     # Recursion.
@@ -83,9 +77,10 @@ if (exists $options {R}) {
 }
 else {
     foreach my $file (@ARGV) {
-        modify_file $file;
+        modify_file($file);
     }
 }
+exit $rc;
 
 # File::Find is weird. If called with a directory, it will call
 # the sub with "." as file name, while having chdir()ed to the
@@ -107,20 +102,18 @@ sub modify_file {
         File::Find::find (\&modify_file, readlink $file);
         return;
     }
-    unless (-e $file) {
-        warn "$file does not exist\n";
-        return;
-    }
     unless (defined $group) {
-        $gid = (stat $file) [5] or do {
-            warn "failed to stat $file: $!\n";
+        $gid = (stat $file)[5] or do {
+            warn "$Program: failed to stat '$file': $!\n";
+            $rc = EX_FAILURE;
             return;
         };
     }
-    chown $uid, $gid, $file or warn "$!\n";
+    unless (chown $uid, $gid, $file) {
+        warn "$Program: '$file': $!\n";
+        $rc = EX_FAILURE;
+    }
 }
-
-exit $warnings;
 
 __END__
 


### PR DESCRIPTION
* Add filename to error string if chown() fails; now it is consistent with stat() error message
* Remove -e file test before chown(); if file doesn't exist chown() will catch it
* Add program name to error messages
* Introduce regular usage() function
* Prefix usage string with "usage:"
* Replace exit($warnings) with exit($rc); now that sig-warn is gone we set $rc directly if chown() failed for any file