### PR TITLE
expand: regex too greedy

### DIFF
--- a/bin/expand
+++ b/bin/expand
@@ -40,7 +40,7 @@ my @tabstops;
 my @files;
 
 # at most one argument
-if($ARGV[0] =~ /-(.*)/) {
+if ($ARGV[0] =~ /\A\-(.+)/) {
     @tabstops = split(/,/, $1);
     usage(1) if grep /\D/, @tabstops; # only integer arguments are allowed
     shift @ARGV;


### PR DESCRIPTION
* This version of expand follows standard and does not treat '-' as stdin [1]
* Unfortunately the regex for the -1,2,3 tab-stop form was matching incorrectly because:
 1) zero characters after '-' were allowed (valid usage requires at least 1 digit after dash)
 2) '-' was allowed to appear after the first character
* With this patch, invalid usage "perl expand - -" fails on the first instance of '-'

1. https://pubs.opengroup.org/onlinepubs/007904975/utilities/expand.html