### PR TITLE
cmp: 2-argument minimum

### DIFF
--- a/bin/cmp
+++ b/bin/cmp
@@ -80,19 +80,18 @@ if ($opt{'l'}) {
     $volume = 2;
 }
 $volume = 0 if $opt{'s'};
-usage() unless @ARGV >= 1 and @ARGV <= 3;  # exits;
 
+usage() if (scalar(@ARGV) < 2);
 $file1 = shift;
 $file2 = shift;
-unless (defined $file2) {
-    $file2 = '-';
-}
 $skip1 = skipnum(shift) if @ARGV;
 $skip2 = skipnum(shift) if @ARGV;
+usage() if @ARGV;
 
 if ($file1 eq '-') {
     if ($file2 eq '-') {
-        exit EX_SUCCESS;
+        warn "$Program: standard input is allowed for one argument only\n";
+        exit EX_FAILURE;
     }
     $fh1 = *STDIN;
 }


### PR DESCRIPTION
* Usage string states that file1 and file2 are required
* Standards document indicates file2 is not supposed to be inferred as stdin [1]
* Either file1 or file2 can be specified as '-' for comparison against stdin
* test1: error: no args: perl cmp
* test2: error: bad option: perl cmp -x 
* test3: error: file2 omitted: perl cmp test.txt
* test4: error: two stdins: perl cmp - -
* test5: compare stdin with file bc: echo '#!/user/bing' | perl cmp - bc
* test6: skip 1 byte of file1: perl cmp ar awk 1
* test7: skip 1 byte of file1 and file2: perl cmp ar awk 1 1
* test8: error: too many args: perl cmp ar awk 1 1 1

1. https://pubs.opengroup.org/onlinepubs/009604499/utilities/cmp.html