### PR TITLE
bc: yyparse() loop regression

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -1378,7 +1378,7 @@ sub yy_err_recover
              " to state $yytable[$yyn]\n" if $yydebug;
         $yyss[++$yyssp] = $yystate = $yytable[$yyn];
         $yyvs[++$yyvsp] = $yylval;
-        yyparse();
+        return 1;
       }
       else
       {
@@ -1401,8 +1401,7 @@ sub yy_err_recover
       print "yydebug: state $yystate, error recovery discards ",
             "token $yychar ($yys)\n";
     }
-    yyclearin();
-    yyparse();
+    return 1;
   }
 0;
 } # yy_err_recover


### PR DESCRIPTION
* A previous commit replaced a goto into yyparse() with a call to yyparse() but this introduced an infinite loop for a file with a syntax error
* yy_err_recover() returns bool; returning 1 instead of calling yyparse() again allows yyparse() to itself return and break out of "yyloop"
* The pattern of return(1) from yy_err_recover() was already established; this patch just makes it more consistent
* Regarding the removed yyclearin() call, that would be called from main()->clear_flags() before yyparse() would be called again
* test1: echo '1++' > A.bc && perl bc -y A.bc
* test2: echo '~' > B.bc && perl  bc -y B.bc

```
%echo '1++' > A.bc && perl bc -y A.bc   # before patch
yydebug: state 1, reading 0 (end-of-file)
yydebug: state 1, reducing by rule 2 (stmt_list_exec : stmt_list_exec stmt_exec)
yydebug: after reduction, shifting from state 0 to state 1
yydebug: state 1, error recovery shifting to state 2
"A.bc", line 1: syntax error
yydebug: error recovery discarding state 2
yydebug: state 1, error recovery shifting to state 2
yydebug: error recovery discarding state 2
yydebug: state 1, error recovery shifting to state 2
yydebug: error recovery discarding state 2
yydebug: state 1, error recovery shifting to state 2
yydebug: error recovery discarding state 2
LOOP
```