### PR TITLE
patch: accept --dry-run option

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -48,7 +48,7 @@ if (@ARGV) {
         suffix|b=s              force|f                 reject-file|r=s
         prefix|B=s              batch|t                 reverse|R
         context|c               fuzz|F=i                silent|quiet|s
-        check|C                 ignore-whitespace|l     skip|S
+        check|dry-run|C         ignore-whitespace|l     skip|S
         directory|d=s           normal|n                unified|u
         ifdef|D=s               forward|N               version|v
         ed|e                    output|o=s              version-control|V=s

--- a/bin/patch
+++ b/bin/patch
@@ -1278,7 +1278,7 @@ specified any argument from B<-b> will be ignored.
 forces I<patch> to interpret the patch file as a context
 diff.
 
-=item -C or --check
+=item -C or --check or --dry-run
 
 checks  that  the patch would apply cleanly, but does
 not modify anything.


### PR DESCRIPTION
* OpenBSD and FreeBSD versions accept -C, --check and --dry-run; GNU version only accepts --dry-run
* This version already accepted -C and --check