### PR TITLE
hangman versus small file

### DIFF
--- a/bin/hangman
+++ b/bin/hangman
@@ -72,11 +72,18 @@ print "\nTHANKS FOR PLAYING!\n";
 
 sub get_a_word {
 	my $wordlist = "wordlist.txt";
-	my( $word );
+	my( $fh, $word );
 	my( $line_num ) = 1;
 	my( $random ) = rand();
-	my( $val ) = int( $random * 9151 ) + 1;
-	open my $fh, '<', $wordlist or die "Could not open <$wordlist>: $!\n";
+
+	open($fh, '<', $wordlist) or die "Could not open <$wordlist>: $!\n";
+	my $lines = 0;
+	$lines++ while (<$fh>);
+	my $val = int($random * $lines) + 1;
+
+	close($fh) or die "Could not close <$wordlist>: $!\n";
+	open($fh, '<', $wordlist) or die "Could not open <$wordlist>: $!\n";
+
 	while( <$fh> ) {
 		if( $line_num == $val ) {
 			$word = $_;
@@ -86,7 +93,7 @@ sub get_a_word {
 			$line_num++;
 		}
 	}
-	close( FILE );
+	close($fh) or die "Could not close <$wordlist>: $!\n";
 	return( $word );
 }
 


### PR DESCRIPTION
* When testing hangman with a small word list the game would terminate before it even started 
* get_a_word() assumed that the wordlist file had 9151 words in it
* This would be a problem for larger word lists too; the list is effectively truncated
* Scale random index ($val) based on the number of lines in word list (with penalty of reading list twice)
* Filehandle FILE used in close() was incorrect
* Raise error if close() failed
* Test1: wordlist.txt with only 2 words
* Test2: wordlist.txt from dict file on my linux system (101,924 words)