### PR TITLE
awk refuses to use a2p

### DIFF
--- a/bin/awk
+++ b/bin/awk
@@ -17,12 +17,6 @@ License: perl
 
 use strict;
 
-SANITY: {
-	my $external_module = 'App::a2p';
-	my $rc = eval "require $external_module; $external_module->import; 1";
-	die "This program needs the $external_module module.\n" unless $rc;
-	}
-
 my(
     $program,		# the code to eval
     $tmpin, 		# the files a2p reads
@@ -80,11 +74,6 @@ while (@ARGV) {
 	    unless (length) { shift; $_ = shift; }
 	    push(@nargs, $_);
 	    last;
-	}
-	elsif (s/^-//) {
-	    if (length) { usage("Long options not supported") }
-	    shift;
-	    next;
 	}
 	else {
 	    usage("unknown flag: -$_");


### PR DESCRIPTION
* My Linux system has perl 5.32.1, and I installed App::a2p under it using cpanm
* Now my system has /usr/local/bin/a2p command available
* I built a newer version of perl; now one perl has App::a2p and the other doesn't
* This version of awk does not use App::a2p, it only runs the command a2p
* The SANITY check was not sane because both perls are able to run a2p, but the awk wrapper refuses on one perl because of App::a2p check
* Delete the SANITY code; there is already a check if a2p fails to run so this is good enough
* Also remove the too-helpful error check for long options; users will still see "unknown flag" error which clearly communicates that the option can't be used
* With patch applied, both perls can run my trivial awk script
```
%cat test.awk
BEGIN {
 printf("\n");
}
%perl5.32.1 awk -f test.awk | xxd
00000000: 0a                                       .
%perl5.34.1 awk -f test.awk | xxd 
00000000: 0a                                       .
```
