### PR TITLE
basename/dirname: exit(1) for no args

### DIFF
--- a/bin/basename
+++ b/bin/basename
@@ -21,9 +21,9 @@ unless (@ARGV == 1 || @ARGV == 2) {
     $0 = basename ($0);
     print <<EOF;
 $0 (Perl bin utils) $VERSION
-$0 string [suffix | /pattern/]
+usage: $0 string [suffix | /pattern/]
 EOF
-    exit;
+    exit 1;
 };
 
 if (@ARGV == 2) {

--- a/bin/dirname
+++ b/bin/dirname
@@ -21,9 +21,9 @@ unless (@ARGV == 1) {
     $0 = basename ($0);
     print <<EOF;
 $0 (Perl bin utils) $VERSION
-$0 string
+usage: $0 string
 EOF
-    exit;
+    exit 1;
 };
 
 print +(dirname $ARGV [0]), "\n";


### PR DESCRIPTION
* This change is covered by Exit Status section of these documents:
https://pubs.opengroup.org/onlinepubs/007904975/utilities/dirname.html
https://pubs.opengroup.org/onlinepubs/007904975/utilities/basename.html

* This was found when testing against the GNU version
* While here, prefix usage string with "usage: "
