### PR TITLE
ln: single argument usage

### DIFF
--- a/bin/ln
+++ b/bin/ln
@@ -66,6 +66,13 @@ foreach my $file (@ARGV) {
         $rc = EX_FAILURE;
     }
 }
+unless (@ARGV) {
+    my $newfile = basename($target);
+    unless (dolink($target, $newfile)) {
+        warn "$Program: failed to link '$target' to '$newfile': $!\n";
+        $rc = EX_FAILURE;
+    }
+}
 exit $rc;
 
 sub usage {


### PR DESCRIPTION
* Short-hand usage of ln on Linux and OpenBSD: "ln -s /etc/hosts" creates a symbolic link "hosts" in the current directory
* This version of ln did not enter files loop if only 1 argument is given
* test1: "perl ln -s awk" --> fail because awk already exists in current directory
* test2: "perl ln -s /etc/not-exists" --> successfully creates a synlink to a non-existent file
* test3: "perl ln -s /etc/hosts"