### PR TITLE
od: add 4-byte hex dump option

### DIFF
--- a/bin/od
+++ b/bin/od
@@ -24,9 +24,9 @@ use constant LINESZ => 16;
 use constant PRINTMAX => 126;
 
 use vars qw/ $opt_A $opt_a $opt_B $opt_b $opt_c $opt_d $opt_e $opt_F $opt_f
- $opt_i $opt_j $opt_l $opt_N $opt_o $opt_s $opt_v $opt_x /;
+ $opt_H $opt_i $opt_j $opt_l $opt_N $opt_o $opt_s $opt_v $opt_X $opt_x /;
 
-our $VERSION = '1.0';
+our $VERSION = '1.1';
 
 my ($offset1, $radix, $data, @arr, $len, $lim);
 my ($lastline, $strfmt, $ml);
@@ -85,7 +85,7 @@ $lastline = '';
 
 my $Program = basename($0);
 
-getopts('A:aBbcdeFfij:lN:osvx') or help();
+getopts('A:aBbcdeFfHij:lN:osvXx') or help();
 if (defined $opt_A) {
     if ($opt_A !~ m/\A[doxn]\z/) {
 	warn "$Program: unexpected radix: '$opt_A'\n";
@@ -132,6 +132,9 @@ elsif ($opt_e || $opt_F) {
 elsif ($opt_f) {
     $fmt = \&float;
 }
+elsif ($opt_H || $opt_X) {
+    $fmt = \&hex4;
+}
 elsif ($opt_i || $opt_s) {
     $fmt = \&decimal;
 }
@@ -142,7 +145,7 @@ elsif ($opt_B || $opt_o) {
     $fmt = \&octal2;
 }
 elsif ($opt_x) {
-    $fmt = \&hex;
+    $fmt = \&hex2;
 }
 else {
     $fmt = \&octal2;
@@ -347,7 +350,7 @@ sub octal2 {
     $strfmt = '%.6o ' x (scalar @arr);
 }
 
-sub hex {
+sub hex2 {
     if (length($data) & 1) { # pad to 16 bit
         @arr = unpack 'S*', $data . "\0";
     }
@@ -357,13 +360,25 @@ sub hex {
     $strfmt = '%.4x ' x (scalar @arr);
 }
 
+sub hex4 {
+    my $remain = length($data) % 4;
+    if ($remain) { # pad to 32 bit
+        my $pad = "\0" x (4 - $remain);
+        @arr = unpack 'L*', $data . $pad;
+    }
+    else {
+        @arr = unpack 'L*', $data;
+    }
+    $strfmt = '%.8x ' x (scalar @arr);
+}
+
 sub diffdata {
     my $currdata = $data . '|';
     return ($currdata eq $lastline) ? 0 : 1;
 }
 
 sub help {
-    print "usage: od [-aBbcdeFfilosxv] [-A radix] [-j skip_bytes] [-N limit_bytes] [file]...\n";
+    print "usage: od [-aBbcdeFfHilosXxv] [-A radix] [-j skip_bytes] [-N limit_bytes] [file]...\n";
     exit EX_FAILURE;
 }
 __END__
@@ -374,7 +389,7 @@ od - dump files in octal and other formats
 
 =head1 SYNOPSIS
 
-B<od> [ I<-aBbcdeFfilosxv> ] [I<-j skip_n_bytes>] [I<-N read_n_bytes>] [ I<-A radix> ] [ F<file>... ]
+B<od> [ I<-aBbcdeFfHilosXxv> ] [I<-j skip_n_bytes>] [I<-N read_n_bytes>] [ I<-A radix> ] [ F<file>... ]
 
 =head1 DESCRIPTION
 
@@ -428,6 +443,10 @@ Same as -e
 
 Show input as floating point numbers in exponent form.
 
+=item -H
+
+Four-byte hex display.
+
 =item -i
 
 Show two-byte signed decimal integers.
@@ -451,6 +470,10 @@ Format input as two-byte octal numbers.
 =item -s
 
 Same as -i
+
+=item -X
+
+Same as -H
 
 =item -x
 


### PR DESCRIPTION
* GNU and OpenBSD support "od -H" and "od -X" options for 4-byte hex format, so add it here too
* Rename 2-byte hex format function to avoid conflict with perl built-in hex()
* Bump program version