### PR TITLE
printf: descriptive error message

### DIFF
--- a/bin/printf
+++ b/bin/printf
@@ -74,7 +74,11 @@ sub parse_fmt {
             $i++;
         } elsif ($f =~ s/\A(\%[0-9\.\-]*[a-zA-Z])//) {
             push @fmt, [ 'str', $1 ]; # unsupported
-	} else {
+        } else {
+            if ($f =~ m/\A[^\%]*(\%[\S]+)/) {
+                warn "$Program: invalid format: '$1'\n";
+                exit EX_FAILURE;
+            }
             die "internal error";
         }
     }


### PR DESCRIPTION
* Follow GNU printf command and attempt to show the bad format specifier which caused an error
* Example: "perl printf '%9 -asd'" now reports "printf: invalid format: '%9'" instead of just "internal error"