### PR TITLE
grep -F versus stdin

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -176,6 +176,7 @@ sub parse_args {
 			}
 		@patterns = ($pattern);
 		}
+	@ARGV = ($opt{'r'} ? '.' : '-') unless @ARGV;
 
 	if ( $opt{H} || $opt{u} ) {    # highlight or underline
 		my $term = $ENV{TERM} || 'vt100';
@@ -243,8 +244,6 @@ sub parse_args {
 	$opt{H}   += $opt{u};
 	$opt{c}   += $opt{C};
 	$opt{1}   += $opt{'s'} && !$opt{c};                                                       # that's a one
-
-	@ARGV = ( $opt{r} ? '.' : '-' ) unless @ARGV;
 
 	$match_code .= 'study;' if @patterns > 5;    # might speed things up a bit
 


### PR DESCRIPTION
* ARGV list was supposed to have the value '-' added if it was empty
* I noticed that grep would simply exit for the following test: echo hello1 | perl grep -F 1
* In this usage the argument "1" is shifted off ARGV list and the code to reset ARGV was happening too late (problem caused by recent grep -F code addition)