### PR TITLE
ed: 2-address insert command

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -749,13 +749,12 @@ sub edInsert {
     my $append = shift;
     my(@tmp_lines);
 
-    if (defined($adrs[1])) {
-        edWarn(E_ADDREXT);
-        return;
-    }
     if (defined($args[0])) {
         edWarn(E_ARGEXT);
         return;
+    }
+    if (defined($adrs[1])) {
+        $adrs[0] = $adrs[1];
     }
     if (!defined($adrs[0])) {
         $adrs[0] = $CurrentLineNum;


### PR DESCRIPTION
* When testing against GNU and OpenBSD versions, "i" command was with a 2-address prefix was treated as invalid
* Be compatible and treat effective address as 2nd address if 2 were specified
* ed commands "a" and "i" are both handled in edInsert(), so this patch covers both
* test1: "1,2i" --> 2i
* test2: ",2i" --> 2i
* test3: "1,2a" --> 2a
* test4: ",2a" --> 2a