### PR TITLE
cp: bundled options

### DIFF
--- a/bin/cp
+++ b/bin/cp
@@ -102,6 +102,7 @@ sub process_arguments {
 	my %opts;
 
 	require Getopt::Long;
+	Getopt::Long::Configure('bundling');
 	Getopt::Long::GetOptionsFromArray(
 		\@args,
 		'f' => \$opts{'f'},


### PR DESCRIPTION
* Single-letter options can be grouped; one combo I type sometimes is -iv
 * Tell Getopt::Long to allow this
```
%perl cp -iv ar ar.rar
'ar' -> 'ar.rar'
```