### PR TITLE
col: buffering code broken

### DIFF
--- a/bin/col
+++ b/bin/col
@@ -121,31 +121,6 @@ while (<>) {
 
         # start row if necessary
         $buf[$row] ||= [];
-
-        # check buffer size
-        if (@buf > $opt_l) {
-            print_line(0);
-
-            if ($buf[1] and @{$buf[1]}) {
-                # print next half line
-                print "\e9";
-                print "\x0D" if !$front;
-                $front = 1;
-
-                print_line(1);
-                print "\e9";
-                print "\x0D" if !$front;
-            } else {
-                # skip to next full line
-                print "\x0A";
-            }
-            $front = 1;
-
-            # splice off top two rows
-            splice(@buf, 0, 2);
-            $max_row -= 2;
-        }
-
     }
 }
 


### PR DESCRIPTION
* I observed strange output from col when the input file was large
* Finally I discovered the issue is related to code that runs when the buffer fills up
* The input loop adds lines to a buffer which are printed in a subsequent loop; however, the buffer code triggers early printing within the input loop
* I could reproduce error earlier by setting a smaller buffer size with -l:  "perl col -l 5 ching"
* The pod manual says -l buffers at least n lines of input
* I propose ignoring -l and buffering the whole file, this at least doesn't result in a runtime error
* Correct buffer management code could be investigated later