### PR TITLE
install: remove extra check for $implied

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -161,6 +161,7 @@ sub install_dirs {
         mkdir $dir, 0755 or die "$Program: mkdir $dir: $!\n";
     }
 
+    return unless $Unix;
     foreach my $directory (@ARGV) {
         my($dir,$implied) = @$directory;
 
@@ -176,9 +177,7 @@ sub install_dirs {
         else {
             $bits = oct $mode;
         }
-
-        # do these make sense elsewhere?
-        modify_file $dir, $bits if !$implied && $Unix;
+        modify_file($dir, $bits);
     }
 }
 


### PR DESCRIPTION
* In install_dirs() the final loop calls modify_file() for each directory
* modify_file() is skipped via "next" if $implied is true, so the call to modify_file() doesn't need its own guard
* modify_file() will not run if $Unix is false, so the loop can be bypassed