### PR TITLE
tr: pod update

### DIFF
--- a/bin/tr
+++ b/bin/tr
@@ -11,9 +11,6 @@ License: perl
 
 =cut
 
-
-# tr - translate or delete characters
-
 use strict;
 
 use File::Basename qw(basename);
@@ -57,7 +54,7 @@ my $cflag = ($opt{'C'} || $opt{'c'}) ? 'c' : '';
 my $dflag = $opt{'d'} ? 'd' : '';
 my $sflag = $opt{'s'} ? 's' : '';
 eval qq{
-    while (<>) {
+    while (<STDIN>) {
 	tr[$string1][$string2]$cflag$dflag$sflag;
 	print;
     }
@@ -66,7 +63,7 @@ eval qq{
     warn "$Program: $@\n";
     exit EX_FAILURE;
 };
-exit EX_SUCCESS; # XXX: Doen't detect failed opens
+exit EX_SUCCESS;
 
 __END__
 
@@ -148,9 +145,7 @@ operation.
 
 =head1 BUGS
 
-There is no way to catch the file open error on ARGV handle
-processing, so the exit status does not reflect file open
-failures.
+I<tr> has no known bugs.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
* Remove mention of open() failures in BUGS section of manual
* Similar to bin/tee and bin/xargs, change the loop to read STDIN to make it more obvious that tr does not open any files
* On my Linux system, if I redirect stdin from /etc/shadow as a regular user, bash shows a permissions error and sets $? to 1; this takes place before perl is started
* Remove header comment that is duplicated in pod