### PR TITLE
join: -a or -v

### DIFF
--- a/bin/join
+++ b/bin/join
@@ -248,14 +248,19 @@ sub get_field_specs {
 }
 
 sub get_options {
+  my ($aflag, $vflag);
   while (@ARGV && $ARGV[0] =~ /^-(.)/) {
     local $_ = shift @ARGV;
     return if $_ eq '--';
     if (s/^-a//) {
+      help() if $vflag;
+      $aflag = 1;
       my $f = get_file_number('a');
       $unpairables[$f] = 1;
     }
     elsif (s/^-v//) {
+      help() if $aflag;
+      $vflag = 1;
       $print_pairables = 0;
       my $f = get_file_number('v');
       $unpairables[$f] = 1;


### PR DESCRIPTION
* The meanings of options -a and -v are incompatible
* Usage string from standards document indicates -a OR -v [1]; this version prints a compatible usage string
* Follow OpenBSD version and fail early if both -a and -v are given

1. https://pubs.opengroup.org/onlinepubs/009604599/utilities/join.html