### PR TITLE
what: do not read stdin

### DIFF
--- a/bin/what
+++ b/bin/what
@@ -13,33 +13,22 @@ License: perl
 
 use strict;
 
-sub printWhat($$$);
+use Getopt::Std qw(getopts);
 
-my $stop = 0;
-if (($#ARGV >= 0) && ($ARGV[0] eq '-s'))
-{
-    $stop = 1;
-    shift;
-}
+my %opt;
+getopts('s', \%opt) or usage();
+@ARGV or usage();
 
-my $file = "";
-if ($#ARGV < 0) ## use stdin
-{
-    printWhat(\*STDIN,$file,$stop);
-}
-else
-{
-    for my $file (@ARGV)
+for my $file (@ARGV)
     {
         open(FILE, '<', $file) or die "Unable to read $file: $!";
-        printWhat(\*FILE,$file,$stop);
+        printWhat(\*FILE, $file, $opt{'s'});
         close FILE;
     }
-}
 
 #### read open file and print "what" statements...
 #### pass in file handle, file name, and whether to stop printing after 1st "what"
-sub printWhat($$$)
+sub printWhat
 {
     my $file_handle = $_[0];
     my $file_name   = $_[1];
@@ -81,6 +70,11 @@ sub printWhat($$$)
         }
         else { $done = 1; }
     }
+}
+
+sub usage {
+    require Pod::Usage;
+    Pod::Usage::pod2usage({ -exitval => 1, -verbose => 0 });
 }
 
 exit;


### PR DESCRIPTION
* The pod manual doesn't mention reading from standard input
* The version on my OpenBSD system prints usage if no arguments are given
* Standards document describes file argument as being required (no implicit stdin) [1]
* Standards document explicitly says standard input is not used, i.e. no special argument or option to signify stdin
* When testing this I discovered invalid option -x did not raise an error, so add error handling
* Below output is from my linux system: two of the file arguments have patterns to display

1. https://pubs.opengroup.org/onlinepubs/009696799/utilities/what.html

```
%perl what /bin/gprof /bin/bash /bin/echo
/bin/gprof:
         Copyright (c) 1983 Regents of the University of California.
/bin/bash:
        Bash version 5.1.4(1) release GNU
/bin/echo:
```