### PR TITLE
ed: inferred range commands

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -938,11 +938,17 @@ sub edParse {
         $command = '/';
         undef $adrs[0];
     }
+    my $commarange = $fields[1] =~ /,/;
+
     $adrs[1] = &CalculateLine(splice(@fields,1,13));
     if ($adrs[1] == -1) {
         edWarn(E_NOMATCH);
         $command = '/';
         undef $adrs[1];
+    }
+    if ($commarange && !defined($adrs[0])) {
+        $adrs[0] = 1;
+        $adrs[1] = maxline() unless defined $adrs[1];
     }
     if (defined($args[0]) && $WANT_FILE{$command} && !$space_sep) {
         return 0;


### PR DESCRIPTION
* Line addresses can be inferred when entering a range with a comma
* An explicit range has two addresses, e.g. "1,2" or "4,$"
* If first address is not given it is always 1
* If first and last address are both not given, last address is $ (last valid line address)
* I discovered this when testing against OpenBSD and GNU ed
* test1: ",n" --> interpret as 1,$n
* test2: ",5n" --> interpret as 1,5n