### PR TITLE
diff: compatible -q flag

### DIFF
--- a/bin/diff
+++ b/bin/diff
@@ -83,7 +83,7 @@ if (defined $opt_C) {
     $Context_Lines = 3;
     set_diff_type('CONTEXT');
 }
-if ($opt_e || $opt_q) {
+if ($opt_e) {
     set_diff_type('ED');
 }
 if ($opt_f) {
@@ -186,7 +186,11 @@ foreach my $piece (@$diffs) {
 $oldhunk->output_diff(\@f1, \@f2, $Diff_Type);
 
 # Print hunks backwards if we're doing an ed diff
-map {$_->output_ed_diff(\@f1, \@f2, $Diff_Type)} @Ed_Hunks if @Ed_Hunks;
+if ($Diff_Type eq 'ED') {
+    foreach $hunk (@Ed_Hunks) {
+        $hunk->output_ed_diff(\@f1, \@f2, 'ED');
+    }
+}
 
 exit EX_DIFFERENT;
 # END MAIN PROGRAM


### PR DESCRIPTION
* -q flag means no diff output is printed, so effectively the diff type (format) has no meaning
* OpenBSD diff ignores  -e -n -u -f -c formatting flags if -q is given; do the same here with exception of -n which is not supported
* output_diff() doesn't really output a diff for ed diffs (but it does for reverse-ed diff)
* Make the calling code for output_ed_diff() more obvious that it is not called for reverse-ed diff type
* test1: no output difference for ed and reverse-ed diffs compared to previous version
* test2: no errors raised for... for opt in c e f u; do perl diff -${opt} -q diff.new diff; done