### PR TITLE
diff: empty files are the same

### DIFF
--- a/bin/diff
+++ b/bin/diff
@@ -145,6 +145,7 @@ chomp(@f1 = <$fh1>);
 close $fh1;
 chomp(@f2 = <$fh2>);
 close $fh2;
+exit(EX_SUCCESS) if (scalar(@f1) == 0 && scalar(@f2) == 0);
 
 # diff yields lots of pieces, each of which is basically a Block object
 my $diffs = diff(\@f1, \@f2);


### PR DESCRIPTION
* Test case: "touch empty && perl diff empty empty"
* Program seems to hang; ctrl-c in perl debugger hints that we are stuck in Algorithm::Diff::traverse_sequences()
* Program grew to use >2GB of memory before I killed it
* traverse_sequences() doesn't seem to handle when both lists of input lines are empty (I didn't bother investigating why)
* Put a sanity check before diff()+traverse_sequences() are called; input files are read in total before diff() so the size of line list is know
* I also tested a non-empty file against an empty one