### PR TITLE
bc: remove non-standard '**' operator

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2224,13 +2224,10 @@ sub yylex
 	    $IDENT;
 	  }
 
-	} elsif (($char eq '*' && $line =~ s/^\*=//) or
-                 ($char eq '^' && $line =~ s/=//)) {
+	} elsif ($char eq '^' && $line =~ s/=//) {
 	    $EXP_EQ;
-	} elsif (($char eq '*' && $line =~ s/^\*//) or
-                 ($char eq '^')) {
+	} elsif ($char eq '^') {
 	    $EXP;
-
 	} elsif ($char eq '|' && $line =~ s/^\|//) {
 	    $O_O;
 	} elsif ($char eq '&' && $line =~ s/^&//) {


### PR DESCRIPTION
* In yylex(), '^' and '**' are both tokenised as $EXP
* Also, '^=' and '**=' are both tokenised as $EXP_EQ
* Operators '**' and '**=' are not part of standard bc grammar so remove them [1]
* Tested against GNU, OpenBSD and Gavin Howard versions of bc

1. https://pubs.opengroup.org/onlinepubs/9699919799/utilities/bc.html

Example input:
2 ^ 8
a = 2
a ^= 8
a