### PR TITLE
nl: -l option unsupported

### DIFF
--- a/bin/nl
+++ b/bin/nl
@@ -263,7 +263,7 @@ nl - line numbering filter
 
 =head1 SYNOPSIS
 
-    nl [-p] [-b type] [-d delim] [-f type] [-h type] [-i incr] [-l num]
+    nl [-p] [-b type] [-d delim] [-f type] [-h type] [-i incr]
        [-n format] [-s sep] [-v startnum] [-w width] [file]
 
 =head1 DESCRIPTION


### PR DESCRIPTION
* Usage string incorrectly mentioned "-l num", but this results in "unknown option" error
* GNU and OpenBSD versions support -l; it could be added to this version later if desirable