### PR TITLE
bc: regression on old perl

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2034,10 +2034,10 @@ sub command_line()
   while (@ARGV) {
     my $f = shift @ARGV;
     if ($f eq '-b') {
-      require Math::BigFloat;
+      eval { require Math::BigFloat } or die "This program requires the Math::BigFloat module\n";
       $bignum = 1;
     } elsif ($f eq '-d') {
-      require Data::Dumper;
+      eval { require Data::Dumper } or die "This program requires the Data::Dumper module\n";
       $debug = 1;
     } elsif ($f eq '-y') {
       $yydebug = 1;

--- a/bin/bc
+++ b/bin/bc
@@ -2034,10 +2034,10 @@ sub command_line()
   while (@ARGV) {
     my $f = shift @ARGV;
     if ($f eq '-b') {
-      use Math::BigFloat;
+      require Math::BigFloat;
       $bignum = 1;
     } elsif ($f eq '-d') {
-      use Data::Dumper;
+      require Data::Dumper;
       $debug = 1;
     } elsif ($f eq '-y') {
       $yydebug = 1;


### PR DESCRIPTION
* The default mode of this bc is not bc at all because it is not arbitrary precision; numbers are just perl floating point values
* It's still useful enough as a basic calculator, but not as a bc-compatible one
* For fun I booted DamnSmallLinux live-cd v4.4.10
* The version of perl on this old linux doesn't include Math::BigFloat
* bc would not load, even in default mode because of a "use" statement; lazy-load with "require" avoids the error
* test1: "perl bc" --> load in not-arbitrary-precision mode and 2**128/33333 is a perl floating point number
* test2: "perl bc -b" --> fail to load Math::BigFloat on old perl