### PR TITLE
ar: add strict

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -11,6 +11,8 @@ License: perl
 
 =cut
 
+use strict;
+
 use POSIX qw(strftime);
 use File::Basename;
 use FileHandle;
@@ -18,15 +20,18 @@ use Getopt::Std qw(getopts);
 
 use constant MAGIC => "!<arch>\n";
 
+use vars qw($opt_d $opt_m $opt_p $opt_q $opt_r $opt_t $opt_x $opt_a $opt_b
+    $opt_c $opt_i $opt_o $opt_u $opt_v);
+
 # allow the first arg to not have a '-'.
-if ($ARGV[0] !~ /^\-/) { $ARGV[0] = '-' . $ARGV[0]; }
+if (@ARGV && $ARGV[0] !~ /^\-/) { $ARGV[0] = '-' . $ARGV[0]; }
 
 getopts('dmpqrtxabciouv') or usage();
 
 # take only one of the following major opts
-if (($opt_d + $opt_m + $opt_p + $opt_q + $opt_r + $opt_t + $opt_x) != 1) {
-    usage();
-}
+my @major = map { $_ || () } ($opt_d, $opt_m, $opt_p, $opt_q, $opt_r,
+    $opt_t, $opt_x);
+usage() unless scalar(@major) == 1;
 
 # -i is the same as -b
 $opt_b |= $opt_i;


### PR DESCRIPTION
* ar was mostly compliant with strict except for option variables
* Instead of summing $opt_d, $opt_m etc (which might be undefined), count options using a list
* Don't access $ARGV[0] if it doesn't exist
* test1: "perl ar" --> invalid: need a major option to determine mode
* test2: "perl ar x notfound" --> valid: equivalent to ar -x notfound
* test3: "perl ar -x -m" --> invalid: -m and -x are not compatible