### PR TITLE
rm: print usage for bad options

### DIFF
--- a/bin/rm
+++ b/bin/rm
@@ -189,6 +189,7 @@ sub process_options {
 		'r' => \$opts{'r'},
 		'v' => \$opts{'v'},
 		);
+	usage() unless $ret;
 
 	$opts{'R'} = 1 if $opts{'r'};
 
@@ -276,7 +277,7 @@ sub usage {
 	require Pod::Usage;
 	Pod::Usage::pod2usage({
 		-exitval => EX_USAGE,
-		-verbose => 2,
+		-verbose => 1,
 		});
 	}
 


### PR DESCRIPTION
* Don't ignore bad options
* e.g. for usage "perl rm -x f1", file f1 should not be removed
* Reduce verbose level of pod2usage() so only SYNOPSIS and Options are displayed
* I found this when testing against GNU rm