### PR TITLE
test: exit(1) for no argument

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -228,7 +228,7 @@ sub test (@) {
     return ($@) ? undef : 0+$result;
 }
 
-exit(2) if (@ARGV == 0);
+exit(1) if (@ARGV == 0);
 my $rc = test @ARGV;
 
 ## For command-lines, zero is success and non-zero is false, so


### PR DESCRIPTION
* The wording of standards document is "exit 1 if expression evaluates to false, or if expression is missing"
* A usage example might be "if [ $xyz ]" in a shell script; unquoted variable will substitute to empty string if not set so no argument is passed to test command
* 4 different versions of test exit(1) consistently for this case: pdksh builtin, bash builtin, /usr/bin/test on Linux and /bin/test on OpenBSD

1. https://pubs.opengroup.org/onlinepubs/009695399/utilities/test.html