### PR TITLE
ed: simplify edSetCurrentLine()

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -860,7 +860,7 @@ sub edQuit {
 sub edSetCurrentLine {
     if (defined($args[0])) {
         edWarn(E_ARGEXT);
-        return;
+        return 0;
     }
 
     my $adr = $adrs[1];
@@ -868,24 +868,17 @@ sub edSetCurrentLine {
         $adr = $adrs[0];
     }
     if (defined($adr)) {
-
-        # user gave us a line, go to it
-        if ($adr <= maxline() && $adr > 0 && maxline() != 0) {
-            $CurrentLineNum = $adr;
-        } else {
+        if ($adr <= 0 || maxline() == 0 || $adr > maxline()) {
             edWarn(E_ADDRBAD);
             return 0;
         }
-
+        $CurrentLineNum = $adr; # jump to specified line
     } else {
-
-        # simply increment the line
-        if ($CurrentLineNum < maxline()) {
-            $CurrentLineNum++;
-        } else {
+        if ($CurrentLineNum == maxline()) {
             edWarn(E_ADDRBAD);
             return 0;
         }
+        $CurrentLineNum++;
     }
 
     print $lines[$CurrentLineNum];


### PR DESCRIPTION
* Code can be reduced by checking for error instead of checking for success
* Style: consistently return 1 or 0 (return value is not currently checked)
* test1: open file with "perl ed awk", then hit return/enter to proceed to maxline+1 (error for increment case)
* test2: open file with "perl ed awk", then type "1" (success for jump case)
* test3: open file with "perl ed awk", then type "10" then hit extra return (success for increment case after jump to 10)
* test4: open file with "perl ed awk", then type "1000" (error for jump case; line number out of range)
