### PR TITLE
grep -f 0

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -146,7 +146,7 @@ sub parse_args {
 
 	my $no_re = $opt{F} || ( $Me =~ /\bfgrep\b/ );
 
-	if ( $opt{f} ) {           # -f patfile
+	if (defined $opt{'f'}) {           # -f patfile
 		die("$Me: $opt{f}: is a directory\n") if ( -d $opt{f} );
 		open PATFILE, '<', $opt{f} or die qq($Me: Can't open '$opt{f}': $!);
 


### PR DESCRIPTION
* It is valid for a pattern file to be named "0" but this was not being ignored by grep
```
%cat > 0
main
puts
^D
%perl grep -nf 0 a.c
4:main(void)
6:	puts("yo");
```