### PR TITLE
wc: terminate options with --

### DIFF
--- a/bin/wc
+++ b/bin/wc
@@ -15,47 +15,20 @@ use strict;
 use locale;
 
 use File::Basename qw(basename);
+use Getopt::Std qw(getopts);
 
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
 my $Program = basename($0);
 
-my %opt;
-
 sub usage {
-    warn "$Program: @_\n" if @_;
     warn "usage: $Program [-a | [-p] [-l] [-w] [-m] [-c] ] [file...]\n";
     exit EX_FAILURE;
 }
 
-@opt{ qw/? a p l w m c/ } = qw(0 0 0 0 0 0 0);
-
-# The $MacPerl::Version variable should be on if ($^O =~ /MacOS/)
-# this unusual construct gets around -w -Mstrict in other places too.
-if ( $MacPerl::Version && $MacPerl::Version =~ /App/) {
-    my $opt = MacPerl::Pick("Which wc option?",
-      "all","default (lwc)",
-      "-l (lines)","-w (words)","-c (bytes)",
-      "-m (chars)","-p (paragraphs)");
-    if ($opt eq "all") { $opt{'a'} = 1; }
-    if ($opt =~ /^-p/) { $opt{'p'} = 1; }
-    if ($opt =~ /^-l/) { $opt{'l'} = 1; }
-    if ($opt =~ /^-w/) { $opt{'w'} = 1; }
-    if ($opt =~ /^-m/) { $opt{'m'} = 1; }
-    if ($opt =~ /^-c/) { $opt{'c'} = 1; }
-}
-else {
-    # use regular switches under the MPW tool and everywhere else.
-    while ($ARGV[0] =~ /^-/) {
-        $ARGV[0] =~ s/^-//;
-        for my $flag (split(//,$ARGV[0])) {
-            usage("unknown flag: `$flag'") unless 'aplwmc' =~ /\Q$flag/;
-            warn "$0: `$flag' flag already set\n" if $opt{$flag}++;
-        }
-        shift;
-    }
-}
+my %opt;
+getopts('aplwmc', \%opt) or usage();
 
 if ((!($opt{'p'} || $opt{'l'} || $opt{'w'} || $opt{'c'})) || ($opt{'a'})) {
    $opt{'l'} = 1; $opt{'w'} = 1; $opt{'c'} = 1;


### PR DESCRIPTION
* Not all commands know about "--" yet
* Conversion to Getopt::Std is simple for wc because options are all single letter flags
* Remove differences for MacPerl which likely don't matter anymore (Getopt::Std will work on OSX perl)
* test1: "perl wc -c -- -c" --> process a file called "-c"
* test2: compare output of GNU version (below); different count for -w flag was present in previous versions
```
%for opt in c l m w; do echo "GNU -$opt"; wc -${opt} awk; echo "PPT -$opt"; perl wc -${opt} awk; echo; done GNU -c
4595 awk
PPT -c
      4595 awk

GNU -l
204 awk
PPT -l
       204 awk

GNU -m
4595 awk
PPT -m
       204       675      4595      4595 awk

GNU -w
701 awk
PPT -w
       675 awk
```
