### PR TITLE
true/false: ignore options

### DIFF
--- a/bin/false
+++ b/bin/false
@@ -11,36 +11,7 @@ License: perl
 
 =cut
 
-
-use strict;
-
-my ($VERSION) = '1.3';
-
-my $STATUS = 1;
-
-if (@ARGV) {
-    if ($ARGV [0] eq '--version') {
-        $0 =~ s{.*/}{};
-        print "$0 (Perl bin utils) $VERSION\n";
-        exit;
-    }
-    if ($ARGV [0] eq '--help') {
-        $0 =~ s{.*/}{};
-        my $success = $STATUS ? "failure" : "success";
-        print <<EOF;
-Usage: $0 [OPTION]
-
-Exit with a $success status.
-
-Options:
-       --version:  Print version number, then exit.
-       --help:     Print usage, then exit.
-EOF
-        exit;
-    }
-}
-
-exit $STATUS;
+exit 1;
 
 __END__
 
@@ -52,40 +23,23 @@ false - Exit unsuccesfully
 
 =head1 SYNOPSIS
 
-(true | false) [OPTION]
+false
 
 =head1 DESCRIPTION
 
-I<true> exits succesfully. I<false> exits unsuccesfully.
-
-=head2 OPTIONS
-
-I<true> and I<false> accept the following options:
-
-=over 4
-
-=item --help
-
-Print out a short help message, then exit.
-
-=item --version
-
-Print out its version number, then exit.
-
-=back
+I<false> exits unsuccesfully.
 
 =head1 ENVIRONMENT
 
-The working of I<true> and I<false> are not influenced by any
-environment variables.
+The working of I<false> is not influenced by any environment variables.
 
 =head1 BUGS
 
-I<true> and I<false> have no known bugs.
+I<false> has no known bugs.
 
 =head1 AUTHOR
 
-The Perl implementation of I<true> and I<false>
+The Perl implementation of I<false>
 was written by Abigail, I<perlpowertools@abigail.be>.
 
 =head1 COPYRIGHT and LICENSE

--- a/bin/true
+++ b/bin/true
@@ -11,36 +11,7 @@ License: perl
 
 =cut
 
-
-use strict;
-
-my ($VERSION) = '1.3';
-
-my $STATUS = 0;
-
-if (@ARGV) {
-    if ($ARGV [0] eq '--version') {
-        $0 =~ s{.*/}{};
-        print "$0 (Perl bin utils) $VERSION\n";
-        exit;
-    }
-    if ($ARGV [0] eq '--help') {
-        $0 =~ s{.*/}{};
-        my $success = $STATUS ? "failure" : "success";
-        print <<EOF;
-Usage: $0 [OPTION]
-
-Exit with a $success status.
-
-Options:
-       --version:  Print version number, then exit.
-       --help:     Print usage, then exit.
-EOF
-        exit;
-    }
-}
-
-exit $STATUS;
+exit 0;
 
 __END__
 
@@ -52,40 +23,23 @@ true - Exit succesfully
 
 =head1 SYNOPSIS
 
-(true | false) [OPTION]
+true
 
 =head1 DESCRIPTION
 
-I<true> exits succesfully. I<false> exits unsuccesfully.
-
-=head2 OPTIONS
-
-I<true> and I<false> accept the following options:
-
-=over 4
-
-=item --help
-
-Print out a short help message, then exit.
-
-=item --version
-
-Print out its version number, then exit.
-
-=back
+I<true> exits succesfully.
 
 =head1 ENVIRONMENT
 
-The working of I<true> and I<false> are not influenced by any
-environment variables.
+The working of I<true> is not influenced by any environment variables.
 
 =head1 BUGS
 
-I<true> and I<false> have no known bugs.
+I<true> has no known bugs.
 
 =head1 AUTHOR
 
-The Perl implementation of I<true> and I<false>
+The Perl implementation of I<true>
 was written by Abigail, I<perlpowertools@abigail.be>.
 
 =head1 COPYRIGHT and LICENSE


### PR DESCRIPTION
* Standards document says that true does not handle options [1]
* No reference to options in the solaris manual either [2]
* I tested 4 versions of true and only the GNU version handles options
* test1: /bin/true --version # gnu version on linux
* test2: builtin true --version # bash builtin on linux
* test3: /usr/bin/true --version # openbsd version
* test4: builtin true --version # ksh builtin on openbsd
* The same is true for false

1. https://pubs.opengroup.org/onlinepubs/009695399/utilities/true.html
2. https://shrubbery.net/solaris9ab/SUNWaman/hman1/true.1.html