### PR TITLE
paste: field separator index

### DIFF
--- a/bin/paste
+++ b/bin/paste
@@ -62,14 +62,14 @@ if ($opt{'s'}) {
 		my $tline;
 		while(<$fh>) {
 			chomp;
-			$tline .= $_ . $sep[$current_sep++];
-			$current_sep = 0 if $current_sep == scalar @sep;
+			$tline .= $_ . $sep[$current_sep];
+			$current_sep = ($current_sep + 1) % scalar(@sep);
 		}
 		chop $tline;
 		print "$tline\n";
 		close $fh;
 	}
-	exit;
+	exit EX_SUCCESS;
 }
 
 my $files_still_open = 1;
@@ -89,11 +89,14 @@ while (1) {
 			chomp($line);
 			$tline .= $line;
 		}
-		$tline .= "$sep[$current_sep++]" if $i != $#fh;
-		$current_sep = 0 if $current_sep == scalar @sep;
+		if ($i != $#fh) {
+			$tline .= $sep[$current_sep];
+			$current_sep = ($current_sep + 1) % scalar(@sep);
+		}
 	}
 	print "$tline\n";
 }
+exit EX_SUCCESS;
 
 __END__
 


### PR DESCRIPTION
* $current_sep alternates between the available separator values
* By default only one separator is used, so the (index) value is always 0
* Use mod (%) to wrap the value back to 0; now the value is only modified in one place
* For the default (non -s) mode, line[n] of each file is joined
* Instead of using chop to kill the extra separator (as done in -s code), separator only gets added to line[n] of files before the last
* Having $current_sep++ inside quotes made reading the code annoying
* Test commands produce the same output as GNU paste
* test1: "perl paste -d 'AB' cp cp cp" --> cp^3
* test2: "perl paste -s -d 'AB' yes yes" --> yes^2