### PR TITLE
ed: edEdit() validation

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -666,6 +666,11 @@ sub edEdit {
             edWarn(E_ADDREXT);
             return 0;
         }
+        if ($NeedToSave && $QuestionsMode && !$UserHasBeenWarned) {
+            $UserHasBeenWarned = 1;
+            edWarn(E_UNSAVED);
+            return 0;
+        }
     }
 
     if (defined $args[0]) {
@@ -727,12 +732,6 @@ sub edEdit {
         $CurrentLineNum = $adrs[0] + scalar(@tmp_lines);
         $NeedToSave = 1;
     } else {
-        if ($NeedToSave && $QuestionsMode && !$UserHasBeenWarned) {
-            $UserHasBeenWarned = 1;
-            edWarn(E_UNSAVED);
-            return;
-        }
-
         @lines = (undef, @tmp_lines);
         $NeedToSave = 0;
         $CurrentLineNum = maxline();


### PR DESCRIPTION
* If I open a file and edit it, the $NeedToSave flag is set
* If I attempt to edit a new file with "e" command, the new file was opened and read into a temporary buffer before validation based on $NeedToSave executes
* I noticed this because I observed a "cannot open file" error when typing a nonexistent filename, instead of a "buffer modified" error
* When editing a new file with "E" command the $NeedToSave flag is not checked, but for "e" command it is
```
%perl ed a.c    # before patch
63
P
*1d
*e aa.cc
aa.cc: No such file or directory
?
*h
cannot open file
*
```