### PR TITLE
Use two-argument form of FileHandle->new

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -222,7 +222,7 @@ sub extractMember {
 				   oct($attr->[4]), int($attr->[1]));
     }
 
-    my $out = FileHandle->new(">$name") or die "$name: $!\n";
+    my $out = FileHandle->new($name, 'w') or die "$name: $!\n";
     binmode($out);
     $out->print($attr->[6]);
     $out->close();
@@ -241,7 +241,7 @@ sub extractMember {
 # [ undef, $modt, $uid, $gid, $mode, $sz, $data ]
 sub readFile {
     my ($file) = @_;
-    my $in = FileHandle->new("< $file") or die "$file: $!\n";
+    my $in = FileHandle->new($file, 'r') or die "$file: $!\n";
     binmode($in);
 
     # read the data in one swell foop
@@ -268,7 +268,7 @@ sub readAr {
     # names in order in file
     my @Names = ( undef );
 
-    my $arfh = FileHandle->new("< $archive") or die "$0: $archive: $!\n";
+    my $arfh = FileHandle->new($archive, 'r') or die "$0: $archive: $!\n";
     binmode($arfh);
 
     # read magic
@@ -332,11 +332,11 @@ sub writeAr {
 
     my $arfh;
     if (!defined($append)) {
-	$arfh = FileHandle->new("> $archive") or die "$0: $archive: $!\n";
+	$arfh = FileHandle->new($archive, 'w') or die "$0: $archive: $!\n";
 	$arfh->print("!<arch>\n");
     }
     else {
-	$arfh = FileHandle->new(">> $archive") or die "$0: $archive: $!\n";
+	$arfh = FileHandle->new($archive, 'a') or die "$0: $archive: $!\n";
     }
 
     # loop through each member of the archive and write to filehandle

--- a/bin/file
+++ b/bin/file
@@ -120,7 +120,7 @@ GetOptions(
 
 # the names of the files are in $fileList.
 if ($fileList) {
-    my $fileListFH = FileHandle->new("< $fileList") or
+    my $fileListFH = FileHandle->new($fileList, 'r') or
       die "$F: $fileList: $!\n";
     unshift(@ARGV,<$fileListFH>);
     $fileListFH->close();
@@ -148,7 +148,7 @@ print STDERR "Using magic file $magicFile\n" if $checkMagic;
 
 # $MF is the magic file state: [ filehandle, buffered last line, line num ]
 my $MF = [];
-$$MF[0] = FileHandle->new("< $magicFile") or die "$magicFile: $!\n";
+$$MF[0] = FileHandle->new($magicFile, 'r') or die "$magicFile: $!\n";
 $$MF[1] = undef;
 $$MF[2] = 0;
 readMagicEntry(\@magic,$MF);
@@ -192,7 +192,7 @@ for my $file (@ARGV) {
     }
 
     # current file handle.  or undef if checkMagic (-c option) is true.
-    my $fh = FileHandle->new("< $file") or die "$F: $file: $!\n" ;
+    my $fh = FileHandle->new($file, 'r') or die "$F: $file: $!\n" ;
 
     # 2) check for script
     if (-x $file && -T _) {


### PR DESCRIPTION
* Previously the calls to open() were standardised to have 3 arguments
* Some scripts open files via FileHandle->new() instead of open()
* The pr command already used the preferred 2-argument form; also switch ar and file commands over to this
