### PR TITLE
patch: chdir happens too late

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -84,6 +84,11 @@ $patchfile = '-' unless defined $patchfile;
 
 my $patch = Patch->new(@options);
 
+if (defined $patch->{'directory'}) {
+    unless (chdir $patch->{'directory'}) {
+        die "failed to change to directory '$patch->{directory}': $!\n";
+    }
+}
 tie *PATCH, Pushback => $patchfile or die "Can't open '$patchfile': $!";
 
 # Extract patches from patchfile.  We unread/pushback lines by printing to
@@ -352,12 +357,6 @@ sub bless {
     # Speculate to user.
     my $n = $type eq 'ed' ? 'n' : '';
     $self->note("Hmm...  Looks like a$n $type diff to me...\n");
-
-    # Change directories.
-    for ($self->{directory}) {
-        defined or last;
-        chdir $_ or $self->skip("Can't chdir '$_': $!\n");
-    }
 
     # Get original file to patch...
     my $orig = $self->{origfile};                   # ...from -o


### PR DESCRIPTION
* When testing against GNU and OpenBSD patch commands I found that -d DIR in this version is interpreted after reading a patch file
* The standard says -d is interpreted "before processing" [1]
* Follow the other versions of patch and do chdir() as early as possible:
A) Failure to chdir() will terminate the program before any input is read
B) If -d option is used, files in the argument list are relative to that directory not to the originating directory

* test1: "perl patch -d ... a.c" --> fail (no such dir)
* test2: "patch -d .. a.c a.diff" --> patch ../a.c with ../a.diff

1. https://pubs.opengroup.org/onlinepubs/007904975/utilities/patch.html