### PR TITLE
cp: pass on child exit-code

### DIFF
--- a/bin/cp
+++ b/bin/cp
@@ -60,7 +60,7 @@ sub run {
 		push @command, @files, $destination;
 
 		my $rc = system { $command[0] } @command;
-		return $rc;
+		return $rc >> 8;
 		}
 	else {
 		require File::Copy;


### PR DESCRIPTION
* When testing "perl cp awk awk" on my linux system, the OS cp command is being run via system()
* Source and destination are the same; cp fails with exit-code 1
* system() returns 256, but only the lowest byte is used when passed to exit(); shift system() return value as suggested in "perldoc -f system"
```
%perl cp awk awk 
cp: 'awk' and 'awk' are the same file
%echo $?
1
```