### PR TITLE
primes: error for numbers with trailing non-digits

### DIFF
--- a/bin/primes
+++ b/bin/primes
@@ -30,7 +30,7 @@ END {
 chomp(my $start = @ARGV ? $ARGV[0] : <STDIN>);
 my $end   = $ARGV[1] || 2**32 - 1;
 for ($start, $end) {
-  s/^\s*\+?(\d{1,10}).*/$1/ || die "$0: $_: illegal numeric format\n";
+  s/\A\s*\+?(\d{1,10})\Z/$1/ || die "$0: $_: illegal numeric format\n";
   $_ > 2**32 - 1 && die "$0: $_: Numerical result out of range\n";
 }
 die "$0: start value must be less than stop value\n" if ($end < $start);


### PR DESCRIPTION
* This version of primes accepts garbage characters at the end of number arguments Start and End 
* e.g. "primes 1xxx 9yyy" is accepted as "primes 1 9"
* Align with OpenBSD behaviour and print an error for this
* I still want to discover why 2 appears before 1 in the output