### PR TITLE
grep: out-of-order check

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -290,7 +290,11 @@ sub matchfile {
 FILE: while ( defined( $file = shift(@_) ) ) {
 		my $compressed = 0;
 
-		if ( -d $file ) {
+		if ( $file eq '-' ) {
+			warn "$Me: reading from stdin\n" if -t STDIN && !$opt->{'q'};
+			$name = '<STDIN>';
+			}
+		elsif ( -d $file ) {
 			if ( -l $file && @ARGV != 1 ) {
 				warn qq($Me: "$file" is a symlink to a directory\n)
 					if $opt->{T};
@@ -324,11 +328,6 @@ FILE: while ( defined( $file = shift(@_) ) ) {
 				}
 			matchfile( $opt, $matcher, @list );    # process files
 			next FILE;
-			}
-
-		if ( $file eq '-' ) {
-			warn "$Me: reading from stdin\n" if -t STDIN && !$opt->{'q'};
-			$name = '<STDIN>';
 			}
 		else {
 			$name = $file;


### PR DESCRIPTION
* grep supports '-' argument for stdin
* On L180 '-' is added to ARGV if it is empty
* The directory check in matchfile() was happening too early, so move the '-' check to top of loop
* test1: "mkdir ./- && echo hi | perl grep hi" --> previously the directory check would get in the way and terminate grep
* test2: "ifconfig | perl grep '^[a-z]'" --> ifconfig lines starting with an interface name