### PR TITLE
unshar: '--' option terminator

### DIFF
--- a/bin/unshar
+++ b/bin/unshar
@@ -20,6 +20,7 @@ License: perl
 
 while (@ARGV && $ARGV[0] =~ s/^-//) {
     local $_ = shift;
+    last if $_ eq '-'; # '--' terminator
     while (/([cdfq])/g) {
 	if ($1 eq 'd') {
 	    $opts{'d'} = /\G(.*)/g && $1 ? $1 : shift;


### PR DESCRIPTION
* I noticed that shar works with command line "perl shar -- -file1", but unshar doesn't
* There was no unshar command on my Linux or OpenBSD system to test against
* I installed gnu sharutils 4.15.2 and proved that it does support '--'

/usr/bin/unshar -- -file1
fs error 2 (No such file or directory) stat-ing -file1