### PR TITLE
bc: assign '=' should not print

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2518,6 +2518,7 @@ sub exec_stmt
      $sym_table{$varName} = { type => 'var',
 			      value => $value };
      push(@ope_stack, $value);
+     $return = 1; # do not print result
      next INSTR;
 
    } elsif($_ eq '=P') {


### PR DESCRIPTION
* Previously this change was committed for internal =P instruction, which runs when assigning an array value, e.g. "ary[0] = 1"
* Apply the same change to the =V instruction, for regular variable assignments
* Instruction =V happens for shortcut assignment operators too
* This patch makes bc agree with GNU version and Gavin Howard version

x = 1
x += 2
x -= 1
x *= 4
x /= 2
x ^= 2