### PR TITLE
ed: clean some redundant code

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -324,9 +324,8 @@ sub edHelp {
     }
     if ($toggle) {
         $EXTENDED_MESSAGES ^= 1;
-        return unless $EXTENDED_MESSAGES;
     }
-    if (defined $Error) {
+    if ($EXTENDED_MESSAGES && defined($Error)) {
          print "$Error\n";
     }
 }
@@ -475,12 +474,7 @@ sub edMove {
     }
 
     my $count = $end - $start + 1;
-    my @copy;
-    if ($count == 1) {
-        push @copy, $lines[$start];
-    } else {
-        @copy = @lines[$start .. $end];
-    }
+    my @copy = @lines[$start .. $end];
     if ($start > $dst && $end > $dst) {
         splice(@lines, $start, $count) if $delete;
         splice @lines, $dst + 1, 0, @copy;
@@ -652,9 +646,6 @@ sub edWrite {
     $NeedToSave = 0;
     $UserHasBeenWarned = 0;
     print "$chars\n" unless ($SupressCounts);
-
-    # v7 docs say to chmod 666 the file ... we're not going to
-    # follow the docs *that* closely today (6/16/99 ---gmj)
 
     if ($qflag) {
         exit 0;


### PR DESCRIPTION
* In edMove(), special code isn't needed for $count of one because the .. operator can handle 1..1
* edPrint() already relies on this because it loops with "$adrs[0] .. $adrs[1]", where both can be equal
* Tested with command "1m20" to move the 1st line in buffer ($end is inferred from $start)
* Remove chmod() comment in edWrite(); OpenBSD version does not perform chmod() and that is a better reference
* Standards document mentions nothing about changing file modes/permissions[1]
* In edHelp() the saved error will be printed each time the "H" command enables the help flag; avoid extra return statement

1. https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ed.html