### PR TITLE
ln: support --version

### DIFF
--- a/bin/ln
+++ b/bin/ln
@@ -86,9 +86,9 @@ sub usage {
 }
 
 sub dolink {
-    my ($file, $targ) = @_;
-    return symlink($file, $targ) if $options{'s'};
-    return link($file, $targ);
+    my ($file, $target) = @_;
+    return symlink($file, $target) if $options{'s'};
+    return link($file, $target);
 }
 
 __END__

--- a/bin/ln
+++ b/bin/ln
@@ -19,7 +19,7 @@ use Getopt::Std qw(getopts);
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
-my $VERSION = '1.3';
+our $VERSION = '1.3';
 my $Program = basename($0);
 
 getopts('sf', \my %options) or usage();
@@ -75,16 +75,20 @@ unless (@ARGV) {
 }
 exit $rc;
 
+sub VERSION_MESSAGE {
+    print "$Program version $VERSION\n";
+    exit EX_SUCCESS;
+}
+
 sub usage {
-    warn "$Program (Perl bin utils) $VERSION\n";
     warn "usage: $Program [-sf] source_file [target_file | [source_files ...] target_directory]\n";
     exit EX_FAILURE;
 }
 
 sub dolink {
-    my ($file, $target) = @_;
-    return symlink($file, $target) if $options{'s'};
-    return link($file, $target);
+    my ($file, $targ) = @_;
+    return symlink($file, $targ) if $options{'s'};
+    return link($file, $targ);
 }
 
 __END__
@@ -122,7 +126,7 @@ Create symbolic links (hard links are created by default)
 
 If the I<target> is not a directory, try to remove any existing
 I<target>s before creating the links. Failure of removing the
-target results in a warning and no futher attempt to make the
+target results in a warning and no further attempt to make the
 link will be made.
 
 =back


### PR DESCRIPTION
* Move version-info line out of usage() into VERSION_MESSAGE() as done in other scripts; this allows Getopt::Std to handle --version flag
* While here, spell a word correctly in pod and spell a variable differently to avoid conflict with global ($target)