### PR TITLE
cat: stop accepting -? flag

### DIFF
--- a/bin/cat
+++ b/bin/cat
@@ -23,13 +23,10 @@ my ($VERSION) = '1.3';
 
 my $Program = basename($0);
 
-getopts ('benstuv?', \my %options)  or do {
-	print <<EOF;
-$Program version $VERSION
-$Program [-benstuv] [file ...]
-EOF
-
-	exit EX_FAILURE;
+getopts('benstuv', \my %options)  or do {
+    warn "$Program version $VERSION\n";
+    warn "usage: $Program [-benstuv] [file ...]\n";
+    exit EX_FAILURE;
 };
 
 my $ends              = exists $options{'e'};


### PR DESCRIPTION
* Undocumented -? option was accepted by getopt but ignored
* This option doesn't appear in GNU or OpenBSD version
* The only option mentioned by standards document is -u [1], so there is probably no reason to keep -?
* While here, prefix usage string with "usage:"

1. https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cat.html