### PR TITLE
ed: runtime error in edSubstitute()

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -506,7 +506,7 @@ sub edSubstitute {
         edWarn(E_ADDRBAD);
         return;
     }
-    unless (defined($args[0])) {
+    if (!defined($args[0]) || length($args[0]) == 0) {
         edWarn(E_PATTERN);
         return;
     }
@@ -514,9 +514,14 @@ sub edSubstitute {
     # do wierdness to match semantics if last character
     # is present or absent
 
-    $args[0] =~ /(.).*/;
-    $char = $1;
-    ($whole,$first,$middle,$last,$flags) = ($args[0] =~ /(($char)[^"$char"]*($char)[^"$char"]*($char)?)([imsx]*)/);
+    $char = substr $args[0], 0, 1;
+    eval {
+        ($whole,$first,$middle,$last,$flags) = ($args[0] =~ /(($char)[^"$char"]*($char)[^"$char"]*($char)?)([imsx]*)/);
+        1;
+    } or do {
+        edWarn(E_PATTERN);
+        return;
+    };
 
     if (defined($char) and defined($whole) and
         ($flags eq "") and (not defined($last))) {


### PR DESCRIPTION
* The program crashes when fed unexpected input after the initial "s" command
* I found this when investigating a capture-variable-outside-of-condition warning from perlcritic
* $char is the 1st character after the "s"; normally it would be "/" as in s/old/new/
* Return early if $args[0] is an empty string
* Adding eval guard around the confusing regex constructed from $char prevents the error
* Possibly the code could be changed later to enforce that $char is '/'
```
perl ed -p 'ed% ' a.c
63
ed% 1
#include <stdio.h>
ed% s*asaaa*
Unknown verb pattern '' in regex; marked by <-- HERE in m/((*) <-- HERE [^"*"]*(*)[^"*"]*(*)?)([imsx]*)/ at ed line 519, <> line 2.
```