### PR TITLE
ed: 1s/pat1/pat2/ incorrectly processes multiple lines

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -501,7 +501,7 @@ sub edSubstitute {
     $adrs[0] = $CurrentLineNum unless (defined($adrs[0]));
     $adrs[1] = $adrs[0] unless (defined $adrs[1]);
 
-    if (defined($adrs[0]) && $adrs[0] == 0) {
+    if ($adrs[0] == 0 || $adrs[1] == 0) {
         edWarn(E_ADDRBAD);
         return;
     }

--- a/bin/ed
+++ b/bin/ed
@@ -499,7 +499,7 @@ sub edSubstitute {
     # parse args
 
     $adrs[0] = $CurrentLineNum unless (defined($adrs[0]));
-    $adrs[1] = $CurrentLineNum unless (defined($adrs[1]));
+    $adrs[1] = $adrs[0] unless (defined $adrs[1]);
 
     unless (defined($args[0])) {
         edWarn(E_PATTERN);

--- a/bin/ed
+++ b/bin/ed
@@ -325,7 +325,7 @@ sub edHelp {
     if ($toggle) {
         $EXTENDED_MESSAGES ^= 1;
     }
-    if ($EXTENDED_MESSAGES && defined($Error)) {
+    if (defined($Error) && ($EXTENDED_MESSAGES || !$toggle)) {
          print "$Error\n";
     }
 }
@@ -501,6 +501,10 @@ sub edSubstitute {
     $adrs[0] = $CurrentLineNum unless (defined($adrs[0]));
     $adrs[1] = $adrs[0] unless (defined $adrs[1]);
 
+    if (defined($adrs[0]) && $adrs[0] == 0) {
+        edWarn(E_ADDRBAD);
+        return;
+    }
     unless (defined($args[0])) {
         edWarn(E_PATTERN);
         return;


### PR DESCRIPTION
* If current line is 10, and I enter 1s/e/E/, the substitution was occurring for lines 1-10 instead of just line 1
* If I want substitution on lines 1-10 I'm supposed to type 1,10s/e/E/
* If I only want to substitute on the current line I omit the addresses and type s/e/E/
* Patch is based on existing behaviour of edPrint()
* When searching for assignments of $adrs[1] I didn't find any more instances where it's set to current line
* Add validation to prevent line address 0 for "s" command (0 is valid for a few ed commands though)
* Fix logic in edHelp() for "h" command