### PR TITLE
glob: pod improvement

### DIFF
--- a/bin/glob
+++ b/bin/glob
@@ -121,15 +121,6 @@ So for MS-DOS for example, you could set these to:
         $FastGlob::rootpat = '[A-Z]:';  # <Drive letter><colon> pattern
         $FastGlob::curdir = '.';        # name of current directory in dir
         $FastGlob::parentdir = '..';    # name of parent directory in dir
-
-        $FastGlob::hidedotfiles = 0;    # hide filenames starting with .
-
-And for MacOS to:
-
-        $FastGlob::dirsep = ':';        # directory path separator
-        $FastGlob::rootpat = '\A\Z';    # root directory prefix pattern
-        $FastGlob::curdir = '.';        # name of current directory in dir
-        $FastGlob::parentdir = '..';    # name of parent directory in dir
         $FastGlob::hidedotfiles = 0;    # hide filenames starting with .
 
 Furthermore, after a call to B<glob>, the variable C<$FastGlob::matched>


### PR DESCRIPTION
* Remove the section with default values for historical MacOS; people using current Mac would use the suggestions for Unix
* While here, remove the extra empty line in the suggested values for DOS