### PR TITLE
basename: support -- option terminator 

### DIFF
--- a/bin/basename
+++ b/bin/basename
@@ -13,19 +13,15 @@ License: perl
 
 
 use strict;
-use File::Basename;
 
-my ($VERSION) = '1.3';
+use File::Basename qw(basename fileparse);
+use Getopt::Std qw(getopts);
 
-unless (@ARGV == 1 || @ARGV == 2) {
-    $0 = basename ($0);
-    print <<EOF;
-$0 (Perl bin utils) $VERSION
-usage: $0 string [suffix | /pattern/]
-EOF
-    exit 1;
-};
+my $Program = basename($0);
+our $VERSION = '1.4';
 
+getopts('') or usage();
+usage() unless (@ARGV == 1 || @ARGV == 2);
 if (@ARGV == 2) {
     $ARGV [1] = quotemeta $ARGV [1] unless $ARGV [1] =~ s{^/(.*)/$}{$1};
 }
@@ -44,6 +40,17 @@ $path =~ s/\/\Z//;  #  "a/" -> "a"
 my @parsed = fileparse($path);
 my $name = shift @parsed;
 print $name, "\n";
+exit 0;
+
+sub VERSION_MESSAGE {
+    print "$Program version $VERSION\n";
+    exit 0;
+}
+
+sub usage {
+    warn "usage: $Program string [suffix | /pattern/]\n";
+    exit 1;
+}
 
 __END__
 

--- a/bin/dirname
+++ b/bin/dirname
@@ -21,7 +21,7 @@ use Getopt::Std qw(getopts);
 my $Program = basename($0);
 our $VERSION = '1.3';
 
-getopts('') or die "usage: $Program string\n";
+getopts('') or usage();
 usage() unless scalar(@ARGV) == 1;
 my $path = shift;
 my $dir = dirname($path);


### PR DESCRIPTION
* Similar to what was committed for bin/dirname, '--' should be interpreted as the end of options (currently it is taken literally)
* This was found when testing against OpenBSD version
* test1: "perl basename --" --> error, no argument
* test2: "perl basename -x" --> error, bad option
* test3: "perl basename -- -x" --> basename of "-x"
* While here, one call to usage() in bin/dirname was missed