### PR TITLE
ar: failed read() error

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -200,8 +200,8 @@ sub printMember {
 # writes a directory-style listing for the specified archive member
 sub printList {
     my ($name, $pAr, $verbose) = @_;
-    my $attr = $pAr->{$name};
     if ($verbose) {
+	my $attr = $pAr->{$name};
 	printf "%9s %7d/%-7d %7d %s %s\n",
 		strmode($attr->[4]),
 		$attr->[2],
@@ -289,7 +289,8 @@ sub readAr {
 
     # read magic
     my $magic;
-    read($arfh,$magic,8);
+    my $nread = read $arfh, $magic, length(MAGIC);
+    die "$0: $archive: $!\n" unless defined $nread;
     if ($magic ne MAGIC) {
 	die "$0: $archive: Inappropriate file type or format\n";
     }


### PR DESCRIPTION
* After opening an archive, print $! if it wasn't possible to read the file
* Now it's easier to tell between i/o errors and files which don't contain the magic number data
* Conditionally declare $attr in printList() which is only needed for verbose mode
* test1: "ar t ." --> directory error
* test2: "perl ar t /bin/sh" --> file format error
* test3: "perl ar t test.a" --> short listing of archive contents
* test4: "perl ar tv test.a" --> detailed listing of archive contents