### PR TITLE
id: gid 0 is valid

### DIFF
--- a/bin/id
+++ b/bin/id
@@ -45,7 +45,7 @@ if ( $opt_u ) { # print uid
 	$tp = scalar getpwuid $tp || $tp if ( $opt_n );
 }
 elsif ( $opt_g ) { # print gid
-	$tp = ($gid)?$gid:(split(/\s+/,($opt_r)?$(:$)))[0];
+	$tp = defined $gid ? $gid : (split(/\s+/,($opt_r)?$(:$)))[0];
 	$tp = scalar getgrgid $tp || $tp if ( $opt_n );
 }
 elsif ( $opt_p ) { # human-readable form (names when possible, etc.)


### PR DESCRIPTION
* Previously commit 92678daec769369d29fef632fc9e412b511698b1 was added to allow resolving "root" to uid 0
* When testing -g option a similar issue was discovered (gid of 0 was being treated as a failure of getpwnam)
* This was discovered while testing against id on my Linux system

```
%grep '^root' /etc/group 
root:x:0:
%/usr/bin/id -g root
0
%perl id -g root # before patch
1000
```