### PR TITLE
od: support -B alias for -o

### DIFF
--- a/bin/od
+++ b/bin/od
@@ -23,8 +23,8 @@ use constant EX_FAILURE => 1;
 use constant LINESZ => 16;
 use constant PRINTMAX => 126;
 
-use vars qw/ $opt_A $opt_a $opt_b $opt_c $opt_d $opt_f $opt_i $opt_j $opt_l
-$opt_N $opt_o $opt_s $opt_v $opt_x /;
+use vars qw/ $opt_A $opt_a $opt_B $opt_b $opt_c $opt_d $opt_f $opt_i $opt_j
+ $opt_l $opt_N $opt_o $opt_s $opt_v $opt_x /;
 
 our $VERSION = '1.0';
 
@@ -85,7 +85,7 @@ $lastline = '';
 
 my $Program = basename($0);
 
-getopts('A:abcdfij:lN:osvx') or help();
+getopts('A:aBbcdfij:lN:osvx') or help();
 if (defined $opt_A) {
     if ($opt_A !~ m/\A[doxn]\z/) {
 	warn "$Program: unexpected radix: '$opt_A'\n";
@@ -135,7 +135,7 @@ elsif ($opt_i || $opt_s) {
 elsif ($opt_l) {
     $fmt = \&long;
 }
-elsif ($opt_o) {
+elsif ($opt_B || $opt_o) {
     $fmt = \&octal2;
 }
 elsif ($opt_x) {
@@ -348,7 +348,7 @@ sub diffdata {
 }
 
 sub help {
-    print "usage: od [-abcdfilosxv] [-A radix] [-j skip_bytes] [-N limit_bytes] [file]...\n";
+    print "usage: od [-aBbcdfilosxv] [-A radix] [-j skip_bytes] [-N limit_bytes] [file]...\n";
     exit EX_FAILURE;
 }
 __END__
@@ -359,7 +359,7 @@ od - dump files in octal and other formats
 
 =head1 SYNOPSIS
 
-B<od> [ I<-abcdfilosxv> ] [I<-j skip_n_bytes>] [I<-N read_n_bytes>] [ I<-A radix> ] [ F<file>... ]
+B<od> [ I<-aBbcdfilosxv> ] [I<-j skip_n_bytes>] [I<-N read_n_bytes>] [ I<-A radix> ] [ F<file>... ]
 
 =head1 DESCRIPTION
 
@@ -384,6 +384,10 @@ Select offset prefix format: 'd' for decimal, 'o' for octal, 'x' for hexadecimal
 
 Dump characters in 7-bit ASCII format, ignoring the highest bit of each byte.
 The names of ASCII control characters are displayed.
+
+=item -B
+
+Same as -o
 
 =item -b
 


### PR DESCRIPTION
* Free/Net/Open BSDs document that "od -B" behaves the same as -o
* GNU version appears to support this as well, but I couldn't find reference to this in its manual