### PR TITLE
bc: mod zero

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2331,7 +2331,7 @@ sub exec_stmt
 	  elsif($_ eq '*_') { $res = $a * $b    ; 1 }
 	  elsif($_ eq '/_') { die 'divide by 0' if ($bignum ? $b->is_zero : $b == 0); $res = $a / $b }
 	  elsif($_ eq '^_') { $res = $a ** $b   ; 1 }
-	  elsif($_ eq '%_') { $res = $a % $b    ; 1 }
+	  elsif($_ eq '%_') { die 'modulo by 0' if ($bignum ? $b->is_zero : $b == 0); $res = $a % $b }
 
 	  elsif($_ eq '==_') { $res = 0 + ($a == $b) ; 1 }
 	  elsif($_ eq '!=_') { $res = 0 + ($a != $b) ; 1 }


### PR DESCRIPTION
* When adding previous commit to avoid divide by zero, mod 0 was missed
* Patch tested under default mode and bignum mode (bc -b)
```
a=123
b=0
a%b
```