### PR TITLE
cat: explicitly close files

### DIFF
--- a/bin/cat
+++ b/bin/cat
@@ -93,6 +93,10 @@ sub do_file {
 
         print;
     }
+    if ($name ne '-' && !close($fh)) {
+        warn "$Program: failed to close '$name': $!\n";
+        return 1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
* Guarantee that if close() failed for file1 that we print a warning for file1 before proceeding to process file2, then eventually exit with error code
* To preserve "cat - -", make sure *STDIN is not closed (on my linux system I type ctrl-d twice to terminate do_file() with EOF)