### PR TITLE
nl: -s separator versus 0

### DIFF
--- a/bin/nl
+++ b/bin/nl
@@ -44,7 +44,7 @@ my $type_h      = $options{h} || "n";
 my $incr        = $options{i};
 my $format      = $options{n};
 my $single_page = $options{p};
-my $sep         = $options{s} || "\t";
+my $sep         = exists $options{'s'} ? $options{'s'} : "\t";
 my $startnum    = $options{v};
 my $width       = $options{w};
 if (defined $format) {


### PR DESCRIPTION
* test1: no space between number and line (perl nl -s '' a.c)
* test2: 0 between number and line (perl nl -s0 a.c)
* Patch tested against GNU nl