### PR TITLE
cut: allow -b range of 1

### DIFF
--- a/bin/cut
+++ b/bin/cut
@@ -73,7 +73,7 @@ sub handle_b {
             my ($start, $end) = split /\-/, $item, 2;
             checknum($start);
             checknum($end);
-            if ($start >= $end) {
+            if ($start > $end) {
                 warn "$me: invalid byte list\n";
                 exit EX_FAILURE;
             }


### PR DESCRIPTION
* Technically the inclusive byte range of 2-2 is a single byte
* When testing against GNU and OpenBSD versions, the usage of "cut -b 2-2" is allowed and interpreted as "cut -b 2"
* This version raised an error previously but it's more compatible to allow it