### PR TITLE
sort: enforce minimum value of 1 for -F and -y

### DIFF
--- a/bin/sort
+++ b/bin/sort
@@ -85,9 +85,14 @@ sub _sort_file {
 
     # set output and other defaults
     $opts->{o}   = !$opts->{o} ? '' : $opts->{o};
-    $opts->{'y'} ||= $ENV{MAX_SORT_RECORDS} || 200000;  # default max records
-    $opts->{F}   ||= $ENV{MAX_SORT_FILES}   || 40;      # default max files
-
+    if (defined $opts->{'F'}) {
+        die "option -F expects a positive number\n" if (int($opts->{'F'}) < 1);
+    }
+    if (defined $opts->{'y'}) {
+        die "option -y expects a positive number\n" if (int($opts->{'y'}) < 1);
+    }
+    $opts->{'y'} ||= $ENV{'MAX_SORT_RECORDS'} || 200000;  # default max records
+    $opts->{'F'} ||= $ENV{'MAX_SORT_FILES'}   || 40;      # default max files
 
     # see big ol' mess below
     _make_sort_sub($opts);

--- a/bin/sort
+++ b/bin/sort
@@ -85,14 +85,15 @@ sub _sort_file {
 
     # set output and other defaults
     $opts->{o}   = !$opts->{o} ? '' : $opts->{o};
+
+    $opts->{'y'} ||= $ENV{'MAX_SORT_RECORDS'} || 200000;  # default max records
+    $opts->{'F'} ||= $ENV{'MAX_SORT_FILES'}   || 40;      # default max files
     if (defined $opts->{'F'}) {
         die "option -F expects a positive number\n" if (int($opts->{'F'}) < 1);
     }
     if (defined $opts->{'y'}) {
         die "option -y expects a positive number\n" if (int($opts->{'y'}) < 1);
     }
-    $opts->{'y'} ||= $ENV{'MAX_SORT_RECORDS'} || 200000;  # default max records
-    $opts->{'F'} ||= $ENV{'MAX_SORT_FILES'}   || 40;      # default max files
 
     # see big ol' mess below
     _make_sort_sub($opts);


### PR DESCRIPTION
* Basic validation
* Options -F and -y are non-standard and control allocation limits within sort
* Currently if the value of zero is given, it is ignored because of truth-test
* Negative amounts are accepted but don't make sense in the context of a limit size