### PR TITLE
bc: array name versus digits

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2519,7 +2519,7 @@ sub exec_stmt
      $sym_table{$varName} = { type => 'var',
 			      value => $value };
      push(@ope_stack, $value);
-     $return = 1; # do not print result
+     $return = 3; # do not print result
      next INSTR;
 
    } elsif($_ eq '=P') {
@@ -2537,7 +2537,7 @@ sub exec_stmt
      $sym_table{$name}{'value'}[$idx] = { type => 'var',
 					  value => $value };
      push(@ope_stack, $value);
-     $return = 1; # do not print result
+     $return = 3; # do not print result
      next INSTR;
 
    } elsif($_ eq 'IF') {

--- a/bin/bc
+++ b/bin/bc
@@ -2526,8 +2526,7 @@ sub exec_stmt
 
      my $varName = pop(@ope_stack);
      my $value = pop(@ope_stack);
-     my ($name, $idx) = ($varName =~ /([a-z]+)\[\](\d+)/);
-
+     my ($name, $idx) = split /\[\]/, $varName, 2;
      $name .= '[]';
      unless (defined($sym_table{$name})
 	     and $sym_table{$name}{'type'} eq 'array')

--- a/bin/bc
+++ b/bin/bc
@@ -2730,7 +2730,7 @@ sub exec_stmt
 
 #     debug {"breaking.\n"};
 
-     $return = 2;
+     $return = 1;
      push(@ope_stack, 0);
 
      last INSTR;


### PR DESCRIPTION
* Array names are allowed to contain numeric digits but cannot start with a digit: ary2 is valid but 2ary is not
* Assigning then fetching an array value didn't work as expected
* I got a hint when adding debug statement to the =P instruction: "name[[]] idx[] varName[ary2[]1] at bc.y line 982, <STDIN> line 2." 
* The regex did not match because varName is "ary2[]1"; the regex expected that a digit would only be found after the "[]" substring
* Make the code more correct by splitting on "[]" to get the array name "ary2" and the index of "1"
* varName string is built earlier by the P instruction

```
%perl bc -d # before patch
ary2[0] = 1
instruction: N, 0
instruction: N, 1
instruction: P, ary2
instruction: =P

ary2[0]
instruction: N, 0
instruction: p, ary2
0
```