### PR TITLE
kill: list signals for bad sig name

### DIFF
--- a/bin/kill
+++ b/bin/kill
@@ -21,27 +21,14 @@ use Config;
 
 # die if no signals or no arguments
 die "No signals defined ?!?" unless defined $Config{"sig_name"};
-die "$0: Too few arguments; try $0 -h\n" unless ( @ARGV );
+usage() unless @ARGV;
 
 my(@signals) = split(/\s+/,$Config{"sig_name"});
 my(%hsignals) = map { $_ => 1 } @signals;
 my($signal) = "TERM"; # default of SIGTERM
 
 if ( $ARGV[0] =~ /^-l$/i ) { # list signals
-	for(my($i)=1;$i<=$#signals;$i++){
-		printf "%2d:%-6s%s",$i,$signals[$i],
-			( ($i % 8 == 0) || ($i == $#signals) )?"\n":" ";
-	}
-	exit 0;
-}
-elsif ( $ARGV[0] =~ /^-h$/i ) { # help me!
-	print "usage:  $0 [-s signalname] PIDS ...
-	$0 [-signalname] PIDS ...
-	$0 [-signalnumber] PIDS ...
-	$0 PIDS ...
-	$0 [-l]
-	$0 [-h]
-";
+	siglist();
 	exit 0;
 }
 elsif ( $ARGV[0] =~ /^-\d+$/ ) { # -signalnumber
@@ -55,8 +42,11 @@ elsif ( $ARGV[0] =~ /^-/ ) { # -NAME or -s NAME
 	$signal = shift @ARGV if ( lc $signal eq "s" ); # -s has signalname param.
 	$signal = uc $signal;
 	$signal =~ s/^SIG//; # remove the "SIG" from SIGNAME
-	die "$0: $signal: Unknown signal; $0 -l lists signals.\n"
-		unless ( $hsignals{$signal} );
+	unless ($hsignals{$signal}) {
+		print "$0: $signal: Unknown signal; valid signals...\n";
+		siglist();
+		exit 1;
+	}
 }
 
 die "$0: No PIDs specified.\n" unless ( @ARGV );
@@ -71,6 +61,23 @@ foreach ( @ARGV ) { # do the kills...
 
 exit $ret;
 
+sub usage {
+	print "usage:  $0 [-s signalname] PID...
+	$0 [-signalname] PID...
+	$0 [-signalnumber] PID...
+	$0 PID...
+	$0 [-l]
+";
+	exit 1;
+}
+
+sub siglist {
+	for(my($i)=1;$i<=$#signals;$i++){
+		printf "%2d:%-6s%s",$i,$signals[$i],
+			( ($i % 8 == 0) || ($i == $#signals) )?"\n":" ";
+	}
+}
+
 =head1 NAME
 
 kill - send signals to a process
@@ -78,12 +85,11 @@ kill - send signals to a process
 =head1 SYNOPSIS
 
 B<kill>
-[ B<-s> I<signalname> C<PIDS ...> ]
-[ B<-signalname> C<PIDS ...> ]
-[ B<-signalnumber> C<PIDS ...> ]
-[ C<PIDS ...> ]
+[ B<-s> I<signalname> C<PID...> ]
+[ B<-signalname> C<PID...> ]
+[ B<-signalnumber> C<PID...> ]
+[ C<PID...> ]
 [ B<-l> ]
-[ B<-h> ]
 
 =head1 DESCRIPTION
 
@@ -105,8 +111,6 @@ to be sent to the specified PIDs.
 should be sent to the specified PID listing.
 
 =item I<-l>	Display a listing of all available signals on the current system.
-
-=item I<-h>	Display the usage help message.
 
 =back
 


### PR DESCRIPTION
* version1: bash: "builtin kill -h" --> "invalid signal specification" error
* version2: GNU: "/usr/bin/kill -h" --> prints usage string
* version3: pdksh: "builtin kill -h" --> "unknown option" error
* version4: OpenBSD: "/bin/kill -h" --> "unknown signal" error, then print signal list
* To me, version4 is the most helpful because it saves the user having to type "kill -l" to see the list
* test1: "perl kill" --> no pid given; print usage
* test2: "perl kill -h" --> print error, show signal list, exit(1)
* test3: "perl kill -l" --> show signal list, exit(0)
* test4: "perl kill 1" --> fails as expected because my user doesn't have permission to kill init process