### PR TITLE
cp: warn for source directory

### DIFF
--- a/bin/cp
+++ b/bin/cp
@@ -67,6 +67,11 @@ sub run {
 		require File::Copy;
 		my $err = 0;
 		foreach my $source (@files) {
+			if (-d $source) {
+				print { error_fh() } "$0: '$source' is a directory (not copied)\n";
+				$err = 1;
+				next;
+			}
 			my $catdst = $destination;
 			if( -d $destination ) {
 				$catdst = catfile( $destination, basename($source) )


### PR DESCRIPTION
* When running on non-unix, avoid passing a directory to File::Copy::copy() and print a helpful warning message
* GNU and OpenBSD versions print a warning for this case too