### PR TITLE
grep: filename prefix correction

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -144,7 +144,6 @@ sub parse_args {
 	@opt{ split //, $nulls } = ('') x length($nulls);
 
 	getopts('incCwsxvhe:f:l1HurtpP:aqTF', \%opt) or usage();
-	$Mult = 1 if ($opt{'r'} || @ARGV > 1 || @ARGV > 0 && -d $ARGV[0]) && !$opt{'h'};
 
 	my $no_re = $opt{F} || ( $Me =~ /\bfgrep\b/ );
 	$match_code = '';
@@ -174,6 +173,7 @@ sub parse_args {
 			}
 		@patterns = ($pattern);
 		}
+	$Mult = ($opt{'r'} || scalar(@ARGV) > 1) ^ $opt{'h'};
 	@ARGV = ($opt{'r'} ? '.' : '-') unless @ARGV;
 
 	if ( $opt{H} || $opt{u} ) {    # highlight or underline
@@ -391,9 +391,11 @@ FILE: while ( defined( $file = shift(@_) ) ) {
 
 			print("$name\n"), next FILE if $opt->{l};
 			my $showmatch = !$opt->{'q'} && !$opt->{'c'};
-			$showmatch && print $Mult && "$name:",
-				$opt->{n} ? "$.:" : "", $_,
-				( $opt->{p} || $opt->{P} ) && ( '-' x 20 ) . "\n";
+			if ($showmatch) {
+				print($name, ':') if $Mult;
+				print $opt->{n} ? "$.:" : "", $_,
+					( $opt->{p} || $opt->{P} ) && ( '-' x 20 ) . "\n";
+			}
 
 			next FILE if (!$opt->{'c'} && $opt->{'1'} || $opt->{'q'}); # single match
 			}


### PR DESCRIPTION
* grep output is expected to show the filename if grep is searching many files, or in a recursive search (grep -r)
* The -h flag disables the filename prefix
* $Mult flag controls showing the filename, and was being set to 1 sometimes when it shouldn't be
* test1: "perl grep perl awk" --> show matches for 1 file (no filename prefix, single file argument)
* test2: "perl grep  perl awk ar" --> matches for 2 files (filenames included)
* test3: "perl grep -h perl awk ar" --> matches for 2 files (filenames disabled by -h)
* test4: "perl grep -hr perl ." --> recursive search (filenames disabled)
* test5: "echo elmo | perl grep elm" --> show matches for stdin (no filename prefix, no file arguments)
* test6: "perl grep -l awk a*" --> show filenames matching awk
* test7: "perl grep -r package ." --> recursive search (filenames included)