### PR TITLE
patch: -o filename versus directory

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -398,6 +398,9 @@ sub bless {
         $self->note("Checking patch against file $orig using Plan C...\n");
         ($in, $out) = ($orig, '');
     } elsif (defined $self->{output}) {
+        if (-d $self->{'output'}) {
+            die "$0: output file '$self->{output}' is a directory\n";
+        }
         $self->note("Patching file $orig using Plan B...\n");
         local $_ = $self->{output};
         $self->skip if -e && not rename $_, $self->backup($_) and


### PR DESCRIPTION
* The "-o file" option is a standard feature of patch
* When I tested -o with a directory argument the directory was replaced with the patched file
* After the initial panic that patch had destroyed the directory, I discovered that it only renamed it to thing.orig
* A directory is not a valid argument for -o; raise an error instead of processing the patch
* This was found when testing against GNU patch