### PR TITLE
ar: file header not printed for -q

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -16,6 +16,8 @@ use File::Basename;
 use FileHandle;
 use Getopt::Std qw(getopts);
 
+use constant MAGIC => "!<arch>\n";
+
 # allow the first arg to not have a '-'.
 if ($ARGV[0] !~ /^\-/) { $ARGV[0] = '-' . $ARGV[0]; }
 
@@ -276,7 +278,7 @@ sub readAr {
     # read magic
     my $magic;
     read($arfh,$magic,8);
-    if ($magic ne "!<arch>\n") {
+    if ($magic ne MAGIC) {
 	die "$0: $archive: Inappropriate file type or format\n";
     }
 
@@ -332,14 +334,11 @@ sub readAr {
 sub writeAr {
     my ($pAr, $pNames, $archive, $append) = @_;
 
-    my $arfh;
-    if (!defined($append)) {
-	$arfh = FileHandle->new($archive, 'w') or die "$0: $archive: $!\n";
-	$arfh->print("!<arch>\n");
-    }
-    else {
-	$arfh = FileHandle->new($archive, 'a') or die "$0: $archive: $!\n";
-    }
+    my $mode = $append ? 'a' : 'w';
+    my $putmagic = !$append || !-e $archive;
+    my $arfh = FileHandle->new($archive, $mode)
+      or die "$0: failed to open '$archive': $!\n";
+    $arfh->print(MAGIC) if $putmagic;
 
     # loop through each member of the archive and write to filehandle
     for my $group (@$pNames) {


### PR DESCRIPTION
* In quick-append mode (-q), ar creates a file if it doesn't exist and appends to a file if it exists
* I discovered that if a file is created in this way, the valid header record is not printed, making the archive invalid
* GNU ar is smart enough to print file header in this case
* step1: quickly create archive with one file: perl ar -q new.ar addbib 
* step2: append another file to archive: perl ar -q new.ar asa
* step3: list files in archive: perl ar -t new.ar