### PR TITLE
patch: refuse to process a directory

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -382,7 +382,9 @@ sub bless {
     }
 
     # Make sure original file exists.
-    if ($self->{force} || $self->{batch}) {
+    if (-e $orig && ! -f $orig) {
+        $self->skip("File '$orig' is not a regular file\n");
+    } elsif ($self->{'force'} || $self->{'batch'}) {
         -e $orig or $self->skip;
     } else {
         until (-e $orig) {


### PR DESCRIPTION
* When testing against GNU patch, the following usage is invalid: "patch . < some.diff"
* An error is displayed: "File . is not a regular file -- refusing to patch"
* Even with patch -f (force) option the usage is not allowed
* Add extra branch to condition where file-exists check happens to handle this