### PR TITLE
od: duplicate marker incorrectly repeats

### DIFF
--- a/bin/od
+++ b/bin/od
@@ -142,15 +142,15 @@ sub emit_offset {
 }
 
 sub dump_line {
-    $ml = ''; # multi-line indention
     if (&diffdata || $opt_v) {
 	emit_offset();
 	&$fmt;
-	printf("%s$strfmt\n", $ml, @arr);
-	$ml = ' ' x 9;
+	printf "$strfmt\n", @arr;
+	$ml = 0;
     }
     else {
-	print "*\n";
+	print "*\n" unless $ml;
+	$ml = 1;
     }
     $lastline = $data . '|';
     $offset1 += length $data;


### PR DESCRIPTION
* I noticed the duplicate line identifier "*\n" was repeated for each duplicate line, instead of being printed only once
* In dump_line() the variable $ml had no effect; possibly it was broken by previous changes
* Make $ml a flag which is set when previous line was duplicate *and* "*\n" was already printed; flag is set until a line differs
* With this patch, output is equivalent when dumping /dev/zero on OpenBSD and Linux

```
%dd if=/dev/zero bs=1000 count=1 2> /dev/null | perl od -c 
00000000  \0  \0  \0  \0  \0  \0  \0  \0  \0  \0  \0  \0  \0  \0  \0  \0 
*
00001740  \0  \0  \0  \0  \0  \0  \0  \0 
00001750
```
