### PR TITLE
bc: array assignment incorrectly prints

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2496,16 +2496,17 @@ sub exec_stmt
      }
 
 #     debug {"p: $name, $idx.\n"};
-     unless (defined($sym_table{$name.'[]'})
-	     and $sym_table{$name.'[]'}{'type'} eq 'array') {
+     $name .= '[]';
+     unless (defined($sym_table{$name})
+	     and $sym_table{$name}{'type'} eq 'array') {
 
-       $sym_table{$name.'[]'} = { type => 'array'};
+       $sym_table{$name} = { type => 'array'};
      }
-     unless ($sym_table{$name.'[]'}{'value'}[$idx]) {
-       $sym_table{$name.'[]'}{'value'}[$idx] = { type => 'var',
+     unless ($sym_table{$name}{'value'}[$idx]) {
+       $sym_table{$name}{'value'}[$idx] = { type => 'var',
 					    value => 0 };
      }
-     push(@ope_stack, $sym_table{$name.'[]'}{'value'}[$idx]{'value'});
+     push(@ope_stack, $sym_table{$name}{'value'}[$idx]{'value'});
      next INSTR;
 
    } elsif($_ eq '=V') {
@@ -2535,6 +2536,7 @@ sub exec_stmt
      $sym_table{$name}{'value'}[$idx] = { type => 'var',
 					  value => $value };
      push(@ope_stack, $value);
+     $return = 1; # do not print result
      next INSTR;
 
    } elsif($_ eq 'IF') {


### PR DESCRIPTION
* In exec_stmt(), instruction 'p' takes an array name and index number, then pushes the array element onto the stack (implicit print)
* The default value for array elements is 0
* The instruction '=P' assignd a value from the stack into an array element
* Make the code for 'p' simpler by appending '[]' to $name, as done for '=P' instruction
* For instruction '=P' the value being assigned to array should not be printed (this is controlled by $return variable)
* For input "a[9] = 123; a[9];" the value of 123 should be printed once, for the 2nd statement
* Tested this input against GNU and OpenBSD versions