### PR TITLE
addbib: -p option handling

### DIFF
--- a/bin/addbib
+++ b/bin/addbib
@@ -13,7 +13,6 @@ License: perl
 
 
 use strict;
-use warnings;
 use Getopt::Std;
 use vars qw($opt_a $opt_p);
 
@@ -34,7 +33,7 @@ my @prompts = (
 		"Keywords:\t%K",
 );
 
-if ($opt_p) {
+if (defined $opt_p) {
 	@prompts = ();
 	open my $PROMPTFILE, '<', $opt_p or die "can't read $opt_p: $!";
 	foreach (<$PROMPTFILE>) {
@@ -113,7 +112,7 @@ while (1) {
 		print "Continue? (y) ";
 		$_ = <>;
 	}
-	last if /^(n|q)/i;
+	last if m/\A[nq]/i;
 }
 
 close $DATABASE or die "can't close $database: $!";


### PR DESCRIPTION
* If file argument '0' was given to the -p option, it was incorrectly ignored
* extra1: remove warnings.pm as done in other scripts
* extra2: simplify prompt input regex by writing it as a character group; found by perlcritic