### PR TITLE
bc: remove alias sub

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -1362,7 +1362,7 @@ my @yyss;
 my @yyvs;
 $yyss[$YYSTACKSIZE] = 0;
 $yyvs[$YYSTACKSIZE] = 0;
-sub YYERROR { &yy_err_recover; }
+
 sub yy_err_recover
 {
   if ($yyerrflag < 3)
@@ -2567,7 +2567,7 @@ sub exec_stmt
        $return = 0; # so the result will be printed
      } elsif($return == 2) {
        print STDERR "No enclosing while or for";
-       YYERROR;
+       yy_err_recover();
      } elsif($return == 3) {
        $return = 0;
      }


### PR DESCRIPTION
* YYERROR() was an alias for yy_err_recover()
* YYERROR() was only called once, so call yy_err_recover() directly
* When testing, I temporarily forced $return=2 instead of working out how to trigger it