### PR TITLE
ed: simplify backwards search

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -1111,13 +1111,8 @@ sub edSearchForward {
 
 sub edSearchBackward {
     my($pattern) = @_;
-    my($line,$start);
 
-    # brute force search...
-
-    $start = $CurrentLineNum > 1 ? $CurrentLineNum - 1 : maxline();
-
-    $line = $start;
+    my $line = $CurrentLineNum > 1 ? $CurrentLineNum - 1 : maxline();
 
     while ($line > 0) {
         if ($lines[$line] =~ /$pattern/) {


### PR DESCRIPTION
* In edSearchBackwards(), init $line index directly instead of copying value from $start
* I found this by accident when reading the code
* Test jumps to line 60, finds "perl" patten backwards on line 9 then again on 7

```
%perl ed -p '>>> ' awk
4595
>>> 60
open(TMPOUT, '+>', ($tmpout = "/tmp/a2pout.$$"))    ||
>>> ?perl
License: perl
>>> n
9	License: perl
>>> ?perl
Author: Tom Christiansen, tchrist@perl.com
>>> n
7	Author: Tom Christiansen, tchrist@perl.com
>>> q
```