### PR TITLE
bc: divide by 0

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2334,7 +2334,7 @@ sub exec_stmt
 	  if   ($_ eq '+_') { $res = $a + $b    ; 1 }
 	  elsif($_ eq '-_') { $res = $a - $b    ; 1 }
 	  elsif($_ eq '*_') { $res = $a * $b    ; 1 }
-	  elsif($_ eq '/_') { $res = $a / $b    ; 1 }
+	  elsif($_ eq '/_') { die 'divide by 0' if ($bignum ? $b->is_zero : $b == 0); $res = $a / $b }
 	  elsif($_ eq '^_') { $res = $a ** $b   ; 1 }
 	  elsif($_ eq '%_') { $res = $a % $b    ; 1 }
 


### PR DESCRIPTION
* Catch illegal division before it happens
* In bignum mode an error would not be thrown previously for this case; testing with is_zero() resolves this
* I tested this in interactive mode for -b and not-b; the die() is caught so bc does not terminate---this is consistent with GNU bc