### PR TITLE
patch: runtime error when patching the wrong file

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -18,7 +18,7 @@ License: perl
 
 use strict;
 
-my $VERSION = '0.27';
+my $VERSION = '0.28';
 
 $|++;
 
@@ -705,13 +705,6 @@ sub apply {
                     }
                 } else {
                     throw('SKIP...ignore this patch') if $self->{forward};
-                }
-            } else {
-                unless ($position || $self->{reverse} || $self->{force}) {
-                    $self->{reverse_check} = 1;
-                    $self->{reverse} = 1;
-                    shift;
-                    return $self->apply(@_);
                 }
             }
         }


### PR DESCRIPTION
* patch failed with a strictness error when I specified a file that does not match the context of my diff
* Patch::apply() calls back into Patch::Context::apply() on L714 with the wrong params
* When setting a breakpoint in Patch::apply(), its params are not identical to Patch::Context::apply(), so passing @_ as parameter obviously fails
* Reading the code, this would only be a problem for applying context diffs (no callback to self->apply() happened for the other diff types)
* I confirmed that this error was not caused by the recent use-base.diff (now I suspect it goes back to 1999)
* Removing the code with the incorrect self->apply() call causes patch to correctly report that applying Hunk1 failed, then the program exits with status 1 to indicate that >=1 lines could not be applied

```
%perl -d patch --dry-run expand ab.diff # stack trace from debugger shows Patch::apply() called with no list-ref params
...
Can't use string (" main(void)
") as an ARRAY ref while "strict refs" in use at patch line 844.
 at patch line 844.
	Patch::Context::apply(Patch::Context=HASH(0x22c8870), 5, 5, " main(void)\x{a}", " {\x{a}", " \x{9}puts(\"yo\");\x{a}", "-\x{9}printf(\"float=%lu double=%lu\\n\", sizeof(float), sizeof(doub"..., " \x{9}exit(1);\x{a}", ...) called at patch line 714
	Patch::apply(Patch::Context=HASH(0x22c8870), 5, 5, " main(void)\x{a}", " {\x{a}", " \x{9}puts(\"yo\");\x{a}", "-\x{9}printf(\"float=%lu double=%lu\\n\", sizeof(float), sizeof(doub"..., " \x{9}exit(1);\x{a}", ...) called at patch line 867
	Patch::Context::apply(Patch::Context=HASH(0x22c8870), 5, 5, ARRAY(0x21d3200), ARRAY(0x21cbbf8)) called at patch line 167
```