### PR TITLE
ls: -1 for non-tty

### DIFF
--- a/bin/ls
+++ b/bin/ls
@@ -498,11 +498,7 @@ unless (getopts('1ACFLRSTWacdfgiklmnopqrstux', \%Options)) {
 if ($Options{'f'}) {
 	$Options{'a'} = 1;
 }
-
-$Attributes = stat(*STDOUT);
-if ($Attributes->mode & 0140000) {
-	$Options{'1'} = '1';
-}
+$Options{'1'} = 1 unless (-t *STDOUT);
 
 # ------ current directory if no arguments
 if ($#ARGV < 0) {


### PR DESCRIPTION
* The manual explains that if output is not a tty, ls will infer the -1 flag (i.e. print one entry per line)
* The old filemode check code did not work on my Linux system but this patch does
* I tested this with a pipe into cat, and with a redirect into a file