### PR TITLE
random: raise error for bad option

### DIFF
--- a/bin/random
+++ b/bin/random
@@ -15,45 +15,15 @@ License: perl
 use strict;
 use Getopt::Std;
 
-my ($VERSION) = '1.2';
+my ($VERSION) = '1.3';
 
 my $warnings = 0;
-
-END {
-    close STDOUT || die "$0: can't close stdout: $!\n";
-    $? = 1 if $? == 255;  # from die
-}
-
-# Print a usuage message on a unknown option.
-# Requires my patch to Getopt::Std of 25 Feb 1999.
-$SIG {__WARN__} = sub {
-    if (substr ($_ [0], 0, 14) eq "Unknown option") {die "Usage"};
-    require File::Basename;
-    $0 = File::Basename::basename ($0);
-    $warnings = 1;
-    warn "$0: @_";
-};
-
-$SIG {__DIE__} = sub {
-    require File::Basename;
-    $0 = File::Basename::basename ($0);
-    if (substr ($_ [0], 0,  5) eq "Usage") {
-        die <<EOF;
-$0 (Perl game utils) $VERSION
-$0 [-er] [denominator]
-EOF
-    }
-    die "$0: @_";
-};
-
-# Get the options.
-getopts ('er', \my %options);
-
-die "Usage" if @ARGV > 1;
-
-my $denominator = @ARGV ? shift : 2;
-
-die "Usage" if $denominator =~ /\D/ || $denominator == 0;
+my %options;
+getopts('er', \%options) or usage();
+my $denominator = shift;
+$denominator = 2 unless defined $denominator;
+usage() if @ARGV;
+usage() if $denominator =~ /\D/ || $denominator == 0;
 
 exit int rand $denominator if exists $options {e};
 
@@ -64,6 +34,11 @@ my $frac = 1 / $denominator;
 while (<>) {print if $frac >= rand;}
 
 exit $warnings;
+
+sub usage {
+    warn "usage: $0 [-er] [denominator]\n";
+    exit 1;
+}
 
 __END__
 


### PR DESCRIPTION
* Comparing the NetBSD version of the random-lines game, unknown options should result in usage string being printed
* Usage was already printed for too-many-arguments case
* Create a regular usage() function as done in other scripts

```
%ifconfig | perl random -r 6 # test1: -r
        RX packets 0  bytes 0 (0.0 B)

        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        RX packets 2057  bytes 452554 (441.9 KiB)
%perl random -e 100 # test2: -e
%echo $?
35
%perl random -x # test3: bad option
Unknown option: x
usage: random [-er] [denominator]
%perl random 123 456 # test4: too many args
usage: random [-er] [denominator]
```