### PR TITLE
primes: error for bad start-stop range

### DIFF
--- a/bin/primes
+++ b/bin/primes
@@ -13,10 +13,6 @@ License: perl
 =cut
 
 
-# primes - generate primes
-# Written for the PPT initiative by Jonathan Feinberg.
-# The algorithm was substantially modified by Benjamin Tilly.
-# See docs for license.
 use strict;
 #use integer; # faster, but cuts the maxint down
 $|++;
@@ -37,6 +33,7 @@ for ($start, $end) {
   s/^\s*\+?(\d{1,10}).*/$1/ || die "$0: $_: illegal numeric format\n";
   $_ > 2**32 - 1 && die "$0: $_: Numerical result out of range\n";
 }
+die "$0: start value must be less than stop value\n" if ($end < $start);
 primes ($start, $end);
 exit 0;
 


### PR DESCRIPTION
* OpenBSD version prints an error if start>stop, which seems better than silently exiting
* Also, remove redundant comment text which is duplicated in the POD