### PR TITLE
ed: allow whitespace in argment

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -73,7 +73,7 @@ use strict;
 
 use Getopt::Std qw(getopts);
 
-use constant E_ADDREXT => 'too many addresses';
+use constant E_ADDREXT => 'unexpected address';
 use constant E_ADDRBAD => 'invalid address';
 use constant E_ARGEXT  => 'extra arguments detected';
 use constant E_SUFFBAD => 'invalid command suffix';
@@ -398,9 +398,14 @@ sub escape_line {
 
 # does not modify buffer
 sub edPipe {
-    return unless defined $args[0];
-    my $rc = system $args[0];
-    print "$args[0]: $!\n" if ($rc == -1);
+    if (defined $adrs[0]) {
+        edWarn(E_ADDREXT);
+        return;
+    }
+    if (defined $args[0]) {
+        my $rc = system $args[0];
+        print "$args[0]: $!\n" if ($rc == -1);
+    }
     print "!\n";
     return;
 }
@@ -945,16 +950,7 @@ sub edParse {
 
     @adrs = ();
 
-    my $cmdline = $_;
-    $cmdline =~ s/\A\s+//;
-
-    if (substr($cmdline, 0, 1) eq '!') {
-        $command = '!';
-        $cmdline =~ s/\A.\s*//;
-        $args[0] = $cmdline;
-        return 1;
-    }
-
+    s/\A\s+//;
     my @fields =
              (/^(
                  (
@@ -969,14 +965,15 @@ sub edParse {
                   (([+-])?(\d+))?         # [+]num | -num
                   (([\+]+)|([-^]+))?        # + | -
                 )?
-                 ([acdeEfhHijlmnpPqQrstwW=])?        # command char
+                 ([acdeEfhHijlmnpPqQrstwW=\!])?        # command char
                  ([a-z])?                # command suffix
-                 (\s*)(\S+)?                # argument (filename, etc.)
+                 (\s*)(.+)?                # argument (filename, etc.)
                  )$/x);
 
 
     return 0 if ($#fields == -1);  # bad syntax
 
+    my $space_sep = length $fields[29];
     if (defined($fields[27])) {
         $command = $fields[27];
     } else {
@@ -985,14 +982,15 @@ sub edParse {
     }
     if (defined $fields[28]) {
         $commandsuf = $fields[28];
-        if (lc($command) ne 'w') {
+        if ($command eq '!' && !$space_sep) { # allow !ls
+            $fields[30] = $commandsuf . $fields[30];
+        } elsif (lc($command) ne 'w') {
             return 0;
         }
     } else {
         $commandsuf = '';
     }
 
-    my $space_sep = length $fields[29];
     $args[0] = $fields[30];
 
     $adrs[0] = &CalculateLine(splice(@fields,1,13));


### PR DESCRIPTION
* In GNU ed, subcommand "f" requires a space before the filename argument, but the first non-space and everything after it becomes the argument
* e.g. for command "f why hello", command is "f" and argument is "why hello"
* The current command parser doesn't agree with this
* This problem was why I implemented "!" subcommand outside the big regex, but it's better for a more general fix
* Within the big regex, only non-spaces matched as the argument but any remaining characters should match
* test1: "!ls -a" no space between "!" and "l", which unfortunately gets taken as command suffix and has to be re-added into $args[0]
* test2: " f 12 " space after 12, sets file argument to "12 "
* OpenBSD ed agrees with GNU version for these tests