### PR TITLE
awk: remove temporary files

### DIFF
--- a/bin/awk
+++ b/bin/awk
@@ -131,6 +131,7 @@ if ($@) {
     die "Couldn't compile and execute awk-to-perl program: $@\n";
 }
 
+unlink $tmpin, $tmpout;
 exit 0;
 
 __END__


### PR DESCRIPTION
* awk wrapper doesn't clean up after itself and I am left with all these spam files... a2pin.6695 a2pout.6695 a2pin.6697 a2pout.6697 a2pin.6699 a2pout.6699 a2pin.6702 a2pout.6702 a2pin.6951 a2pout.6951 a2pin.6953 a2pout.6953
* unlink before exit is better, whether or not the files are written in /tmp