### PR TITLE
rev: terminate options with --

### DIFF
--- a/bin/rev
+++ b/bin/rev
@@ -14,6 +14,7 @@ License: gpl
 use strict;
 
 use File::Basename qw(basename);
+use Getopt::Std qw(getopts);
 
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
@@ -25,48 +26,33 @@ $|++;
 
 my ($VERSION) = '1.4';
 
+my %opt;
+getopts('v', \%opt) or usage();
+if ($opt{'v'}) {
+	print "$Program $VERSION\n";
+	exit EX_SUCCESS;
+}
+
 my $rc = EX_SUCCESS;
-if (scalar(@ARGV) == 0 || $ARGV[0] !~ m/^-./) {
-	if (@ARGV) {
-		foreach my $file (@ARGV) {
-			if (-d $file) {
-				warn "$Program: '$file' is a directory\n";
-				$rc = EX_FAILURE;
-				next;
-			}
-			my $fh;
-			unless (open $fh, '<', $file) {
-				warn "$Program: cannot open '$file': $!\n";
-				$rc = EX_FAILURE;
-				next;
-			}
-			rev($fh);
-			if ($!) {
-				warn "$Program: '$file': $!\n";
-				$rc = EX_FAILURE;
-			}
-		}
-	} else {
-		rev(*STDIN);
+foreach my $file (@ARGV) {
+	if (-d $file) {
+		warn "$Program: '$file' is a directory\n";
+		$rc = EX_FAILURE;
+		next;
+	}
+	my $fh;
+	unless (open $fh, '<', $file) {
+		warn "$Program: cannot open '$file': $!\n";
+		$rc = EX_FAILURE;
+		next;
+	}
+	rev($fh);
+	if ($!) {
+		warn "$Program: '$file': $!\n";
+		$rc = EX_FAILURE;
 	}
 }
-elsif ($ARGV[0] eq '--version') {
-	print " $Program $VERSION\n";
-}
-else {
-	print <<EOF;
-Usage: $Program [OPTION] [FILE]
-
-Reverses lines of the named file or the text input on STDIN
-
-Options:
-	--version:  Print version number, then exit.
-	--help || -h:     Print usage, then exit;
-
-EOF
-	exit EX_FAILURE;
-}
-
+rev(*STDIN) unless @ARGV;
 exit $rc;
 
 sub rev {
@@ -76,6 +62,19 @@ sub rev {
 		my $r = reverse;
 		print $r, $/;
 	}
+}
+
+sub usage {
+	print <<EOF;
+Usage: $Program [OPTION] [FILE]...
+
+Reverse lines of the named file(s) or the text input on STDIN
+
+Options:
+	-v    Print version number, then exit.
+
+EOF
+	exit EX_FAILURE;
 }
 
 __END__
@@ -88,7 +87,7 @@ rev - reverse lines of a file
 
 =head1 SYNOPSIS
 
-rev [options] [file]
+rev [-v] [file]...
 
 =head1 DESCRIPTION
 
@@ -102,13 +101,9 @@ I<rev> accepts the following options:
 
 =over 4
 
-=item  --help || -h
+=item  -v
 
-Print a short help message, then exits.
-
-=item  --version
-
-Prints out its version number, then exits.
+Print version number then exit
 
 =back
 


### PR DESCRIPTION
* GNU and OpenBSD versions of rev use getopt(), so they support '--' for terminating options; add getopt() here too
* Remove --help (-h); usage string is still printed
* Update SYNOPSIS and usage() to indicate multiple input files can be processed
* test1: "perl rev -- -v 01 02" --> 3 input files (now I can read file called "-v" without typing "./-v")
* test2: "perl rev -x" --> bad option