### PR TITLE
ls: conditional get_columns()

### DIFF
--- a/bin/ls
+++ b/bin/ls
@@ -373,6 +373,7 @@ sub List {
 	} else {
 
 		# ------ compute rows, columns, width mask
+		$WinCols = get_columns() unless defined $WinCols;
 		$Cols = int($WinCols / $Maxlen) || 1;
 		$Rows = int(($#_+$Cols) / $Cols);
 		$Mask = sprintf("%%-%ds ", $Maxlen);
@@ -494,7 +495,6 @@ if ($Options{'f'}) {
 	$Options{'a'} = 1;
 }
 
-$WinCols = get_columns();
 $Attributes = stat(*STDOUT);
 if ($Attributes->mode & 0140000) {
 	$Options{'1'} = '1';


### PR DESCRIPTION
* get_columns() has the side effect of running external commands via unix() function
* Not all modes of ls need the value of $WinCols, e.g. "ls -1" and "ls -l"
* Init $WinCols the 1st time it is used within List()
* "defined" guard is there because List() can be called repeatedly, e.g. "ls dir1 dir2"