### PR TITLE
ed: command mode versus ctrl+d

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -90,8 +90,8 @@ my $Error = undef;              # saved error string for h command
 my $Prompt = undef;             # saved prompt string for -p option
 my $SupressCounts = 0;          # byte counts are printed by default
 my @lines;                      # buffer for file being edited.
-my $command = "";               # single letter command entered by user
-my $commandsuf = "";            # single letter modifier of command
+my $command;                    # single letter command entered by user
+my $commandsuf;                 # single letter modifier of command
 my @adrs;                       # 1 or 2 line numbers for commands to operate on
 my @args;                       # command arguments (filenames, search patterns...)
 
@@ -185,8 +185,14 @@ edEdit($NO_QUESTIONS_MODE, $NO_APPEND_MODE);
 input() while 1;
 
 sub input {
+    $command = $commandsuf = '';
+    @adrs = ();
+    @args = ();
+
     print $Prompt if defined $Prompt;
-    last unless ($_ = <>);
+    unless ($_ = <>) {
+        edQuitAsk() or return;
+    }
     chomp;
 
     if (!edParse()) {
@@ -868,9 +874,6 @@ sub edSetCurrentLine {
 #
 
 sub edParse {
-
-    @adrs = ();
-
     s/\A\s+//;
     my @fields =
              (/^(


### PR DESCRIPTION
* Fix the error 'Can't "last" outside a loop block at ed line 189', triggered by ctrl+d (eof) after loading a file in ed
* When adding the input() function the "last" statement was missed in the error handling code
* Consistently clear globals before calling edParse(); prevent saved state from previous command input from being used by subsequent commands
* Follow OpenBSD ed and make ^D equivalent to typing the regular "q" command
* Example case: Open a text file and delete 1st line with "1d" command, then hit ^D
* The first time I hit ^D in command mode, edQuit() will print a warning about the modified buffer (called via edQuitAsk())
* When I hit ^D a second time, edQuit() remembers that a warning was already printed, so the program exits