### PR TITLE
touch: fix typos

### DIFF
--- a/bin/touch
+++ b/bin/touch
@@ -16,13 +16,12 @@ use strict;
 
 use File::Basename qw(basename);
 use Getopt::Std qw(getopts);
+use IO::File;
 
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
 my $Program = basename($0);
-
-sub parse_time ($);
 
 my ($VERSION) = '1.3';
 
@@ -31,7 +30,7 @@ my $rc = EX_SUCCESS;
 my %options;
 getopts('acmfr:t:', \%options) or usage();
 unless (@ARGV) {
-    warn "$Program: missing file agument\n";
+    warn "$Program: missing file argument\n";
     usage();
 }
 
@@ -45,7 +44,7 @@ if (defined $options{'r'}) {
     $special_time = 1;
 }
 elsif ($options {t}) {
-    $atime = $mtime = parse_time $options {t};
+    $atime = $mtime = parse_time($options{'t'});
     die "-t $options{t}: Time out of range!\n" if $atime < 0;
     $special_time = 1;
 }
@@ -58,15 +57,17 @@ foreach my $file (@ARGV) {
     # Check if the file exists. If not, create it.
     unless (-e $file) {
         next if $no_create;
-        local *FILE;
-        require Fcntl;  # Import
-        sysopen FILE, $file, Fcntl::O_CREAT () or do {
-            warn "$Program: $file: $!\n";
+        my $fh = IO::File->new($file, O_CREAT);
+        unless ($fh) {
+            warn "$Program: failed to create '$file': $!\n";
             $rc = EX_FAILURE;
             next;
-        };
-        close FILE;
-
+        }
+        unless ($fh->close) {
+            warn "$Program: failed to close '$file': $!\n";
+            $rc = EX_FAILURE;
+            next;
+        }
         # Nothing to be done, unless time different than now.
         next unless $special_time;
     }
@@ -94,7 +95,7 @@ sub usage {
     exit EX_FAILURE;
 }
 
-sub parse_time ($) {
+sub parse_time {
     my $time = shift;
 
     my ($first, $seconds) = split /\./ => $time, 2;
@@ -166,7 +167,7 @@ not influence the exit status.
 
 =item -f
 
-This option is ignored, and only recognized for compatability reasons.
+This option is ignored, and only recognized for compatibility reasons.
 
 =item -m
 


### PR DESCRIPTION
* Fix typo in pod and one in error string
* Replace sysopen+fcntl with IO::File->new()
* Add return-value check for close()