### PR TITLE
cal: display_help() tweak

### DIFF
--- a/bin/cal
+++ b/bin/cal
@@ -258,8 +258,7 @@ sub get_year {
 
 sub display_help {
 	print <<END_HELP;
-cal - part of the Perl Power Tools
-cal [-j] [-y] [[month] year]
+usage: cal [-jy] [[month] year]
 
     -j : Display calendar using julian days, where each day
          number is the day of the year.


### PR DESCRIPTION
* Example scenario: I type "perl cal -r", expecting it to work like "cal -r" on NetBSD
* I get a message that -r is invalid. Ok
* I get a message that cal is part of perl power tools; I don't care, I just want to see the valid options
* Remove the introductory text from display_help() and prefix the usage string with "usage: "
* The distribution info is still available at the bottom of the manual (perl perldoc cal)