### PR TITLE
whois: forbid query containing only whitespace

### DIFF
--- a/bin/whois
+++ b/bin/whois
@@ -50,6 +50,10 @@ exit EX_SUCCESS;
 
 sub whois {
     my $domain = shift;
+    if (length($domain) == 0 || $domain !~ m/\S/) {
+        warn "empty domain name\n";
+        exit EX_FAILURE;
+    }
     my $sock = IO::Socket::INET->new(
         PeerAddr => $host,
         PeerPort => 43,


### PR DESCRIPTION
* A correctly formed whois query will contain non-whitespace characters so catch invalid input before connecting to whois server
* Example bad input: perl whois ' '