### PR TITLE
od: strange output for -b option

### DIFF
--- a/bin/od
+++ b/bin/od
@@ -174,7 +174,7 @@ sub octal1 {
     $upformat = 'C*'; # for -b
     $pffmt = '%.3o ';
     @arr = unpack($upformat,$data);
-    $strfmt = $pffmt x $len;
+    $strfmt = $pffmt x (scalar @arr);
 }
 
 sub char1 {


### PR DESCRIPTION
* Output for -b flag is handled in octal1()
* When debugging I observed $len == 1, but arr list contains 16 elements
* $pffmt needs to repeat for each element of arr list
* Repeating $pffmt was was handled correctly in other formatting functions, e.g. decimal(), so follow this
```
%perl od -b od | tail -n5
00013600 162 
00013620 157 
00013640 162 
00013660 145 
00013670
```