### PR TITLE
bc: symbol table correction

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -800,8 +800,6 @@ repository:
 
 =cut
 
-#define YYBYACC 1
-
 use strict;
 
 # The symbol table : the keys are the identifiers, the value is in the
@@ -2398,6 +2396,7 @@ sub exec_stmt
      unless (defined($sym_table{$name})
 	     and $sym_table{$name}{'type'} eq 'var') {
        $sym_table{$name}{'value'} = 0;
+       $sym_table{$name}{'type'} = 'var';
      }
      push(@ope_stack, $sym_table{$name}{'value'});
      next INSTR;


### PR DESCRIPTION
* Entries in sym_table hash need to have type & value
* When investigating a warning for "eq on undefined value" on L2400 I noticed that the newly created sym_table entry needs a type of "var" (this code handles auto-assignment of zero to variables)
* The hint came from further down in the code, where array values are initialised to zero (virtual 'p' instruction)
* Also remove the C preprocessor declaration of YYBYACC which was not referenced anywhere