### PR TITLE
touch: -r argument truth check

### DIFF
--- a/bin/touch
+++ b/bin/touch
@@ -40,7 +40,7 @@ my $modification_time = exists $options {m}  ||  !exists $options {a};
 my $no_create         = exists $options {c};
 
 my ($atime, $mtime, $special_time);
-if ($options {r}) {
+if (defined $options{'r'}) {
     ($atime, $mtime) = (stat $options {r}) [8, 9] or die "$options{r}: $!\n";
     $special_time = 1;
 }


### PR DESCRIPTION
* Option -r takes a file argument to copy stat() data from
* Fix issue where filename of "0" is ignored because perl treated it as no-r-argument-given