### PR TITLE
id: don't ignore extra arguments

### DIFF
--- a/bin/id
+++ b/bin/id
@@ -32,6 +32,7 @@ if ( ($opt_G + $opt_g + $opt_p + $opt_u) > 1 ) {
 my($user,$pw,$uid,$gid,$tp);
 
 if ( @ARGV ) { # user specified
+	help() if scalar(@ARGV) > 1;
 	($user,$pw,$uid,$gid) = getpwnam $ARGV[0];
 	if (!defined($uid) && $ARGV[0] =~ m/\A[0-9]+\Z/) {
 		($user,$pw,$uid,$gid) = getpwuid $ARGV[0];


### PR DESCRIPTION
* This version of id follows BSD and only supports one user argument
* Instead of ignoring extra arguments, print usage and exit as done by OpenBSD version
* test1: valid usage: "perl id 0" --> display root user on my Linux system
* test2: invalid usage: "perl id 0 0 0 0 0" --> previously did not raise error
* test3: valid usage: "perl id" --> user taken as "current user"