### PR TITLE
rm: can't delete a filename including a dash

### DIFF
--- a/bin/rm
+++ b/bin/rm
@@ -143,7 +143,7 @@ sub preprocess_options {
 
 	# Expand clustering
 	@new_args = map {
-			if( /-(.+)/ ) {
+			if( /\A\-(.+)/ ) {
 				my $cluster = $1;
 				map { "-$_" } split //, $cluster;
 			}


### PR DESCRIPTION
* A filename starting with a dash can be given as an argument like this: ./-o-
* The cp program seems to support this but rm does not (see below)
* I also tested a file called a-b
* Debugging showed that preprocessed_args is incorrectly ['-c','-p','-.','-1']
* Stepping through preprocess_options() revealed a regex on L146 which was not bound to the start of the string
```
%perl cp cp ./-cp.1
%perl rm ./-cp.1 
Unknown option: c
Unknown option: p
Unknown option: .
Unknown option: 1
Usage: rm [-fiPrRv] file ...
```