### PR TITLE
colrm: accidental $_

### DIFF
--- a/bin/colrm
+++ b/bin/colrm
@@ -54,7 +54,7 @@ if (@ARGV > 2) {
 			print substr $line, 0, $startcol - 1;
 			print substr $line, $endcol;
 		}
-		print "$_\n";
+		print "\n";
 	}
 }
 exit EX_SUCCESS;


### PR DESCRIPTION
* In 2-argument mode, the default variable $_ is not used in the loop
* Adding \n back to line is reversing the chomp at start of loop
* I checked that $_ did not have a value here
* test: "perl colrm 2 2 < file.txt" removes the 2nd character on each line of file.txt