### PR TITLE
grep: shortcut exit path for -q

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -403,7 +403,10 @@ FILE: while ( defined( $file = shift(@_) ) ) {
 			}
 		}
 	continue {
-		print $Mult && "$name:", $total, "\n" if $opt->{c};
+		if ($opt->{'c'}) {
+			print($name, ':') if $Mult;
+			print $total, "\n";
+		}
 		close FILE;
 		}
 	$Grand_Total += $total;

--- a/bin/grep
+++ b/bin/grep
@@ -383,21 +383,23 @@ FILE: while ( defined( $file = shift(@_) ) ) {
 			next LINE unless $Matches;
 
 			$total += $Matches;
+			last FILE if $opt->{'q'}; # single match for all files
 
 			if ( $opt->{p} || $opt->{P} ) {
 				s/\n{2,}$/\n/ if $opt->{p};
 				chomp         if $opt->{P};
 				}
-
-			print("$name\n"), next FILE if $opt->{l};
-			my $showmatch = !$opt->{'q'} && !$opt->{'c'};
-			if ($showmatch) {
+			if ($opt->{'l'}) {
+				print $name, "\n";
+				next FILE;
+			}
+			unless ($opt->{'c'}) {
 				print($name, ':') if $Mult;
 				print $opt->{n} ? "$.:" : "", $_,
 					( $opt->{p} || $opt->{P} ) && ( '-' x 20 ) . "\n";
 			}
 
-			next FILE if (!$opt->{'c'} && $opt->{'1'} || $opt->{'q'}); # single match
+			next FILE if $opt->{'1'}; # single match per file
 			}
 		}
 	continue {


### PR DESCRIPTION
* The -q flag in grep is concerned if a match was found in any file
* The program can successfully terminate after the first match without searching subsequent files in argument list
* GNU grep behaves in this way; strace on my Linux system confirms that only the 1st file in argument list is opened when that file contains a match
```
%strace  grep -q perl ar awk 2> trace # gnu grep
%grep open trace
...
openat(AT_FDCWD, "ar", _RDONLY|O_NOCTTY|O_LARGEFILE) = 3
^^^ final openat() in process
```