### PR TITLE
tail: tweak filename title

### DIFF
--- a/bin/tail
+++ b/bin/tail
@@ -125,8 +125,6 @@ sub parse_args()
     }
 
     usage(EX_FAILURE, 'The number cannot be zero') if $point == 0;
-
-    $point = $point ? $point : -10;
     }
 
     $files = [ @ARGV ];
@@ -425,7 +423,7 @@ sub handle_args($$$)
 
         # Do not print the tail of the files if we are using xtail
         unless($me eq "xtail") {
-            print "*** $file ***\n" if(scalar @files >= 2);
+            print "==> $file <==\n" if(scalar @files >= 2);
             print_tail \*FH, $file, $point, $type;
             print "\n" if(++$i < scalar(@files));
         }


### PR DESCRIPTION
* Make tail use "==> FILENAME <==\n" format when printing output from multiple files; this conforms with GNU and OpenBSD versions
* This is also consistent with the filename title printed by bin/head
* test: same md5 sum compared to tail(1) on my Linux system: "perl tail -n 50 awk ar arithmetic | md5sum"
* While here, delete dead code in parse_args(); $point is always assigned a default value of -10 at top of function