### PR TITLE
ping: fatal error for unknown options

### DIFF
--- a/bin/ping
+++ b/bin/ping
@@ -17,12 +17,19 @@ use Getopt::Std;
 use Socket;
 use Net::Ping;
 
-my %opt;
-getopts('nI:',\%opt);
-die "Usage: $0 host [timeout]\n" unless @ARGV;
+sub usage {
+    require Pod::Usage;
+    Pod::Usage::pod2usage({ -exitval => 1, -verbose => 0 });
+}
 
+my %opt;
+getopts('nI:', \%opt) or usage();
 my $host = shift;
-my $timeout = (@ARGV) ? shift : 20;
+my $timeout = shift;
+usage() unless defined $host;
+$timeout = 20 unless defined $timeout;
+usage() if @ARGV;
+
 my $a = gethostbyname($host);
 
 if ( $a ) {


### PR DESCRIPTION
* Print usage and exit for invalid option -x
* Include -n flag in usage string
* Throw error if extra arguments appear (closer to BSD version)
* test1: "perl ping" --> error; no host
* test2: "perl ping -x" --> error; no -x flag
* test3: "perl ping 127.0.0.1 10" --> success; localhost with timeout of 10 seconds
* test4: "perl ping 8.8.8.8 10 11" --> error; 11 means nothing