### PR TITLE
unexpand: -- option terminator

### DIFF
--- a/bin/unexpand
+++ b/bin/unexpand
@@ -39,19 +39,21 @@ my $opt_a = 0;
 my @tabstops;
 my @files;
 
-my $arg;
-while($arg = shift @ARGV) {
-    if($arg eq '-a') {
+while (@ARGV && $ARGV[0] =~ /\A\-(.+)/) {
+    my $val = $1;
+    if ($val eq '-') { # '--' terminator
+	shift @ARGV;
+	last;
+    }
+    if ($val eq 'a') {
 	$opt_a = 1;
-	next;
-    }
-    if($arg =~ /^-(.*)/) {
-	@tabstops = split(/,/, $1);
+    } else {
+	@tabstops = split /,/, $val;
 	usage() if grep /\D/, @tabstops;
-	next;
     }
-    push @files, $arg;
+    shift @ARGV;
 }
+@files = @ARGV;
 
 # $tabstop is used only if multiple tab stops have not been defined
 $tabstop = $tabstops[0] if scalar @tabstops == 1;


### PR DESCRIPTION
* This was identified when testing against GNU version
* Rewrite option parser to align with bin/expand; global $arg variable is not needed
* Example valid usage: "perl unexpand -a -2 -- -a" --> tabstop=2, aflag=1, read file "-a"
* Example bad usage: "perl unexpand -x -2 3" --> no -x