### PR TITLE
shar: error detected for no files processed

### DIFF
--- a/bin/shar
+++ b/bin/shar
@@ -31,20 +31,20 @@ sub usage {
 }
 
 getopts('') or usage();
+@ARGV or usage();
 binmode STDOUT;
 
-my $dirty = 0;
-ARGUMENT: for my $f ( @ARGV ) {
-    unless ($dirty) {
-	print '# --cut here--
+print '# --cut here--
 # To extract, remove everything before the "cut here" line
 # and run the command "sh file".
 ';
-	$dirty = 1;
-    }
+
+my $done = 0;
+ARGUMENT: for my $f ( @ARGV ) {
     if (-d $f) {
 	print "echo x - $f/\n";
 	print "mkdir -p $f\n";
+	$done++;
 	next ARGUMENT;
     }
     unless (open FH, '<', $f) {
@@ -68,9 +68,9 @@ ARGUMENT: for my $f ( @ARGV ) {
     }
     print "FUNKY_STUFF\n";
     close(FH);
+    $done++;
 }
-
-unless ($dirty) {
+if ($done == 0) {
     warn "$Program: no input files were processed\n";
     exit EX_FAILURE;
 }


### PR DESCRIPTION
* Print usage and exit if no file arguments are given (in docs, at least one file argument is required and standard input is not used)
* Remove variable $dirty for keeping track of whether header was printed; just print it once before loop
* Introduce variable $done to count how many files were processed
* Checking $dirty at end of loop was incorrect; this resulted in printing an error on success and exiting with error code
* test1: "perl shar" --> no args, usage
* test2: "perl shar no-such-file" --> print message "no files were processed"
* test3: "perl shar tar" --> archive one file 'tar' successfully