### PR TITLE
patch: pod update for --ifdef

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -1263,7 +1263,7 @@ directory, and cd to it before doing anything else.
 
 causes  I<patch>  to use the "#ifdef...#endif" construct
 to mark changes.  The argument following will be used
-as the differentiating symbol.  [see L<"note 7">]
+as the differentiating symbol.
 
 =item -e or --ed
 
@@ -1584,11 +1584,6 @@ thinks the failed hunks belong in the new file rather than the old one.
 
 If the original file cannot be found or is read-only, but a suitable SCCS or RCS
 file is handy, GNU patch will attempt to get or check out the file.
-
-=head2 note 7
-
-GNU patch requires a space between the B<-D> and the argument.  This has been
-made optional.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
* Remove note about GNU patch requiring a space between -D and argument (this might have been true for ancient versions but not anymore)
* This version of patch outputs a trailing comment for the ifndef blocks; the OpenBSD version does this also

```
%ifconfig > A
%sed 's/eth0/ent0/' A > B
%perl diff -u A B > AB.diff 
%/usr/bin/patch --version 
GNU patch 2.7.6
%/usr/bin/patch -Dostuff -o C A AB.diff
patching file C (read from A)
%perl patch -Dostuff -o D A AB.diff
Hmm...  Looks like a unified diff to me...
Patching file A using Plan B...
Hunk #1 succeeded at 1.
done
%perl diff C D 
5c5
< #endif
---
> #endif /* ostuff */
```