### PR TITLE
join: remove non-standard -h flag

### DIFF
--- a/bin/join
+++ b/bin/join
@@ -251,8 +251,7 @@ sub get_options {
   while (@ARGV && $ARGV[0] =~ /^-(.)/) {
     local $_ = shift @ARGV;
     return if $_ eq '--';
-    if    (/^-[h?]$/)  { help() }        # terminates
-    elsif (s/^-a//) {
+    if (s/^-a//) {
       my $f = get_file_number('a');
       $unpairables[$f] = 1;
     }


### PR DESCRIPTION
* Usage string is still printed for -h with this patch
* When looking at POD I discovered the SYNOPSIS fails to mention -j option, but address this later