### PR TITLE
cut: -f not allowed with -b

### DIFF
--- a/bin/cut
+++ b/bin/cut
@@ -27,6 +27,7 @@ getopts('b:c:d:f:ns', \%opt) or usage();
 # There's no difference between -b and -c on any unix I
 # use regularly -- it's for i18n. Thus, -n is a noop, too.
 $opt{b} = $opt{c} if defined $opt{c};
+usage() if $opt{'b'} && $opt{'f'};
 
 handle_b() if $opt{b};
 handle_f() if $opt{f};


### PR DESCRIPTION
* Invalid usage resulted in undocumented behaviour; "perl cut -b 1 -f 1" would run handle_b(), exit and ignore "-f 1"
* GNU and OpenBSD versions fail in this case because only one of -b and -f can be specified
* For Perl version, option -c is an alias for -b, so add validation check after equivalence code for -c