### PR TITLE
tac: validate input for -S option

### DIFF
--- a/bin/tac
+++ b/bin/tac
@@ -28,11 +28,7 @@ my $Program = basename($0);
 my $VERSION = '0.18';
 
 my %opts;
-unless (getopts('bBrs:S:', \%opts)) {
-    warn "$Program version $VERSION\n";
-    warn "usage: $Program [-br] [-s separator] [-B] [-S bytes] [file...]\n";
-    exit EX_FAILURE;
-}
+getopts('bBrs:S:', \%opts) or usage();
 my %long = qw/
     b before
     B binary
@@ -48,7 +44,12 @@ if (defined $opts{separator} && $opts{regex}) {
         $_ = qr/$_/;
     }
 }
-
+if (defined $opts{'size'}) {
+    if ($opts{'size'} !~ m/\A[0-9]+\Z/ || $opts{'size'} == 0) {
+        warn "$Program: option -S expects a number >= 1\n";
+        usage();
+    }
+}
 $opts{files} = \@ARGV;
 
 my $fh = IO::Tac->new(%opts);
@@ -57,6 +58,12 @@ unless ($fh) {
 }
 print while <$fh>;
 exit EX_SUCCESS;
+
+sub usage {
+    warn "$Program version $VERSION\n";
+    warn "usage: $Program [-br] [-s separator] [-B] [-S bytes] [file...]\n";
+    exit EX_FAILURE;
+}
 
 END {
     close STDOUT || die "$Program: can't close stdout: $!\n";


### PR DESCRIPTION
* tac -S option takes a number of bytes to read; this option does not exist in GNU version
* It doesn't make sense for -S value to be negative or zero so enforce a minimum of 1
* Printing usage string seemed slightly helpful, so create a usage() function
* The -S option might provide no benefit to the user and could be removed in future