### PR TITLE
split: dead code

### DIFF
--- a/bin/split
+++ b/bin/split
@@ -147,7 +147,7 @@ elsif ($opt{'p'}) {
 }
 
 ## Line operations.
-elsif ((! $opt{'p'}) and (! $opt{'b'})) {
+else {
     my $fh;
     $nlines = 1000 unless $nlines;
     my $line = 0;
@@ -158,9 +158,6 @@ elsif ((! $opt{'p'}) and (! $opt{'b'})) {
 	$line++;
     }
 }
-
-else { clue };
-
 close $in;
 exit;
 


### PR DESCRIPTION
* The default branch is really for -l flag, i.e. line-based split mode
* The user doesn't need to type -l if they are happy with default of "-l 1000"
* Only one of -b/-l/-p is allowed