### PR TITLE
mkdir: style patch

### DIFF
--- a/bin/mkdir
+++ b/bin/mkdir
@@ -14,18 +14,17 @@ License: perl
 
 use strict;
 
+use File::Basename qw(basename dirname);
 use Getopt::Std qw(getopts);
 
 my ($VERSION) = '1.3';
-my $Program;
-BEGIN { $Program = do { require File::Basename; File::Basename::basename($0) }; }
+my $Program = basename($0);
 
 $SIG{__WARN__} = sub { warn "$Program: @_\n" };
 $SIG{__DIE__} =  sub { die  "$Program: @_\n" };
 
 my %options;
 getopts('m:p', \%options) or usage();
-
 usage() unless @ARGV;
 
 use constant EX_SUCCESS => 0;
@@ -36,7 +35,7 @@ sub usage {
 	require Pod::Usage;
 	Pod::Usage::pod2usage({
 		-exitval => EX_USAGE,
-		-verbose => 2,
+		-verbose => 1,
 		});
 	}
 
@@ -51,14 +50,13 @@ if (exists $options{'m'} && $options{'m'} =~ /[^0-7]/) {
 # or not. "intermediate" directories are the directories interfered by
 # -p, but not given on the command line.
 if (exists $options{'p'}) {
-    require File::Basename;
     my @ARGV2;
     while (@ARGV) {
         my $dir = pop @ARGV;
         my $intermediate = 0;
-        while( $dir ne File::Basename::dirname($dir) ) {
+        while( $dir ne dirname($dir) ) {
             push @ARGV2 => [$dir, $intermediate ++];
-            $dir = File::Basename::dirname($dir);
+            $dir = dirname($dir);
         }
     }
     @ARGV = reverse @ARGV2;


### PR DESCRIPTION
* Multiple lazy-loads of File::Basename in the one script seemed a bit overcomplicated; just import basename() and dirname() so they can be used as needed
* When I typed a wrong option the entire manual was printed when I only needed to know the usage, not the license details; reducing the verbose level of pod2usage() helps this