### PR TITLE
mail: overloaded hostname() definition

### DIFF
--- a/bin/mail
+++ b/bin/mail
@@ -41,7 +41,7 @@ package
 @ISA=qw(PerlPowerTools::mailprog);
 
 use IO::Socket;
-use Sys::Hostname;   # Claims to be standard?
+use Sys::Hostname qw();
 
 %mailer::fields=(
 	  user => undef,
@@ -83,7 +83,7 @@ sub new {
 		}
 		# Find my address...
 		if (! defined $ENV{HOSTNAME}) {
-			my $hostname=hostname();
+			my $hostname = Sys::Hostname::hostname();
 			if (! $hostname) {
 				die "Unable to find a reasonable hostname.  Use \$HOSTNAME.\n";
 			}


### PR DESCRIPTION
* In package "mailer", hostname() is a setter method for object attribute "hostname" (L48)
* Sys::Hostname auto-imports a hostname() which causes a conflict; as a result I cannot send a mail message with 'm' command
* Prevent auto-import of Sys::Hostname symbols to resolve this

```
%perl mail
Loading the mailfile /home/pi/mbox
Mail [0.02 Perl] [linux]
 N  1                                    154/ 904 (no subject)
    2           nobody  Mon Sep 17 00:00  41/1036 [PATCH] another patch
    3           nobody  Mon Sep 17 00:00  32/ 706 re: [PATCH] another patch
    4           nobody  Sat Aug 27 23:07 120/3138 [PATCH 1/2] GIT: Try all addr
    5           nobody  Sat Aug 27 23:07 107/3764 [PATCH] Fixed two bugs in git
    6           nobody  Mon Sep 17 00:00  72/2926 [PATCH] a commit.
    7           nobody  Mon Sep 17 00:00   8/ 194 [PATCH] another patch
    8           nobody  Mon Sep 17 00:00  12/ 297 re: [PATCH] another patch
    9           nobody  Mon Sep 17 00:00  24/ 866 (no subject)
   10 b9704a518e211584  Mon Sep 17 00:00  36/1214 Re: discussion that lead to t
   11           nobody  Fri Aug  8 22:24  37/ 905 [PATCH 3/3 v2] Xyzzy
   12    bda@mnsspb.ru  Wed Nov 12 17:54  53/1727 [Navy-patches] [PATCH]	=?utf-
   13           nobody  Mon Sep 17 00:00   7/ 152 [PATCH] a patch
   14           nobody  Mon Sep 17 00:00  90/2363 Why doesn't git-am does not l
   15           nobody  Mon Sep 17 00:00  17/ 304 check bogus body header (from
   16           nobody  Mon Sep 17 00:00  18/ 296 check bogus body header (date
> m
Subject: hey
yo
.
hostname() does not accepts arguments (it used to silently discard any provided) at mail line 90.
```