### PR TITLE
grep: fix regression for -F search

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -210,22 +210,12 @@ sub parse_args {
 		if ($opt{'w'} || $opt{'x'} || $opt{'H'} || $opt{'u'}) {
 			die("$Me: -H, -u, -w and -x are incompatible with -F\n");
 		}
-		for (0 .. $#patterns) {
-			$patterns[$_] = quotemeta $patterns[$_];
-		}
 		my $testop = $opt{'v'} ? '==' : '!=';
 		if ($opt{'i'}) {
-			for (0 .. $#patterns) {
-				$patterns[$_] = lc $patterns[$_];
-			}
-			for my $pattern (@patterns) {
-				$match_code .= "\$Matches++ if (index(lc(\$_), '$pattern') $testop -1);";
-			}
+			$match_code = "for my \$pat (\@patterns) { \$Matches++ if (index(lc \$_, lc \$pat) $testop -1) }";
 		}
 		else { # case sensitive
-			for my $pattern (@patterns) {
-				$match_code .= "\$Matches++ if (index(\$_, '$pattern') $testop -1);";
-			}
+			$match_code = "for my \$pat (\@patterns) { \$Matches++ if (index(\$_, \$pat) $testop -1) }";
 		}
 		$matcher = eval "sub { $match_code }";
 		die if $@;


### PR DESCRIPTION
* The following search should match, but did not because of the '#' character: perl grep -F '#include' a.c
* This was because quotemeta() was escaping it as ```\#``` which was then expanded between single quotes
* The $matcher closure can refer to patterns list directly; this avoids having to expand pattern strings within quotes
* This version is easier to follow because duplicate statements are not added to the closure code if many patterns are specified
```
%perl head -n1 a.c
#include <stdio.h>
%perl grep -F '#include' a.c
#include <stdio.h>
%perl grep -Fi '#includE' a.c
#include <stdio.h>
```