### PR TITLE
asa: avoid repeated regex

### DIFF
--- a/bin/asa
+++ b/bin/asa
@@ -49,15 +49,22 @@ exit $rc;
 sub run_file {
 	my $fh = shift;
 
+	my %prefix = (
+		'1' => "\f",
+		'+' => "\r",
+		'0' => "\n\n",
+		'-' => "\n\n\n",
+	);
 	while (<$fh>) {
 		chomp;
-		s/^$/ /;
-		s/^[^10+-]/\n/;
-		s/^1/\f/;
-		s/^\+/\r/;
-		s/^0/\n\n/;
-		s/^-/\n\n\n/;
-		print;
+		if (!length($_)) {
+			print "\n";
+			next;
+		}
+		my $c = substr $_, 0, 1;
+		$_ = substr $_, 1;
+		my $p = exists $prefix{$c} ? $prefix{$c} : "\n";
+		print $p, $_;
 	}
 }
 


### PR DESCRIPTION
* The 1st two regex in run_file() handled empty lines and lines not starting with 1, 0, '+' or '-'; i.e. both regex were run together resulting in output of "\n"
* Structure run_file() differently to avoid running every regex when a single lookup in a mapping table is good enough
* The patched version appears to produce the same output as previous version