### PR TITLE
awk: auto-clean /tmp

### DIFF
--- a/bin/awk
+++ b/bin/awk
@@ -17,7 +17,7 @@ License: perl
 
 use strict;
 
-use File::Temp qw(tempfile);
+use File::Temp qw();
 
 my(
     $program,		# the code to eval
@@ -44,8 +44,10 @@ usage() unless @ARGV;
 open(SAVE_OUT, '>&', STDOUT) || die "can't save stdout: $!";
 die unless defined fileno SAVE_OUT;
 
-my ($tmpin_fh, $tmpin) = tempfile();
-my ($tmpout_fh, $tmpout) = tempfile();
+my $tmpin_fh = File::Temp->new();
+my $tmpin = $tmpin_fh->filename();
+my $tmpout_fh = File::Temp->new();
+my $tmpout = $tmpout_fh->filename();
 
 # And some people think getopts does everything. Sheesh.
 while (@ARGV) {


### PR DESCRIPTION
* Switch from calling tempfile() to File::Temp->new() to allow the input and output files to be unlinked automatically when the program terminates
* This prevents remnant files in /tmp if die() happens