### PR TITLE
tail: allow -n1 and -n 1

### DIFF
--- a/bin/tail
+++ b/bin/tail
@@ -82,8 +82,8 @@ sub parse_args()
 
     } else {
 
-    # special handling for -numeric options
-        Getopt::Long::config("pass_through");
+    # pass_through is special handling for -numeric options
+    Getopt::Long::config('bundling', 'pass_through');
     GetOptions("b=s", "c=s", "f", "h", "n=s", "r");
 
     usage 0 if $opt_h;
@@ -104,8 +104,11 @@ sub parse_args()
     }
 
     for (@ARGV) {
-        $point = check_number($1), shift @ARGV, last
-        if /^([-+].*)$/;
+        if (m/\A[\-\+]/) {
+            $point = check_number($_);
+            shift @ARGV;
+            last;
+        }
     }
 
     usage 1, "The number cannot be null" if $point == 0;


### PR DESCRIPTION
* I habitually type "tail -n5"; this is supported by GNU tail and OpenBSD tail
* Enabling bundling option in Getopt::Long makes it work in this version
* Style: avoid capture variable when the entire argument string "+590" is passed to check_number()
* test1: "perl tail -5 tail" -- historical option format, last 5 lines
* test2: "perl tail +590 tail" -- historical option format, line 590 to end
* test3: "perl tail -n5 tail" -- last 5 lines
* test4: "perl tail -n-5 tail" -- last 5 lines
* test5: "perl tail -n+590 tail" -- line 590 to end