### PR TITLE
morse: leading whitespace failure

### DIFF
--- a/bin/morse
+++ b/bin/morse
@@ -63,6 +63,7 @@ if ($opt{'f'} || scalar(@ARGV) == 0) {
 sub mors2txt {
     my $line = shift;
 
+    $line =~ s/\A\s+//;
     foreach my $m (split /\s+/, $line) {
         if (!exists($translations{$m})) {
             die "$m: unknown token";


### PR DESCRIPTION
* When demonstrating the morse program to my son I found an error in decode mode; it can be reproduced like this: %printf "\n.\n" | perl morse -rs 
: unknown token at morse line 68, <> line 2.

* The following worked as expected, going from text2morse2text:
%printf "aye\nbee\nc++\n" | perl morse -s | perl morse -rs

* So I put on my debuggin' shoes... $line was "\n.\n", split() returns list ('', '.') and the program barfs on the empty string
* Empty string is also indicated by the "unknown token" error message with no character before the ':'
* Fix this by trimming leading whitespace before split()