### PR TITLE
expand: single tabstop correction

### DIFF
--- a/bin/expand
+++ b/bin/expand
@@ -101,7 +101,7 @@ sub expand_line {
 		if(defined($line_desc{$curs})) {
 		    $incr = $line_desc{$curs};
 		} else { # Jupiter, and beyond the infinite
-		    $incr = 1;
+		    $incr = $tabstop;
 		}
 	    } else {
 		$incr = $curs%$tabstop ? ($tabstop - $curs%$tabstop)


### PR DESCRIPTION
* The default number of spaces for a tab is 8
* The number of spaces is changed by running something like "perl expand -12 file", but when doing this I get one space not 12
* line_desc is only set if multiple tabstops were specified (not relevant to this usage)
* When one tabstop is given, e.g. "expand -12 file", $tabstop has been updated and we should use its value
* Now -12 argument works the same as OpenBSD and GNU version