### PR TITLE
ed: simplify edWrite()

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -623,14 +623,14 @@ sub edWrite {
         }
     }
 
-    $filename = defined($args[0]) ? $args[0] : $RememberedFilename;
-
-    if (!defined($filename)) {
+    if (defined $args[0]) {
+        $filename = $RememberedFilename = $args[0];
+    } elsif (defined $RememberedFilename) {
+        $filename = $RememberedFilename;
+    } else {
         edWarn(E_NOFILE);
         return;
     }
-    $RememberedFilename = $filename;
-
     my $mode = $AppendMode ? '>>' : '>';
     unless (open $fh, $mode, $filename) {
         warn "$filename: $!\n";


### PR DESCRIPTION
* Similar to previous patch in edEdit(), avoid assignment of $RememberedFilename into itself if $args[0] is not set
* The empty string check for $args[0] in edEdit() is not needed here because the input was already passed through the main parse-commads regex