### PR TITLE
bc: remove signal handling

### DIFF
--- a/bin/bc
+++ b/bin/bc
@@ -2739,16 +2739,6 @@ sub floor_idx {
   return -1;
 }
 
-# catch signals
-sub catch
-{
-  my $signum = shift;
-  print STDERR "\n" if (-t STDERR && -t STDIN);
-  &yyerror("Floating point exception") if $signum == 8;
-  main();
-}
-
-# main program
 sub main
 {
   my $status;
@@ -2766,9 +2756,6 @@ sub main
       exit $status if ! $@;
     }
 }
-
-$SIG{'INT'} = 'catch';
-$SIG{'FPE'} = 'catch';
 
 select(STDERR);
 $| = 1;


### PR DESCRIPTION
* Standard bc does not require any signal handling [1]
* Different versions of bc treat SIGINT differently
* The previous code resulted in bc exiting on ^C on my Linux system, so there's effectively no difference with this patch

1. https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/bc.html