### PR TITLE
du: remove unix path assumption

### DIFF
--- a/bin/du
+++ b/bin/du
@@ -16,18 +16,19 @@ License: perl
 # Perl Power Tools - du
 # Greg Hewgill <greg@hewgill.com> 1999-03-07
 
-use Getopt::Std;
 use strict;
 
+use File::Spec;
+use Getopt::Std;
+
 use vars qw($opt_H $opt_L $opt_P $opt_a $opt_c $opt_k $opt_l $opt_r $opt_s $opt_x);
-use vars qw(%inodes $depth $blocksize $grandtotal $filesystem $dirsep);
+use vars qw(%inodes $depth $blocksize $grandtotal $filesystem);
 
 %inodes = ();      # A record of where we've been
 $depth = 0;        # Current recursion depth
 $blocksize = 512;  # Default block size
 $grandtotal = 0;   # Total of all command line argument totals
 $filesystem = 0;   # Current file system (used for -x processing)
-$dirsep = '/';     # Assume '/' is the directory separator
 
 $blocksize = $ENV{BLOCKSIZE} if $ENV{BLOCKSIZE}; # use environment if present
 
@@ -83,7 +84,7 @@ sub traverse {
   # Do recursion
   if (opendir(DIR, $fn)) {
     foreach (readdir(DIR)) {
-      my $subdir = ($fn =~ /$dirsep$/o) ? "$fn$_" : "$fn$dirsep$_";
+      my $subdir = File::Spec->catfile($fn, $_);
       # Don't try to traverse '.' or '..'
       $total += traverse($subdir) unless /^\.{1,2}$/;
     }
@@ -160,8 +161,6 @@ If the environment variable BLOCKSIZE is set, and the B<-k> option is not
 specified, the block counts will be displayed in units of that size block.
 
 =head1 BUGS
-
-The directory separator is assumed to be '/'.
 
 The number of blocks reported is based on the size of the file. This may
 or may not reflect the actual number of blocks allocated by the file system


### PR DESCRIPTION
* du had a documented bug where '/' was the path separator
* As done in other scripts, make use of catfile() when joining a directory name to a filename
* This works the same on my Linux system, but in theory it will work better on windows
* catfile() can handle directory names with a redundant separator at the end, so a conditional expression is not needed
* Remove global variable $dirsep
