### PR TITLE
ed: line 0 is invalid for write command

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -578,6 +578,10 @@ sub edWrite {
     } elsif (defined($adrs[0]) && !defined($adrs[1])) {
         $adrs[1] = $adrs[0];
     }
+    if ($adrs[0] == 0) {
+        edWarn(E_ADDRBAD);
+        return;
+    }
     if (length $commandsuf) {
         if ($commandsuf eq 'q') {
             $qflag = 1;


### PR DESCRIPTION
* When testing previous commit I discovered that this version of ed incorrectly accepts "0,1w file.mp3" command
* Address range 0-1 is not valid because lines count from 1
* Error was also not raised for "0w file.mp3", i.e. single-address mode
* Follow OpenBSD and GNU versions by printing invalid-address error
* Technically, the command ",1w file" is valid; this is interpreted as implied range of "1,1" which is the same as just "1w"