### PR TITLE
mail: connect() error tweak

### DIFF
--- a/bin/mail
+++ b/bin/mail
@@ -112,9 +112,7 @@ sub new {
 			Type => SOCK_STREAM,
 			Timeout => 15,
 	);
-	if (! $socket) {
-		die $emsg;
-	}
+	die $emsg . $IO::Socket::errstr . "\n" unless $socket;
 	my($ofh)=select($socket); $|=1; select($ofh);
 
 	# Get the SMTP header


### PR DESCRIPTION
* When sending a mail message we need to connect to a relay host
* Append the system error string to the nice error in $emesg, which is already terminated with a newline
* This makes the error take up 2 lines but I think it's still better because we can see more specific error info
```
%RELAYHOST=127.0.0.1 perl mail go@google.com # now shows...
Unable to connect to the specified relay host
IO::Socket::INET: connect: Connection refused
```