### PR TITLE
fold: '-' is not stdin

### DIFF
--- a/bin/fold
+++ b/bin/fold
@@ -90,10 +90,12 @@ if ($Space_Break && $Width < $Tabstop) {
     usage("width must be greater than $Tabstop with the -s option");
 }
 
-unshift(@ARGV, '-') unless @ARGV;
 my $err = 0;
 for (@ARGV) {
     $err |= fold_file($_);
+}
+unless (@ARGV) {
+    $err |= fold_file();
 }
 exit ($err ? EX_FAILURE : EX_SUCCESS);
 
@@ -121,17 +123,18 @@ sub fold_file {
     my($column, $char, $input, $output);
 
     $column = 0;
-    if (-d $filename) {
-        warn "$Program: $filename: is a directory\n";
-        return 1;
-    }
-    if ($filename eq '-') {
-        $input = *STDIN;
-    } else {
-        unless (open $input, '<', $filename) {
-            warn "$Program: $filename: $!\n";
+    if (defined $filename) {
+        if (-d $filename) {
+            warn "$Program: '$filename': is a directory\n";
             return 1;
         }
+        unless (open $input, '<', $filename) {
+            warn "$Program: '$filename': $!\n";
+            return 1;
+        }
+    } else {
+        $filename = '(stdin)';
+        $input = *STDIN;
     }
 
     # the following hack allows us to dispense with the


### PR DESCRIPTION
* GNU fold treats '-' as a special file argument but that is an extension
* Standards document contains wording that stdin is only used if no arguments are given; OpenBSD follows this [1]
* The pod manual also says stdin is only used as a default for no file arguments ('-' is not documented to have a special meaning)
* This change was recently made to bin/head also

1. https://pubs.opengroup.org/onlinepubs/009695299/utilities/fold.html