### PR TITLE
ed: simplify CalculateLine()

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -1044,12 +1044,7 @@ sub CalculateLine {
 
     if (defined($offsetexpr)) {
         $myline = $CurrentLineNum unless defined($myline);
-
-        if ($offsetdir =~ /^-$/) {
-            $myline -= $offsetammount;
-        } else {
-            $myline += $offsetammount;
-        }
+        $myline += int $offsetexpr;
     }
 
     if (defined($plusesorminusesexpr)) {


### PR DESCRIPTION
* The $offsetexpr variable can be used directly to avoid conditional code when calculating effective line address
* $offsetexpr is either "+123" or "-456"; both forms are valid to feed to int()
* I found this when reading perlcritic warnings for fixed-pattern regex
* The following test sets initial line address to 5 (output is the same for previous version and for GNU ed)
```
%perl ed -p '>>> ' asa
1903
>>> 5
Name: asa
>>> -1n
4	
>>> -1n
3	=begin metadata
>>> +2n
5	Name: asa
>>> q
```