### PR TITLE
fmt: validate width

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -30,6 +30,10 @@ Getopt::Long::config('bundling');
 GetOptions(
     'w=i' => \$MAX_WIDTH,
 ) or usage();
+if ($MAX_WIDTH <= 0) {
+    warn "$Program: width must be positive\n";
+    exit EX_FAILURE;
+}
 
 my $fmt_line = '<' x $MAX_WIDTH;
 


### PR DESCRIPTION
* I observed a suspicious warning when providing negative number as input...
```
%perl fmt -w-1000000 a.c > /dev/null
Negative repeat count does nothing at fmt line 34.
```
* Value for -w must be an int; follow OpenBSD fmt and raise error for 0 and negative
* test1: "perl fmt -w 1.1  a.c" --> already covered by Getopt::Long
* test2: "perl fmt -w''  a.c" --> same as test1
* test3: "perl fmt -w0  a.c" --> new validation
* test4: "perl fmt -w-100  a.c" --> same as test3