### PR TITLE
ed: edit empty file

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -710,6 +710,8 @@ sub edEdit {
     }
     if ($chars == 0) {
         $UserHasBeenWarned = 0;
+        $CurrentLineNum = 0;
+        @lines = (0);
         print "0\n" unless $SupressCounts;
         return 1;
     }


### PR DESCRIPTION
* The previous empty-file guard added to edEdit() wasn't good enough
* Before returning from edEdit() the buffer was not replaced with an empty buffer
* Line 1 is no longer a valid address after "e empty" command
```
%perl ed a.c    # before patch
63
P
*1
#include <stdio.h>
*e empty
0
*1
#include <stdio.h>
*q
```