### PR TITLE
cat: line number compat

### DIFF
--- a/bin/cat
+++ b/bin/cat
@@ -78,9 +78,6 @@ sub do_file {
             $was_empty = $is_empty;
         }
 
-        $_ = sprintf "%6d  %s", ++ $count, $_ if $number_lines ||
-                                                 $number_non_blanks && /\S/;
-
         s/$/\$/ if $ends;
         if ($nonprinting) {
             s/([\x80-\xFF])/"M-" . ("\x7F" & $1)/ge;
@@ -91,6 +88,9 @@ sub do_file {
             s/\x09/^I/g;
         }
 
+        if ($number_lines || ($number_non_blanks && /\S/)) {
+            printf "%6d\t", ++$count;
+        }
         print;
     }
     if ($name ne '-' && !close($fh)) {


### PR DESCRIPTION
* When printing line number prefix for -n and -b flags, terminate the line number with a tab character
* This makes the output compatible with the OpenBSD and GNU versions
* Flags -n and -b are not covered in standards document [1]
* Line number can be printed directly without modifying the value of line buffer $_
* Now md5sum matches for /bin/cat -n and -b output on my linux system

1. https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cat.html