### PR TITLE
ar: missing library error

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -14,12 +14,12 @@ License: perl
 use POSIX qw(strftime);
 use File::Basename;
 use FileHandle;
+use Getopt::Std qw(getopts);
 
 # allow the first arg to not have a '-'.
 if ($ARGV[0] !~ /^\-/) { $ARGV[0] = '-' . $ARGV[0]; }
 
-require "getopts.pl";
-Getopts("dmpqrtxabciouv");
+getopts('dmpqrtxabciouv') or usage();
 
 # take only one of the following major opts
 if (($opt_d + $opt_m + $opt_p + $opt_q + $opt_r + $opt_t + $opt_x) != 1) {


### PR DESCRIPTION
* Previous version failed on my system with the error: "Can't locate getopts.pl in @INC"
* test1: bad option: "perl ar -Z" prints usage as expected
* test2: new archive: "perl ar -rc 123.a cmp col" creates a file successfully
* test3: list members: "perl ar -t 123.a" shows cmp and col
* test4: extract all: "perl ar -x 123.a" creates the files as expected
* NB: did not test with ar file generated by GNU binutils ar