### PR TITLE
bc: avoid extra copy of filehandle

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2045,8 +2045,7 @@ sub next_file
     debug { "reading from $file\n" };
 
     die "path '$file' is a directory\n" if (-d $file);
-    open(IN, '<', $file) or die("cannot open '$file': $!\n");
-    $input = IN;
+    open($input, '<', $file) or die("cannot open '$file': $!\n");
     $cur_file = $file;
     return 1;
 


### PR DESCRIPTION
* In next_file(), the old filehandle $input is closed if we're not processing the 1st file
* The filehandle $input is global; open it directly instead of copying into it from "IN"
* IN was not referenced anywhere else in the program