### PR TITLE
words: throw error for too many args

### DIFF
--- a/bin/words
+++ b/bin/words
@@ -27,6 +27,11 @@ my $Program = basename($0);
 
 getopts('m:w:') or usage();
 usage() unless @ARGV;
+my $letters = shift;
+if (@ARGV) {
+    warn "$Program: extra argument: '$ARGV[0]'\n";
+    usage();
+}
 
 my $wordlist;
 if (defined $opt_w) {
@@ -58,7 +63,6 @@ unless (open $dict, '<', $wordlist) {
 
 $| = 1;
 
-my $letters = shift;
 $letters = lc $letters;              # convert to lowercase
 $letters =~ tr/a-z//cd;              # strip non-letter characters
 


### PR DESCRIPTION
* words command takes only one argument; show an error if user accidentally provides 2 arguments instead of ignoring the second
* Zero-args case was already handled