### PR TITLE
banner: magic number

### DIFF
--- a/bin/banner
+++ b/bin/banner
@@ -47,8 +47,9 @@ if (defined $opt{'w'}) {
 
 # scale characters to width
 my @printmask;
-for (my $i = 0; $i < $width; $i++) {
-  $printmask[$i * 132 / $width] = 1;
+for (0 .. ($width - 1)) {
+  my $i = int($_ * DWIDTH / $width);
+  $printmask[$i] = 1;
 }
 
 # get message


### PR DESCRIPTION
* Program was previously converted to use DWIDTH constant, but the init code for printmask list can use it too
* Explicitly convert values to int which will be used as array index; some elements in printmask list are implicitly 0
* Tested with "perl banner -w 40 perl2u"