### PR TITLE
glob: handle bare tilde

### DIFF
--- a/bin/glob
+++ b/bin/glob
@@ -227,8 +227,14 @@ sub match_glob($) {
                        ? (getpwnam($usr))[7]
                        : (defined $ENV{HOME} ? $ENV{HOME}
                                              : (getpwuid($<))[7]);
-        $usrdir && s/^\~\Q$usr\E/$usrdir/ && $usr
-            or push @errors, "Unknown user: $usr";
+        push @errors, "Unknown user: $usr" unless $usrdir;
+
+        if (length $usr) {
+            s/\A\~\Q$usr\E/$usrdir/;
+        }
+        else {
+            s/\A\~/$usrdir/;
+        }
     }
 
     # If there's no wildcards, just return it


### PR DESCRIPTION
* A tilde by itself signifies $HOME if it is not followed by a username
* I regularly type "cd ~/somedir" but an error was being raised by this version of glob
* Splitting the code into separate regexps makes this a bit clearer
* With this patch the output matches the following globs from bash
* test1: "echo ~" --> /home/pi
* test2: "echo ~/" --> /home/pi/
* test3: "echo ~pi" --> /home/pi
* test4: "echo ~pi/" --> /home/pi/
* This also matches output from perl's glob() on my system