### PR TITLE
ar: runtime error for bad args

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -34,7 +34,9 @@ $opt_b |= $opt_i;
 # extract position offset
 my $position;
 if ($opt_a || $opt_b) {
-    $position = basename(shift);
+    my $val = shift;
+    usage() unless defined $val;
+    $position = basename($val);
 }
 
 # the archive filename


### PR DESCRIPTION
```
%perl ar -a -x
Uncaught exception from user code:
	fileparse(): need a valid pathname at ar line 40.
	File::Basename::fileparse(undef) called at /usr/local/lib/perl5/5.34.1/File/Basename.pm line 222
	File::Basename::basename(undef) called at ar line 40
```
* Flags -a and -b require extra position value in ARGV; if this is missing it is reasonable to print usage and exit