### PR TITLE
whoami: treat arguments as error

### DIFF
--- a/bin/whoami
+++ b/bin/whoami
@@ -15,6 +15,13 @@ License: artistic2
 
 use strict;
 
+use constant EX_SUCCESS => 0;
+use constant EX_FAILURE => 1;
+
+if (@ARGV) {
+	warn "usage: whoami\n";
+	exit EX_FAILURE;
+}
 my @coderefs = (
 	sub { getpwuid($>) },
 	sub { require Win32; Win32::LoginName() },
@@ -26,10 +33,10 @@ foreach my $coderef ( @coderefs ) {
 	my $user = eval { $coderef->() };
 	next unless defined $user;
 	print "$user\n";
-	exit;
+	exit EX_SUCCESS;
 	}
 
-exit 1;
+exit EX_FAILURE;
 
 =head1 NAME
 


### PR DESCRIPTION
* Follow OpenBSD and GNU versions of 'whoami' by raising an error if argument count is not zero
* Add symbolic exit codes, as done in other scripts