### PR TITLE
primes: fail for too many args

### DIFF
--- a/bin/primes
+++ b/bin/primes
@@ -27,6 +27,10 @@ END {
   $? = 1 if $? == 255;  # from die
 }
 
+if (scalar(@ARGV) > 2) {
+    require Pod::Usage;
+    Pod::Usage::pod2usage({ -exitval => 1, -verbose => 0 });
+}
 chomp(my $start = @ARGV ? $ARGV[0] : <STDIN>);
 my $end   = $ARGV[1] || 2**32 - 1;
 for ($start, $end) {


### PR DESCRIPTION
* This version of primes takes 0, 1 or 2 arguments
* 0 args: read Start from standard input and use default End
* 1 arg: Start is arg1 and End is default
* 2 args: explicit Start and End
* This patch is compatible with NetBSD, which prints usage if >2 args are given