### PR TITLE
ar: simplify strmode()

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -387,29 +387,14 @@ sub writeAr {
 sub strmode {
     my ($mode) = @_;
 
-    # just the RWX bits.
-    $mode = oct($mode) & 0777;
-    my @modemap = (0400 => 'r',    #  R for owner
-		   0200 => 'w',    #  W for owner
-		   0100 => 'x',    #  X for owner
-
-		   0040 => 'r',    #  R for group
-		   0020 => 'w',    #  W for group
-		   0010 => 'x',    #  X for group
-
-		   0004 => 'r',    #  R for other
-		   0002 => 'w',    #  W for other
-		   0001 => 'x');   #  X for other
-
-    my $modestr;
-    while (@modemap) {
-	my ($bit,$letter) = splice(@modemap,0,2);
-	if ($mode & $bit) {
-	    $modestr .= $letter;
-	}
-	else {
-	    $modestr .= "-";
-	}
+    die "bad file mode: $mode" if $mode !~ m/([0-7]+)/;
+    my $ugo = substr $1, -3; # only rwx bits
+    my $modestr = '';
+    foreach (split //, $ugo) {
+	my $i = oct;
+	$modestr .= $i & 4 ? 'r' : '-';
+	$modestr .= $i & 2 ? 'w' : '-';
+	$modestr .= $i & 1 ? 'x' : '-';
     }
     return $modestr;
 }


### PR DESCRIPTION
* When listing archive file contents with "perl ar -tv file.a", the -v flag enables printing the file permissions for each archive member
* Take advantage of the $mode param being an octal string
* As before, only take the last 3 octal digits and deal with trailing spaces in $mode param
* By inspecting the 3 octal digits separately, there's no need for a modemap table to interpret the bits at the various positions for user/owner, group and other
* Patch tested against a file created by this ar, and another file created by binutils

```
%perl ar -q test.a words wordlist.txt.old
%perl ar -tv test.a
rwxr-xr-x    1000/1000       3975 Jun 12 09:13 2024 words
rw-r--r--    1000/1000         23 Feb  7 13:00 2024 wordlist.txt.old
```