### PR TITLE
echo: remove non-standard -?

### DIFF
--- a/bin/echo
+++ b/bin/echo
@@ -15,33 +15,15 @@ package PerlPowerTools::echo;
 
 use strict;
 
-my ($VERSION) = '1.2';
+my ($VERSION) = '1.3';
 
 __PACKAGE__->run( @ARGV ) unless caller();
 
 sub run {
     my ( $self, @args ) = @_;
 
-    unless (@args) {
-        print "\n";
-        exit 0;
-    }
-
-    if ($args[0] eq '-?') {
-    print <<EOF;
-Usage: echo [-n] [arguments]
-
-Displays the command line arguments, seperated by spaces.
-
-Options:
-       -n:     Do not print a newline after the arguments.
-       -?:     Display usage information.
-EOF
-        exit 0;
-    }
-
     my $N = 1;
-    if ($args[0] eq '-n') {
+    if (@args && $args[0] eq '-n') {
         $N = 0;
         shift @args;
     }
@@ -50,7 +32,6 @@ EOF
     print "\n" if $N == 1;
 
     exit 0;
-
 }
 
 1;
@@ -69,7 +50,7 @@ echo [-n] [arguments...]
 
 =head1 DESCRIPTION
 
-echo prints the command line arguments seperated by spaces. A newline is
+echo prints the command line arguments separated by spaces. A newline is
 printed at the end unless the '-n' option is given.
 
 =head2 OPTIONS
@@ -81,10 +62,6 @@ I<echo> accepts the following options:
 =item -n
 
 Do not print a newline after the arguments.
-
-=item -?
-
-Print out a short help message, then exit.
 
 =back
 


### PR DESCRIPTION
* Sometimes echo is built into the shell
* Standards document for echo doesn't mention the -? flag [1]
* The versions of echo that I tested don't support it
* I think it's better to follow convention and not treat -? as an option
* Sync pod and fix a typo in DESCRIPTION

1. https://pubs.opengroup.org/onlinepubs/009604599/utilities/echo.html

```
# bash builtin
% builtin echo $BASH_VERSION
5.1.4(1)-release
% builtin echo -?
-?
% builtin echo --version
--version

# gnu echo
% /bin/echo -?
-?
% /bin/echo --version
echo (GNU coreutils) 8.32

# pdksh builtin
% builtin echo -?
-?
% builtin echo --version
--version
% builtin echo $KSH_VERSION
@(#)PD KSH v5.2.14 99/07/13.2

# openbsd echo
% /bin/echo -?
-?
% /bin/echo --version
--version
```