### PR TITLE
grep: trailing characters in error messages

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -278,13 +278,13 @@ FILE: while (defined ($file = shift(@_))) {
 
 	if (-d $file) {
 	    if (-l $file && @ARGV != 1) {
-		warn qq($Me: "$file" is a symlink to a directory\n" )
+		warn qq($Me: "$file" is a symlink to a directory\n)
 		    if $opt->{T};
 		next FILE;
 
 	    }
 	    if (!$opt->{r}) {
-		warn qq($Me: "$file" is a directory\n");
+		warn qq($Me: "$file" is a directory\n);
 		next FILE;
 	    }
 	    unless (opendir(DIR, $file)) {


### PR DESCRIPTION
* Some calls to warn have string quoted with qq()
* Remove stray " from end of error messages, which caused perl to append "at grep line x"