### PR TITLE
asa: regex too greedy

### DIFF
--- a/bin/asa
+++ b/bin/asa
@@ -14,24 +14,51 @@ License: perl
 
 use strict;
 
-exit 1 if grep {!-r} @ARGV;		# traditional
+use File::Basename qw(basename);
 
-if (grep /-/, @ARGV) {
-	$0 =~ s(.*/)();
-	warn "usage: $0 [filename ...]\n";
-	exit 2;						# traditional
+use constant EX_SUCCESS => 0;
+use constant EX_FAILURE => 1;
+
+my $Program = basename($0);
+
+if (grep /\A\-/, @ARGV) {
+	warn "usage: $Program [file ...]\n";
+	exit EX_FAILURE;
 }
+my $rc = EX_SUCCESS;
+foreach my $file (@ARGV) {
+	next if (-d $file);
+	my $fh;
+	unless (open $fh, '<', $file) {
+		warn "$Program: Can't open '$file': $!\n";
+		$rc = EX_FAILURE;
+		next;
+	}
+	run_file($fh);
 
-while (<>) {
-	chomp;
-	s/^$/ /;
-	s/^[^10+-]/\n/;
-	s/^1/\f/;
-	s/^\+/\r/;
-	s/^0/\n\n/;
-	s/^-/\n\n\n/;
-	print
-		or exit 1;			# traditional
+	unless (close $fh) {
+		warn "$Program: Can't close '$file': $!\n";
+		$rc = EX_FAILURE;
+	}
+}
+unless (@ARGV) {
+	run_file(*STDIN);
+}
+exit $rc;
+
+sub run_file {
+	my $fh = shift;
+
+	while (<$fh>) {
+		chomp;
+		s/^$/ /;
+		s/^[^10+-]/\n/;
+		s/^1/\f/;
+		s/^\+/\r/;
+		s/^0/\n\n/;
+		s/^-/\n\n\n/;
+		print;
+	}
 }
 
 =head1 NAME


### PR DESCRIPTION
* Problem1: asa would refuse to open a file with a dash
* Problem2: if opening a file fails, asa did not proceed to the next file argument
* This patch brings the code closer to NetBSD version [1]
* test1: "echo hi | perl asa" --> no args; read stdin
* test2: "perl asa real-file" --> one file argument; real-file is not a command option
* test3: "perl asa notfound real-file" --> warn for not opening 'notfound', process 'real-file' then exit with code 1 to indicate error

1.  http://cvsweb.netbsd.org/bsdweb.cgi/src/usr.bin/asa/asa.c?annotate=1.17