### PR TITLE
tee: '--' option terminator

### DIFF
--- a/bin/tee
+++ b/bin/tee
@@ -19,6 +19,7 @@ License: perl
 
 while ($ARGV[0] =~ /^-(.+)/ && (shift, ($_ = $1), 1)) {
     next if /^$/;
+    last if $_ eq '-'; # '--' terminator
     s/i// && (++$ignore_ints, redo);
     s/a// && (++$append,      redo);
     s/u// && (++$unbuffer,    redo);


### PR DESCRIPTION
* The following command works the same on Linux and OpenBSD: "tee -- -mylog"
* The argument list contains one file called "-mylog"; it's not an option as it appears after '--'
* Perl code has a custom option parser so it needs to handle '--' directly