### PR TITLE
arithmetic: empty answer is not a number

### DIFF
--- a/bin/arithmetic
+++ b/bin/arithmetic
@@ -14,7 +14,6 @@ License: perl
 
 use strict;
 use integer;
-use warnings;
 
 use File::Basename qw(basename);
 use Getopt::Std qw(getopts);

--- a/bin/arithmetic
+++ b/bin/arithmetic
@@ -14,6 +14,7 @@ License: perl
 
 use strict;
 use integer;
+use warnings;
 
 use File::Basename qw(basename);
 use Getopt::Std qw(getopts);
@@ -100,7 +101,9 @@ while ($questions < QUESTIONS) {
             report();
         }
         chomp $guess;
-        if ($guess =~ /\D/) {
+        $guess =~ s/\A\s+//;
+        $guess =~ s/\s+\Z//;
+        if (length($guess) == 0 || $guess =~ /\D/) {
             print "Please type a number.\n";
             redo;
         }


### PR DESCRIPTION
* regex m/\D/ didn't match on empty string, so previously if I typed enter instead of a number it was treated as a wrong answer
* It's more correct to treat empty line as bad input and prompt again for a number
* While here, make the input loop more user friendly by trimming leading and trailing spaces before testing for m/\D/