### PR TITLE
sum: ambiguous options

### DIFF
--- a/bin/sum
+++ b/bin/sum
@@ -42,6 +42,7 @@ if ($Program =~ m/cksum/) {
 	$alg = \&sum1;
 }
 if (defined $opt{'a'}) {
+	help() if defined $opt{'o'};
 	my %codetab = (
 		'crc'    => \&crc32,
 		'md5'    => \&do_md5,


### PR DESCRIPTION
* This version of sum attempts to be compatible with NetBSD by offering -o 1 and -o 2 for the historic BSD and SYSV sum algorithms respectively
* When -o is used for selecting an algorithm, forbid -a option which is used for selecting newer algorithms such as md5