### PR TITLE
cp: support '--' terminator

### DIFF
--- a/bin/cp
+++ b/bin/cp
@@ -58,7 +58,7 @@ sub run {
 		# it doesn't.
 		my @command = 'cp';
 		push @command, map { "-$_" } grep { $opts->{$_} } qw(i f p v );
-		push @command, @files, $destination;
+		push @command, '--', @files, $destination;
 
 		my $rc = system { $command[0] } @command;
 		return $rc >> 8;


### PR DESCRIPTION
* '--' option terminator is ignored when executing an external command
* When debugging this I discovered the command list passed to system() strips off the '--' (technically Getopt::Long does)
* Explicit terminator can be added between options and filenames
```
%perl cp -- -a ..   # before patch, on linux
cp: missing destination file operand after '..'
Try 'cp --help' for more information.
```