### PR TITLE
apply: simplify run_cmd()

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -88,13 +88,7 @@ sub run_cmd {
         print join(' ', 'exec', $cmd, @_), "\n";
         return;
     }
-    my $status;
-    if (scalar(@_) > 0) {
-        $status = system $cmd, @_;
-    }
-    else {
-        $status = system $cmd;
-    }
+    my $status = system $cmd, @_;
     if ($status != 0) {
         if ($status == -1) {
             warn "$Program: command failed: $!\n";


### PR DESCRIPTION
* It is safe to pass @_ to system() if @_ is empty
* This happens when running apply with the -0 option
* test: "perl apply -0 echo 1 2 3" --> echo runs 3 times with no argument