### PR TITLE
cal: unused variable

### DIFF
--- a/bin/cal
+++ b/bin/cal
@@ -147,7 +147,7 @@ sub fmt_month {
 
 sub make_month_array {
 	my( $year, $month ) = @_;
-	my( @month_array, $numdays, $remain, $x, $y ) = ();
+	my( @month_array, $numdays, $x, $y ) = ();
 	my( $firstweekday ) = &day_of_week_num( $year, $month, 1 );
 	$numdays = &days_in_month( $year, $month );
 	if ($opts{'j'}) {


### PR DESCRIPTION
* $remain was unused in make_month_array()
* perlcritic didn't find this one for me, possibly because of the assignment in the declaration statement