### PR TITLE
kill: signal number validation

### DIFF
--- a/bin/kill
+++ b/bin/kill
@@ -18,7 +18,6 @@ License:
 
 use strict;
 use Config;
-use integer;
 
 # die if no signals or no arguments
 die "No signals defined ?!?" unless defined $Config{"sig_name"};


### PR DESCRIPTION
* The existing validation for signal-number-too-big doesn't work correctly when "use integer" is enabled
* I tested this with a very large number
* "perl kill -7685876587234234 12" proceeded to kill process 12 incorrectly
* Removing integer pragma fixes this issue for me