### PR TITLE
du: warn on stat() failure

### DIFF
--- a/bin/du
+++ b/bin/du
@@ -57,8 +57,10 @@ sub traverse {
   my $total = 0;
   local $depth = $depth + 1;
   my @s = ($opt_L || $opt_H && $depth == 1) ? stat $fn : lstat $fn;
-  # If we can't stat the file, return silently
-  return 0 unless @s;
+  unless (@s) {
+    warn "$0: cannot access '$fn': $!\n";
+    return 0;
+  }
   # Check for cross-filesystem traversals (-x option)
   if ($depth == 1) {
     $filesystem = $s[0];


### PR DESCRIPTION
* du can take a number of file arguments
* GNU and OpenBSD versions will print a warning if a file fails to stat, then proceed to the next file
* test: "touch there1 there2 && perl du nothere1 nothere2 there1 there2" --> two warning lines and two du summary lines