### PR TITLE
cmp: sysread failure guard

### DIFF
--- a/bin/cmp
+++ b/bin/cmp
@@ -168,12 +168,13 @@ if ($skip2) {
 }
 
 READ: while (defined ($read_in1 = sysread $fh1, $buffer1, $chunk_size)) {
-                      $read_in2 = sysread $fh2, $buffer2, $chunk_size;
+    $read_in2 = sysread $fh2, $buffer2, $chunk_size;
+    $read_in2 = 0 unless defined $read_in2; # sysread failed
 
     my $checklength = min($read_in1, $read_in2);
     $checklength-- if $checklength;
 
-    if ($buffer1 ne $buffer2) {
+    if ($checklength != 0 && $buffer1 ne $buffer2) {
         my @bytes1 = unpack 'C*', $buffer1;
         my @bytes2 = unpack 'C*', $buffer2;
 


### PR DESCRIPTION
* Input loop terminates if sysread on file1 fails
* If sysread failed on file2, $read_in2 would be undef, then $checklength would be undef
* It is not correct to compare the two input buffers in this case; $buffer2 possibly wouldn't have been modified since the previous loop iteration
* Skip the buffer comparison if $checklength is zero (treat sysread failure in the same way because there are no bytes to compare)
* In this case it would be correct for cmp to report "EOF on file2" because the read length for file1 is greater
