### PR TITLE
col: incorrectly reads file argument

### DIFF
--- a/bin/col
+++ b/bin/col
@@ -40,6 +40,7 @@ if (defined $opt_l) {
 } else {
     $opt_l = 512;
 }
+usage() if @ARGV;
 
 my @buf = [];       # character buffer
 my $col = 0;        # current column number


### PR DESCRIPTION
* GNU col and OpenBSD col treat the +2 as a bad option; usage string is printed
* This version accepts '+2' as a filename but prints strange output 
* I started reading manuals and discovered col is *not* supposed to accept file arguments
* Only stdin is supposed to be read according to standards document[1]
* The "usage" error for GNU & OpenBSD occurs because remaining arguments are found after getopt is finished

1. https://pubs.opengroup.org/onlinepubs/7908799/xcu/col.html

```
%perl col +2 col # old output
Can't open +2: No such file or directory at col line 71. #!/usr/bin/perl

=begin metadata
...
		p
		 r
		  i
		   n
		    t

		      $
		       s
			p
			 a
			  c
			   e
			    s
			     ;
Can't use an undefined value as an ARRAY reference at col line 246, <> line 267.
```