### PR TITLE
pr -0 causes divzero

### DIFF
--- a/bin/pr
+++ b/bin/pr
@@ -127,6 +127,10 @@ while (@ARGV && $ARGV[0] =~ /^-(.+)/ && (shift, ($_ = $1), 1)) {
     # Accept -2, -3, etc...
     if (s/\A([0-9]+)//) {
         $columns = $1;
+        if ($columns == 0) {
+	    warn "$Program: invalid number of columns: $columns\n";
+	    exit EX_FAILURE;
+        }
         redo OPTION;
     }
 


### PR DESCRIPTION
* The -NUM option can be used for setting column count, but -0 is not a valid input
```
%perl pr -0  a.c
Illegal division by zero at pr line 338.
```
*  When tracing this, COLINFO list is empty and $columns is zero
* Follow GNU implementation and raise error for -0