### PR TITLE
tac: strict.pm coverage

### DIFF
--- a/bin/tac
+++ b/bin/tac
@@ -16,6 +16,8 @@ License: perl
 # tac - concatenate and print files in reverse
 #
 
+use strict;
+
 use File::Basename qw(basename);
 use Getopt::Std qw(getopts);
 
@@ -25,7 +27,8 @@ use constant EX_FAILURE => 1;
 my $Program = basename($0);
 my $VERSION = '0.18';
 
-unless (getopts('bBrs:S:', \my %opts)) {
+my %opts;
+unless (getopts('bBrs:S:', \%opts)) {
     warn "$Program version $VERSION\n";
     warn "usage: $Program [-br] [-s separator] [-B] [-S bytes] [file...]\n";
     exit EX_FAILURE;


### PR DESCRIPTION
* The code at beginning of file was not covered by "strict"
* When adding strict at top of file, %opts was not in global scope
* This patch fixes a bug where options such as -s SEP were being ignored
