### PR TITLE
grep: sprinkle catfile()

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -49,6 +49,7 @@ License: perl
 
 use strict;
 
+use File::Spec;
 use Getopt::Std;
 
 our $VERSION = '1.001';
@@ -309,7 +310,8 @@ FILE: while ( defined( $file = shift(@_) ) ) {
 				}
 			@list = ();
 			for ( readdir(DIR) ) {
-				push( @list, "$file/$_" ) unless /^\.{1,2}$/;
+				next if $_ eq '.' or $_ eq '..';
+				push @list, File::Spec->catfile($file, $_);
 				}
 			closedir(DIR);
 			if ( $opt->{t} ) {


### PR DESCRIPTION
* Copy the code pattern from bin/du when running grep in recursive mode
* Joining directory entry names with catfile() is likely more portable
* I didn't test this patch on windows, but grep works the same with patch applied on my linux system, e.g. "perl grep -r grep ."