### PR TITLE
fold: add getopts()

### DIFF
--- a/bin/fold
+++ b/bin/fold
@@ -28,59 +28,34 @@ use strict;
 use locale;             # for what a space is.
 
 use File::Basename qw(basename);
+use Getopt::Std qw(getopts);
 
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
 my $Program = basename($0);
 
-my(
-    $Byte_Only,         # if they said -b, ignore tabs etc
-    $Space_Break,       # they said -s, so look for white space breaks
-    $Width,             # screen size
-    $Tabstop,           # tab stops are every Tabstop
-);
+for (0 .. $#ARGV) {
+    last if $ARGV[$_] eq '--';
+    $ARGV[$_] = "-w$1" if $ARGV[$_] =~ m/\A\-([0-9]+)\z/;
+}
 
-$Tabstop  =  8;   # sane tab stops
-$Width    = 80;   # default screen size
+my %opt;
+getopts('bsw:', \%opt) or usage();
+my $Tabstop     = 8; # sane tab stops
+my $Width       = defined $opt{'w'} ? $opt{'w'} : 80;
+my $Byte_Only   = $opt{'b'} || 0;
+my $Space_Break = $opt{'s'} || 0;
 
 sub usage {
     warn "$Program: @_\n" if @_;
     warn qq[
-$Program [-bs] [-w I<width> | -<width>] [file ...]
+usage: $Program [-bs] [-w width] [file ...]
     -s         split lines on whitespace where possible
     -b         count bytes, not characters
     -w WIDTH   maximum length of lines on output
-    -WIDTH     maximum length of lines on output (archaic form)
 ];
     exit EX_FAILURE;
-}
-
-# do this by hand, because we don't like $opt_80, $opt_132, etc.
-# and we want to check for dups.  --tchrist
-OPTION:
-while (@ARGV && $ARGV[0] =~ /^-(.+)/ && (shift, ($_ = $1), 1)) {
-
-    next OPTION unless length;
-    last if $_ eq '-'; # -- terminator
-
-    if (s/^b//) {
-        warn "-b flag already set" if $Byte_Only++;
-        redo OPTION;
-    }
-
-    if (s/^s//) {
-        warn "-s flag already set" if $Space_Break++;
-        redo OPTION;
-    }
-
-    # historical practice makes -72 and -w 72 the same
-    if (s/^(\d.*)// || s/^w(.*)//) {
-        $Width = $1 || shift;
-        next OPTION;
-    }
-
-    usage("unexpected option: -$_");
 }
 
 unless ($Width && $Width =~ /^\d+$/) {


### PR DESCRIPTION
* Reduce the amount of custom code for pre-posix argument handling of -NUM
* Pre-process ARGV by converting -123 to -w123, then hand off to getopts()
* Prefix usage string with "usage:"
* Sync usage string with pod document; no need to encourage people to use the old -NUM form for width
* test1: "echo `perl cat cat` | perl fold -40" --> process stdin with -w 40
* test2: "perl fold -s -w 72 moo" --> regular -w form with file input instead of stdin