### PR TITLE
rm: raise error for long options

### DIFF
--- a/bin/rm
+++ b/bin/rm
@@ -134,6 +134,12 @@ sub preprocess_options {
 		@rest = @new_args[ $args{'--'} .. $#new_args ];
 		@new_args = @new_args[0 .. ($args{'--'} - 1)];
 		}
+	foreach (@new_args) {
+		if (m/\A\-\-/) {
+			warn "unknown option: '$_'\n";
+			usage();
+		}
+	}
 
 	# Expand clustering
 	@new_args = map {


### PR DESCRIPTION
* I noticed that if I provide "long" options to rm, it gets confused and attempts to remove files starting with a dash
* When debugging this, preprocess_options() was incorrectly deciding to save long options into new_args list; call usage() instead because this rm only supports single letter options
```
%perl rm --this    # before patch
rm: cannot remove '-t': No such file or directory
rm: cannot remove '-h': No such file or directory
rm: cannot remove '-i': No such file or directory
rm: cannot remove '-s': No such file or directory
```