### PR TITLE
grep: pattern of 0

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -136,8 +136,8 @@ sub parse_args {
 
 	$optstring = "incCwsxvhe:f:l1HurtpP:aqTF";
 
-	$zeros = 'inCwxvhelut';    # options to init to 0 (prevent warnings)
-	$nulls = 'pP';             # options to init to "" (prevent warnings)
+	$zeros = 'inCwxvhlut';    # options to init to 0 (prevent warnings)
+	$nulls = 'epP';             # options to init to "" (prevent warnings)
 
 	@opt{ split //, $zeros } = (0) x length($zeros);
 	@opt{ split //, $nulls } = ('') x length($nulls);
@@ -162,7 +162,9 @@ sub parse_args {
 		close PATFILE;
 		}
 	else {    # make sure pattern is valid
-		$pattern = $opt{e} || shift(@ARGV) || usage();
+		$pattern = $opt{'e'};
+		$pattern = shift(@ARGV) unless length $pattern;
+		usage() unless defined $pattern;
 		unless ($no_re) {
 			eval { 'foo' =~ /$pattern/, 1 }
 				or die "$Me: bad pattern: $@";


### PR DESCRIPTION
* The following correct usage was not accepted: "perl grep 0 file"
* Within parse_args(), $opt{e} was initialised to 0 but that is confusing because 0 could be a pattern; instead set it to empty string
* First check if $opt{e} and use it if not empty
* Expect pattern to be the next ARGV element
* Raise error via usage() only if there were no remaining ARGV elements (previously usage() was called if it was 0, i.e. false)