### PR TITLE
fold: terminate options with --

### DIFF
--- a/bin/fold
+++ b/bin/fold
@@ -62,6 +62,7 @@ OPTION:
 while (@ARGV && $ARGV[0] =~ /^-(.+)/ && (shift, ($_ = $1), 1)) {
 
     next OPTION unless length;
+    last if $_ eq '-'; # -- terminator
 
     if (s/^b//) {
         warn "-b flag already set" if $Byte_Only++;


### PR DESCRIPTION
* Tested against GNU fold and OpenBSD fold
* POSIX semantics: If I want to fold a file called "-s" I put it after "--" (perl fold -s -- -s)
* Single "-" means read stdin; "---" is an invalid option
* Based on a similar patch to uniq