### PR TITLE
rm: zero args versus -f

### DIFF
--- a/bin/rm
+++ b/bin/rm
@@ -86,12 +86,13 @@ sub run {
 	$self->error( "$Program: -P ignored\n" ) if $self->is_overwrite;
 
 	unless ( () = $self->files ) {
+		exit(EX_SUCCESS) if $self->is_force;
 		$self->error( "$Program: missing argument\n" );
-		exit EX_FAILURE;
+		usage();
 	}
 
 	my $errors = grep { $self->process_file( $_ ) } $self->files;
-	$self->exit( $errors ? EX_FAILURE : EX_SUCCESS );
+	exit( $errors ? EX_FAILURE : EX_SUCCESS );
 }
 
 sub new {
@@ -109,8 +110,6 @@ sub defaults {
 		output_fh    => \*STDOUT,
 		);
 }
-
-sub exit  { my $self = shift; exit(shift) }
 
 sub files { my $self = shift; @{ $self->{files} } }
 


### PR DESCRIPTION
* NetBSD, OpenBSD and GNU versions do exit(0) for "rm -f" with no file arguments
* Standards document says -f flag should not modify the exit status for nonexistent operands[1]
* Support this here too
* Make the program more consistent by exiting directly via exit() instead of mixing calls to exit() and $self->exit() (definition of custom exit() can be eliminated)
* Behave more like BSD version by printing usage for bare "rm" with no -f and no args

1. https://pubs.opengroup.org/onlinepubs/009695399/utilities/rm.html