### PR TITLE
glob: unused variable

### DIFF
--- a/bin/glob
+++ b/bin/glob
@@ -215,7 +215,6 @@ $matched = 0;
 
 sub match_glob($) {
     local $_ = shift;
-    my $glob_expr = $_;
 
     $matched = 0;
     @errors  = ();


### PR DESCRIPTION
$glob_expr assigned but not used in match_glob()