### PR TITLE
ed: no-match error for s///

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -530,9 +530,6 @@ sub edSubstitute {
     }
 
     # do the search and substitution
-
-    $LastMatch = $CurrentLineNum;
-
     for my $lineno ($adrs[0]..$adrs[1]) {
         my $evalstring = "\$lines[\$lineno] =~ s$args[0]";
 
@@ -542,6 +539,10 @@ sub edSubstitute {
             $UserHasBeenWarned = 0;
         }
 
+    }
+    unless (defined $LastMatch) {
+        edWarn(E_NOMATCH);
+        return;
     }
 
     $CurrentLineNum = $LastMatch;


### PR DESCRIPTION
* Difference observed when testing against GNU ed and OpenBSD ed
* If current line doesn't contain "A", the command s/A/B is expected to generate the error "no match"
* This error happens for searches (? and /), but not for s///
* The logic in edSubstitute() was wrong because LastMatch assumed the current line was a positive match before the loop starts
* The corrected version sets LastMatch only if a match occurred