### PR TITLE
split: out-of-order check

### DIFF
--- a/bin/split
+++ b/bin/split
@@ -110,12 +110,12 @@ unless (defined $prefix && length $prefix) {
     $prefix = 'x';
 }
 
-die("$me: $infile: is a directory\n") if (-d $infile);
 my $in;
 if ($infile eq '-') {
     $in = *STDIN;
 }
 else {
+    die("$me: $infile: is a directory\n") if (-d $infile);
     open($in, '<', $infile) or die("$me: Can't open $infile: $!\n");
 }
 binmode $in;


### PR DESCRIPTION
* The check for the special argument '-' should take place before stat
* The old code was wrong because "split -" produced 2 different results depending on whether I had a directory called "-"
* test1: "perl split -"  == stdin
* test2: "perl split ./-" == file called "-"
* test3: "perl split -- -" == same as test1