### PR TITLE
cmp: avoid repeated substr() on binary buffer

### DIFF
--- a/bin/cmp
+++ b/bin/cmp
@@ -42,6 +42,7 @@ use Getopt::Std qw(getopts);
 use constant EX_SUCCESS   => 0;
 use constant EX_DIFFERENT => 1;
 use constant EX_FAILURE   => 2;
+use constant EX_USAGE     => 2;
 
 use constant ST_INO  => 1;
 use constant ST_SIZE => 7;
@@ -231,7 +232,7 @@ sub skipnum {
 
 sub usage {
     warn "usage: $Program [-l] [-s] file1 file2 [skip1 [skip2]]\n";
-    exit EX_FAILURE;
+    exit EX_USAGE;
 }
 
 sub manual {

--- a/bin/cmp
+++ b/bin/cmp
@@ -42,7 +42,6 @@ use Getopt::Std qw(getopts);
 use constant EX_SUCCESS   => 0;
 use constant EX_DIFFERENT => 1;
 use constant EX_FAILURE   => 2;
-use constant EX_USAGE     => 2;
 
 use constant ST_INO  => 1;
 use constant ST_SIZE => 7;
@@ -182,26 +181,29 @@ READ: while (defined ($read_in1 = sysread $fh1, $buffer1, $chunk_size)) {
     }
 
     if ($buffer1 ne $buffer2) {
-        for (0..$checklength) {
-            next unless (substr $buffer1,$_,1) ne (substr $buffer2,$_,1);
-            my $report_lines = $lines_read + 1 +  (substr $buffer1,0,$_) =~ tr[\n][\n];
+        my @bytes1 = unpack 'C*', $buffer1;
+        my @bytes2 = unpack 'C*', $buffer2;
+
+        for (0 .. $checklength) {
+            $lines_read++ if ($bytes1[$_] == ord("\n"));
+            next if ($bytes1[$_] == $bytes2[$_]);
+            my $report_lines = $lines_read + 1;
             my $report_bytes = $bytes_read + 1 + $_;
-            if ($volume == 1 ) {
+            if ($volume == 1) {
                 print "$file1 $file2 differ: char $report_bytes, line $report_lines\n";
                 exit EX_DIFFERENT;
             } elsif ($volume == 0) {
                 exit EX_DIFFERENT;
-	    } else {
+            } else {
                 $saw_difference ||= 1;
-                printf "%6d %3o %3o\n", $report_bytes, ord(substr $buffer1,$_,1),
-                                                       ord(substr $buffer2,$_,1);
+                printf "%6d %3o %3o\n", $report_bytes, $bytes1[$_], $bytes2[$_];
                 next READ if $_ == $checklength;
                 next;
-	    }
+            }
         }
+    } else {
+        $lines_read += $buffer1 =~ tr[\n][\n];
     }
-
-    $lines_read += $buffer1 =~ tr[\n][\n];
     $bytes_read += $checklength;
 
     if ($read_in1 < $read_in2) {
@@ -229,7 +231,7 @@ sub skipnum {
 
 sub usage {
     warn "usage: $Program [-l] [-s] file1 file2 [skip1 [skip2]]\n";
-    exit EX_USAGE;
+    exit EX_FAILURE;
 }
 
 sub manual {


### PR DESCRIPTION
* Slightly simplify code by unpack()ing buffers that are not equal
* $lines_read becomes a tally, and $report_lines is always ahead by one because $lines_read counts from zero
* When printing the differences with -l flag, ord+substr pattern is avoided by using unpacked buffers
* Retire EX_USAGE which had same value as EX_FAILURE