### PR TITLE
cp: warn on File::Copy::copy() failure

### DIFF
--- a/bin/cp
+++ b/bin/cp
@@ -85,7 +85,10 @@ sub run {
 					return EX_FAILURE;
 					}
 				}
-			$err = 1 if (File::Copy::copy($source, $catdst) == 0);
+			if (File::Copy::copy($source, $catdst) == 0) {
+				print { error_fh() } "$0: $source -> $catdst: copy failed: $!\n";
+				$err = 1;
+				}
 			}
 		return $err ? EX_FAILURE : EX_SUCCESS;
 		}


### PR DESCRIPTION
* When cp runs in non-unix mode, take advantage of File::Copy::copy() setting $! on failure
* When the destination was a non-existent directory, cp would do exit(1) but did not show the reason for failure