### PR TITLE
tee: standard -i flag

### DIFF
--- a/bin/tee
+++ b/bin/tee
@@ -26,9 +26,7 @@ while ($ARGV[0] =~ /^-(.+)/ && (shift, ($_ = $1), 1)) {
     s/n// && (++$nostdout,    redo);
     die "usage tee [-aiun] [filenames] ...\n";
 }
-if ($ignore_ints) {
-    for my $sig ('INT', 'TERM', 'HUP', 'QUIT') { $SIG{$sig} = 'IGNORE'; }
-}
+$SIG{'INT'} = 'IGNORE' if $ignore_ints;
 $SIG{'PIPE'} = 'PLUMBER';
 $mode = $append ? '>>' : '>';
 $fh = 'FH000';


### PR DESCRIPTION
* Standards document mentions that only SIGINT is ignored for "tee -i" [1]
* Dragonfly/Free/Net/Open- BSD manuals are consistent and list only SIGINT
* Other historical systems documented that -i ignored interrupts but did not explicitly say which ones

1. https://pubs.opengroup.org/onlinepubs/009696699/utilities/tee.html