### PR TITLE
whois: add strict

### DIFF
--- a/bin/whois
+++ b/bin/whois
@@ -20,6 +20,8 @@ License:
 # Added a -6 switch for 6BONE (whois.6bone.net)
 # Added a -g switch for .gov (whois.nic.gov)
 
+use strict;
+
 use Getopt::Std qw(getopts);
 use IO::Socket;
 
@@ -54,11 +56,11 @@ sub whois {
         Proto => 'tcp',
     );
     unless ($sock) {
-        warn "failed to connect: '$host': $!";
+        warn "$host: $IO::Socket::errstr\n";
         exit EX_FAILURE;
     }
     print {$sock} "$domain\r\n";
-    while ($line = <$sock>) {
+    while (my $line = <$sock>) {
         print $line;
     }
     close $sock;


### PR DESCRIPTION
* I didn't notice that strict was not declared; when adding it, a declaration for $line was needed
* While here, prefer error string from IO::Socket over $! if connect fails (same change proposed for bin/mail)
```
%perl whois -h 127.0.0.1 good.juan.com
127.0.0.1: IO::Socket::INET: connect: Connection refused
```