### PR TITLE
bc: forbid negative array index

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2459,10 +2459,14 @@ sub exec_stmt
      next INSTR;
 
    } elsif($_ eq 'P') {
-
-	 my $value = pop @ope_stack;
-	 my $index = pop @ope_stack;
-	 push @ope_stack, $value;
+     my $index = splice @ope_stack, -2, 1; # rval remains top of stack
+     if($index !~ /^\d+$/) {
+       print STDERR "Non-integer index $index for array\n";
+       $return = 3;
+       @ope_stack = ();
+       @stmt_list=();
+       last INSTR;
+     }
      push @ope_stack, $instr->[1] . '[]' . $index;
      next INSTR;
 
@@ -2489,7 +2493,7 @@ sub exec_stmt
        $return = 3;
        @ope_stack = ();
        @stmt_list=();
-       YYERROR;
+       last INSTR;
      }
 
 #     debug {"p: $name, $idx.\n"};


### PR DESCRIPTION
* Negative array index is being caught when accessing a value (p instruction), but is not caught when assigning a value (P instruction)
* Adapt existing guard code from 'p' instruction
* For consistency with undefined-function error, replace YYERROR call with "last INSTR"
* Only the 2nd-from-top ope_stack element is needed; fetch it with splice instead of pop+push dance for $value

```
%perl bc -d # before patch
ary[-1]
instruction: N, 1
instruction: m_
instruction: p, ary
Non-integer index -1 for array

ary[-1] = 123
instruction: N, 1
instruction: m_
instruction: N, 123
instruction: P, ary
instruction: =P
wat
```