### PR TITLE
pr: fail for -3x option

### DIFF
--- a/bin/pr
+++ b/bin/pr
@@ -125,9 +125,9 @@ while (@ARGV && $ARGV[0] =~ /^-(.+)/ && (shift, ($_ = $1), 1)) {
     }
 
     # Accept -2, -3, etc...
-    if (s/^(\d.*)//) {
+    if (s/\A([0-9]+)//) {
         $columns = $1;
-        next OPTION;
+        redo OPTION;
     }
 
     usage("unexpected option: -$_");


### PR DESCRIPTION
* GNU pr and OpenBSD pr read option -3x as -3 -x
* An error is raised because -x is not a valid option
* This version was incorrectly absorbing non-digits after the "-3"
* Removing the dot-match makes this version consistent
* redo statement allows -x to be interpreted as the next option after $columns is set to 3