### PR TITLE
install: "usage()" > "die usage()"

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -20,14 +20,15 @@ use Getopt::Std qw(getopts);
 my ($VERSION) = '1.3';
 my $Program = basename($0);
 
-sub usage () {
-    <<EOUsage;
+sub usage {
+    print <<EOUsage;
 $Program (Perl bin utils) $VERSION
 
 Usage: $Program [-CcDps] [-g group] [-m mode] [-o owner] file1 file2
        $Program [-CcDps] [-g group] [-m mode] [-o owner] file ... directory
        $Program -d [-g group] [-m mode] [-o owner] directory ...
 EOUsage
+    exit 1;
 }
 
 $SIG{__DIE__} = sub {
@@ -43,11 +44,12 @@ my $Errors = 0;
 
 # process options
 my %opt;
-getopts('CcDdf:g:Mm:o:ps', \%opt) or die usage;
-die usage unless @ARGV;
+getopts('CcDdf:g:Mm:o:ps', \%opt) or usage();
+usage() unless @ARGV;
 
 if ($opt{d} and grep($_, @opt{qw/ C c D p /}) > 0) {
-    die "$Program: -d not allowed with -[CcDp]\n", usage;
+    warn "$Program: -d not allowed with -[CcDp]\n";
+    usage();
 }
 
 $opt{C}++ if $opt{p};
@@ -188,7 +190,8 @@ sub install_files {
         die "$Program: missing destination file operand after '$dst'\n";
     }
     if (!$dir and @ARGV > 1) {
-        die "$Program: $dst is not a directory\n", usage;
+        warn "$Program: '$dst' is not a directory\n";
+        usage();
     }
 
     my $mode = $opt{m} || '755';


### PR DESCRIPTION
* Making usage() exit instead of returning a string is more consistent with usage() in other commands
* test1: "perl install -G" --> unknown option
* test2: "perl install" --> no arguments
* test3: "perl -c -d ABC DEF" --> -d not allowed with -c
* test4: "perl install awk xargs" --> final argument is not a directory