### PR TITLE
grep: fix -Fc regression

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -147,6 +147,7 @@ sub parse_args {
 	@opt{ split //, $nulls } = ('') x length($nulls);
 
 	getopts( $optstring, \%opt ) or usage();
+	$opt{'s'} = 1 if $opt{'c'};
 
 	my $no_re = $opt{F} || ( $Me =~ /\bfgrep\b/ );
 	$match_code = '';
@@ -243,7 +244,6 @@ sub parse_args {
 	$opt{1}   += $opt{l};                                                                     # that's a one and an ell
 	$opt{H}   += $opt{u};
 	$opt{c}   += $opt{C};
-	$opt{'s'} += $opt{c};
 	$opt{1}   += $opt{'s'} && !$opt{c};                                                       # that's a one
 
 	@ARGV = ( $opt{r} ? '.' : '-' ) unless @ARGV;


### PR DESCRIPTION
* Combining -F and -c flags had the incorrect result of showing matching lines followed by a count
* When debugging this I discovered the opt hash was supposed to be massaged so s-flag is set if c-flag is set
```
%perl grep -Fc '/' aa.c     # before patch
	/* I SHOULD BE INVISIBLE */
1
```