### PR TITLE
bc: eliminate jump into yyparse()

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -1382,7 +1382,7 @@ sub yy_err_recover
              " to state $yytable[$yyn]\n" if $yydebug;
         $yyss[++$yyssp] = $yystate = $yytable[$yyn];
         $yyvs[++$yyvsp] = $yylval;
-        next yyloop;
+        yyparse();
       }
       else
       {
@@ -1406,16 +1406,19 @@ sub yy_err_recover
             "token $yychar ($yys)\n";
     }
     yyclearin();
-    next yyloop;
+    yyparse();
   }
 0;
 } # yy_err_recover
 
-sub yyparse
+sub clear_flags
 {
   yyclearin();
   $yynerrs = $yyerrflag = $yyssp = $yyvsp = $yyss[0] = $yystate = 0;
+}
 
+sub yyparse
+{
 yyloop: while(1)
   {
     yyreduce: {
@@ -2749,6 +2752,7 @@ sub main
     {
       $line = '';
       eval {
+        clear_flags();
         $status = yyparse();
         1;
       } or do {


### PR DESCRIPTION
* When temporarily enabling warnings in bc I observe warnings for incorrect use of "next"
* Function yy_err_recover() jumped to a label outside of itself, within yyparse()
* yyparse() was structured so that it first initialises flags then enters main loop
* Jumping back to yyparse() was unsafe because the flags would all be cleared again, including $yyssp (yy_err_recover() already adjusts $yyssp)
* Clear flags before calling yyparse(), and let yyparse() enter the loop immediately so that it's safe to call it from yy_err_recover()
```
%perl bc # before patch
4++
line 1: syntax error
Exiting subroutine via next at bc line 1387, <STDIN> line 1 (#1)
```