### PR TITLE
apply: use library max() instead of hand-rolled

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -15,6 +15,7 @@ License: perl
 use strict;
 
 use File::Basename qw(basename);
+use List::Util qw(max);
 
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
@@ -55,11 +56,7 @@ usage() unless @ARGV;
 
 # Scan $command for ``%d''.
 my @thingies = $command =~ /${magic}(\d+)/g;
-
-if (@thingies) { # Ignore $argc, found our own.
-    $argc = 0;
-    foreach (@thingies) {$argc = $_ if $_ > $argc}
-}
+$argc = max(@thingies) if @thingies;
 
 # Now, apply the command till we run out.
 my $err = EX_SUCCESS;


### PR DESCRIPTION
* apply has a special mode where %NUM in the command string is substituted with an argument
* %NUM can be repeated in the command string, and the highest number determines how many arguments are consumed
* The explanation of this feature in the pod manual could be improved
* This example takes 2 elements from ARGV per instance of echo command (example tested against OpenBSD version)

```
perl apply 'echo %1 %2' a*
a ab
ab.diff ab.diff.orig
ac.diff ac.diff.orig
ac.diff.Orig ac.diff.ORig
ac.diff.ORIg ac.diff.ORIG
a.col addbib
alink apply
apply.new ar
ar2 arch
arithmetic ar.unexpand.new
ar.unexpand.old ar.uu
asa asd
a.uniq awk
```