### PR TITLE
tee: add strict

### DIFF
--- a/bin/tee
+++ b/bin/tee
@@ -17,44 +17,57 @@ License: perl
 # Tom Christiansen <tchrist@convex.com>
 # 6 June 91
 
+use strict;
+
 use Getopt::Std qw(getopts);
+use IO::File;
 
 my %opt;
 getopts('aiu', \%opt) or die "usage: tee [-aiu] [file ...]\n";
 $SIG{'INT'} = 'IGNORE' if $opt{'i'};
-$SIG{'PIPE'} = 'PLUMBER';
 $| = 1 if $opt{'u'};
 
-my $mode = $opt{'a'} ? '>>' : '>';
-my $fh = 'FH000';
-my %fh = ('STDOUT', 'standard output'); # always go to stdout
+my $mode = $opt{'a'} ? 'a' : 'w';
 my $status = 0;
+my $default_fd = fileno(*STDOUT);
+my %fh = ($default_fd => {
+    'name' => 'standard output',
+    'fh' => *STDOUT,
+});
 
 for (@ARGV) {
-    if (!open($fh, $mode, $_)) {
+    if (-d $_) {
+	warn "$0: '$_' is a directory\n";
+	$status++;
+	next;
+    }
+    my $fh = IO::File->new($_, $mode);
+    unless (defined $fh) {
 	warn "$0: cannot open $_: $!\n"; # like sun's; i prefer die
 	$status++;
 	next;
     }
-    select((select($fh), $| = 1)[0]) if $unbuffer;
-    $fh{$fh++} = $_;
+    select((select($fh), $| = 1)[0]) if $opt{'u'};
+    my $fd = fileno($fh);
+    $fh{$fd}->{'name'} = $_;
+    $fh{$fd}->{'fh'} = $fh;
 }
 while (<STDIN>) {
-    for my $fh (keys %fh) {
+    for my $fh (get_filehandles()) {
 	print {$fh} $_;
     }
 }
-for my $fh (keys %fh) {
-    next if close($fh) || !defined $fh{$fh};
-    warn "$0: couldn't close $fh{$fh}: $!\n";
-    $status++;
+for my $fd (keys %fh) {
+    unless (close $fh{$fd}->{'fh'}) {
+	warn sprintf("%s: close '%s': %s\n", $0, $fh{$fd}->{'name'}, $!);
+        $status++;
+    }
 }
 exit $status;
 
-sub PLUMBER {
-    warn "$0: pipe to \"$fh{$fh}\" broke!\n";
-    $status++;
-    delete $fh{$fh};
+sub get_filehandles {
+    my @handles = map { $fh{$_}->{'fh'} } (keys %fh);
+    return @handles;
 }
 
 =encoding utf8


### PR DESCRIPTION
* Correct left-over reference to variable $unbuffer
* Remove custom SIGPIPE code which doesn't exist in the BSD version (the only reference to signals is SIGINT being ignored)
* Standards document mentions nothing about SIGPIPE in Asynchronous Events section[1]
* Output files table (%fh) is now keyed based on file descriptor and contains filehandle and the saved filename from ARGV
* Explicitly check for directory before opening a file
* test1: "ifconfig | perl tee out.1" --> out.1 created
* test2: "ifconfig | perl tee -a out.1 out.2" --> existing out.1 appended, out.2 created

1. https://pubs.opengroup.org/onlinepubs/009696699/utilities/tee.html