### PR TITLE
ed: implement ! command

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -60,7 +60,6 @@ License: gpl
 #                u - undo
 #                v - global command "inVerted"
 #                x - get encryption key
-#                ! - shell command
 #
 #        - Create regression test suite...test against "real" ed.
 #        - add a "-e" flag to allow it to be used in sed(1) like fashion.
@@ -230,6 +229,8 @@ while (1) {
 
         if (!length($command)) {
             &edSetCurrentLine;
+        } elsif ($command eq '!') {
+            edPipe();
         } elsif ($command eq '=') {
             &edPrintLineNum;
 
@@ -393,6 +394,15 @@ sub escape_line {
         }
     }
     return $s;
+}
+
+# does not modify buffer
+sub edPipe {
+    return unless defined $args[0];
+    my $rc = system $args[0];
+    print "$args[0]: $!\n" if ($rc == -1);
+    print "!\n";
+    return;
 }
 
 # merge lines back into $lines[$adrs[0]]
@@ -933,12 +943,17 @@ sub edSetCurrentLine {
 
 sub edParse {
 
-    #
-    # Parse commands....and yes, this could be done a lot more elegantly
-    # with fancy regexps
-    #
-
     @adrs = ();
+
+    my $cmdline = $_;
+    $cmdline =~ s/\A\s+//;
+
+    if (substr($cmdline, 0, 1) eq '!') {
+        $command = '!';
+        $cmdline =~ s/\A.\s*//;
+        $args[0] = $cmdline;
+        return 1;
+    }
 
     my @fields =
              (/^(


### PR DESCRIPTION
* Take a hint from the TODO comments
* The big regex in edParse() doesn't help because spaces have a special meaning; the new branch bypasses it
* "!" line is printed at end of command output (or after error message if command can't be started)
* Ignore if the command exits with non-zero status; print error only if command doesn't start
* edPipe() doesn't take any line addresses because the output is not saved into the buffer
* Tested against GNU and OpenBSD versions
* test1: shell pattern: "!for i in 1 2 3; do echo $i; done"
* test2: zero exit status command: "!ls"
* test3: non-zero exit status command: "!false"