### PR TITLE
whois: submit new query per domain

### DIFF
--- a/bin/whois
+++ b/bin/whois
@@ -41,25 +41,28 @@ set_host('whois.internic.net') unless defined $host;
 
 $| = 1;
 
-my $sock = IO::Socket::INET->new(
-    PeerAddr => $host,
-    PeerPort => 43,
-    Proto => 'tcp',
-    );
-
-die "IO::Socket::INET $!" unless $sock;
-
-for my $i (@ARGV) {
-    print {$sock} "$i ";
+foreach my $domain (@ARGV) {
+    whois($domain);
 }
-print {$sock} "\r\n";
-
-while($line = <$sock>) {
-    print $line
-}
-
-close($sock);
 exit EX_SUCCESS;
+
+sub whois {
+    my $domain = shift;
+    my $sock = IO::Socket::INET->new(
+        PeerAddr => $host,
+        PeerPort => 43,
+        Proto => 'tcp',
+    );
+    unless ($sock) {
+        warn "failed to connect: '$host': $!";
+        exit EX_FAILURE;
+    }
+    print {$sock} "$domain\r\n";
+    while ($line = <$sock>) {
+        print $line;
+    }
+    close $sock;
+}
 
 sub usage {
     warn "usage: whois [-6adprg] [-h host] domain...\n";


### PR DESCRIPTION
* NetBSD version of whois takes multiple domain names
* NetBSD version does a new connection for each domain name, so we can follow this [1]
* The query submitted by this version is not correct when multiple names are specified
* With this patch I can successfully query 2 domains in one go

1. http://cvsweb.netbsd.org/bsdweb.cgi/src/usr.bin/whois/whois.c?annotate=1.36.30.1

```
%perl whois installgentoo.com omledom.com   # before patch
No match for "INSTALLGENTOO.COM OMLEDOM.COM".
```