### PR TITLE
join: '--' option terminator

### DIFF
--- a/bin/join
+++ b/bin/join
@@ -250,6 +250,7 @@ sub get_field_specs {
 sub get_options {
   while (@ARGV && $ARGV[0] =~ /^-(.)/) {
     local $_ = shift @ARGV;
+    return if $_ eq '--';
     if    (/^-[h?]$/)  { help() }        # terminates
     elsif (s/^-a//) {
       my $f = get_file_number('a');


### PR DESCRIPTION
* This was found when testing against the GNU version of join
* Add handling to custom option parser get_options()
* test: "cp awk ./-a && perl join -- -a -a | md5sum" --> join file "-a" with itself