### PR TITLE
ed: simplify relative line calculation

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -1062,13 +1062,7 @@ sub CalculateLine {
 
     if (defined($plusesorminusesexpr)) {
         $myline = $CurrentLineNum unless defined($myline);
-
-        if (defined($pluses)) {
-            $myline += length($pluses);
-        } elsif (defined($minuses)) {
-            $myline -= length($minuses);
-        }
-
+        $myline += length($pluses||'') - length($minuses||'');
     }
 
     return $myline;


### PR DESCRIPTION
* Based on prior regex, "+-" and "-+" are invalid relative addresses; GNU ed accepts "+-" but this version treats it as "extra arguments" error
* "++n" is numbered print, 2 lines ahead of currentLine
* "--n" is numbered print, 2 lines behind currentLine
* Only one of $pluses or $minuses will be set at this time
* Writing the logic in this way will make it easier to support "--++" in future for GNU compat