### PR TITLE
kill: validate pid

### DIFF
--- a/bin/kill
+++ b/bin/kill
@@ -53,6 +53,10 @@ die "$0: No PIDs specified.\n" unless ( @ARGV );
 
 my($ret) = 0;
 foreach ( @ARGV ) { # do the kills...
+	unless (m/\A\-?[0-9]+\Z/) {
+		warn "$0: failed to parse argument '$_'\n";
+		exit 1;
+	}
 	unless (kill $signal, $_) {
 		warn "$0: $_: $!\n";
 		$ret = 1;


### PR DESCRIPTION
* Avoid passing non-numeric pids to kill()
* Printing "Can't kill a non-numeric process ID" is not helpful because kill can accept many pids and the error doesn't indicate which pid is bad; print a helpful error instead
* This was found when testing against the bash-builtin kill