### PR TITLE
od: fix line offsets

### DIFF
--- a/bin/od
+++ b/bin/od
@@ -156,10 +156,9 @@ while ($len = read($fh, $buf, 1)) {
 	    print "*\n";
 	}
 	$lastline = $data . '|';
+	$offset1 += length $data;
 	undef $data;
     }
-
-    $offset1++;
     last if $is_limit;
 }
 unless (defined $len) {


### PR DESCRIPTION
* Byte offsets were broken in a previous commit
* $offset1 is advanced by -j SKIP_BYTES; otherwise it counts from zero
* Advance $offset1 only after successfully printing a line of output (this does not affect $is_limit)
* At EOF, $offset1 is advanced by the remaining bytes; length($data) is correct
```
%perl od -c od | head -n1
00000017   #   !   /   u   s   r   /   b   i   n   /   p   e   r   l  \n 
%od -c od | head -n1
0000000   #   !   /   u   s   r   /   b   i   n   /   p   e   r   l  \n
```