### PR TITLE
patch: retire Patch::import()

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -269,12 +269,6 @@ BEGIN {
     $ERROR = 0;
 }
 
-sub import {
-    no strict 'refs';
-    *{caller() . '::throw'} = \&throw;
-    @{caller() . '::ISA'}   = 'Patch';
-}
-
 # Simple throw/catch error handling.
 sub throw {
     $@ = join '', @_;
@@ -655,7 +649,7 @@ sub suffix_backup {
 sub apply {
     my ($self, $i_start, $o_start, @hunk) = @_;
 
-    $self->{skip} and throw 'SKIP...ignore this patch';
+    $self->{skip} and throw('SKIP...ignore this patch');
 
     if ($self->{reverse}) {
         my $not = { qw/ + - - + / };
@@ -703,11 +697,11 @@ sub apply {
                             $self->{reverse} = 0;
                             $position = 0;
                             prompt ('Apply anyway? [n] ') =~ /^[yY]/
-                                or throw 'SKIP...ignore this patch';
+                                or throw('SKIP...ignore this patch');
                         }
                     }
                 } else {
-                    throw 'SKIP...ignore this patch' if $self->{forward};
+                    throw('SKIP...ignore this patch') if $self->{forward};
                 }
             } else {
                 unless ($position || $self->{reverse} || $self->{force}) {
@@ -718,7 +712,7 @@ sub apply {
                 }
             }
         }
-        $position or throw "Couldn't find anywhere to put hunk.\n";
+        $position or throw("Couldn't find anywhere to put hunk.\n");
     } else {
         # No context.  Use given position.
         $position = [$i_start - $self->{i_lines} - 1]
@@ -730,7 +724,7 @@ sub apply {
     my $ifdef = $self->{ifdef};
 
     # Make sure we're where we left off.
-    seek $in, $self->{i_pos}, 0 or throw "Couldn't seek INFILE: $!";
+    seek $in, $self->{i_pos}, 0 or throw("Couldn't seek INFILE: $!");
 
     my $line = $self->{o_lines} + $position->[0] + 1;
     my $off  = $line - $o_start;
@@ -796,7 +790,7 @@ sub index {
     my ($self, $match, $pos, $lines) = @_;
     my $in = $self->{i_fh};
 
-    seek $in, $pos, 0 or throw "Couldn't seek INFILE [$in, 0, $pos]: $!";
+    seek($in, $pos, 0) or throw("Couldn't seek INFILE [$in, 0, $pos]: $!");
     <$in> while $lines--;
 
     if ($self->{'ignore-whitespace'}) {
@@ -816,7 +810,7 @@ sub index {
                 $line eq $match->[$_] or $fail++, last;
             }
             if ($fail) {
-                seek $in, $tell, 0 or throw "Couldn't seek INFILE: $!";
+                seek($in, $tell, 0) or throw("Couldn't seek INFILE: $!");
                 <$in>;
             } else {
                 return ($tell, $line);
@@ -837,7 +831,7 @@ sub index {
 package
 	Patch::Context; # hide from PAUSE
 
-BEGIN { Patch->import }
+use base 'Patch';
 
 # Convert hunk to unified diff, then apply.
 sub apply {
@@ -891,13 +885,13 @@ sub rummage {
 package
 	Patch::Ed; # hide from PAUSE
 
-BEGIN { Patch->import }
+use base 'Patch';
 
 # Pipe ed script to ed or try to manually process.
 sub apply {
     my ($self, @cmd) = @_;
 
-    $self->{skip} and throw 'SKIP...ignore this patch';
+    $self->{skip} and throw('SKIP...ignore this patch');
 
     my $out = $self->{o_fh};
 
@@ -926,8 +920,8 @@ sub apply {
     }
 
     # Erase any trace of magic line.
-    truncate $out, 0 or throw "Couldn't truncate OUT: $!";
-    seek $out, 0, 0  or throw "Couldn't seek OUT: $!";
+    truncate($out, 0) or throw("Couldn't truncate OUT: $!");
+    seek($out, 0, 0)  or throw("Couldn't seek OUT: $!");
 
     # Try to apply ed script by hand.
     $self->note("Pipe to ed failed.  Switching to Plan J...\n");
@@ -944,7 +938,7 @@ sub apply {
         my @hunk = @{$cmd[$i]};
 
         shift(@hunk) =~ m!^(\d+)(?:,(\d+))?([acds])!
-            or throw "Unable to parse ed script.";
+            or throw('Unable to parse ed script');
 
         my ($start, $end, $cmd) = ($1, $2 || $1, $3);
 
@@ -1043,7 +1037,7 @@ sub apply {
 package
 	Patch::Normal; # hide from PAUSE
 
-BEGIN { Patch->import }
+use base 'Patch';
 
 # Convert hunk to unified diff, then apply.
 sub apply {
@@ -1064,7 +1058,7 @@ sub apply {
 package
 	Patch::Unified; # hide from PAUSE
 
-BEGIN { Patch->import }
+use base 'Patch';
 
 # Check for filename in diff header, then in 'Index:' line.
 sub rummage {


### PR DESCRIPTION
* Program is written in oo-style with subclasses of Patch (Context, Ed, Normal and Unified) 
* Declare subclasses as subclasses with "use base" instead of calling Patch->import() manually
* Now the custom import() code can be deleted
* Two example methods called from subclass are note() and throw()
* I noticed this when searching for "no strict" within bin/ directory
* test1: patch a normal diff (output of "diff a.c b.c")
* test2: patch a unified diff (output of "diff -u a.c b.c")
* test3: patch an ed diff (output of "diff -e a.c b.c")
* test4: patch a context diff (output of "diff -c a.c b.c")