### PR TITLE
ar: warn if archive member isn't found

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -179,10 +179,13 @@ exit 0;
 sub printMember {
     my ($name, $pAr, $verbose) = @_;
 
-    print "\n<$name>\n\n" if $verbose;
-
-    # dump the data
-    print $pAr->{$name}[6];
+    if (exists $pAr->{$name}) {
+	print "\n<$name>\n\n" if $verbose;
+	print $pAr->{$name}[6];
+    }
+    else {
+	warn "entry not found in archive: '$name'\n";
+    }
 }
 
 # writes a directory-style listing for the specified archive member


### PR DESCRIPTION
* ar -p mode with no arguments prints all members of the archive to standard output
* ar -p can be given explicit member names to print
* If I type the wrong member name GNU ar gives me a warning and proceeds to print the next member argument
* Example: "perl ar -p new.ar notfound asa" --> print warning on stderr for notfound not being found, then print content of file asa on stdout