### PR TITLE
ed: eliminate global variable $fname

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -163,8 +163,8 @@ if ($opt{'v'}) {
     $EXTENDED_MESSAGES = 1;
 }
 
-shift if (@ARGV && $ARGV[0] eq '-');
 $args[0] = shift;
+$args[0] = undef if (defined($args[0]) && $args[0] eq '-');
 Usage() if @ARGV;
 $SupressCounts = 1 if ($opt{'s'} || !defined($args[0]));
 

--- a/bin/ed
+++ b/bin/ed
@@ -162,17 +162,11 @@ if ($opt{'v'}) {
     warn "perl ed version $VERSION\n";
     $EXTENDED_MESSAGES = 1;
 }
-if ($opt{'s'}) {
-    $SupressCounts = 1;
-}
 
-&Usage if scalar(@ARGV) > 1;
-my $fname = shift;
-if (!defined($fname) || $fname eq '-') {
-    $SupressCounts = 1;
-} else {
-    $args[0] = $fname;
-}
+shift if (@ARGV && $ARGV[0] eq '-');
+$args[0] = shift;
+Usage() if @ARGV;
+$SupressCounts = 1 if ($opt{'s'} || !defined($args[0]));
 
 &edEdit($NO_QUESTIONS_MODE,$NO_APPEND_MODE);
 


### PR DESCRIPTION
* edEdit() is always called and expects a filename to be passed in $args[0]
* Special filename '-' is the same as no filename; edEdit() expects $args[0] to be unset and will read stdin
* Extra file arguments are not allowed; only one file can be edited at a time
* When stdin is read, byte counts are not displayed
