### PR TITLE
moo: quit on EOF

### DIFF
--- a/bin/moo
+++ b/bin/moo
@@ -37,8 +37,7 @@ print "MOO\n";
     {
         print "Your guess? ";
         chomp (my $guess = <>);
-
-        exit if 'q' eq substr lc $guess, 0, 1;
+        exit if (!defined($guess) || $guess =~ m/\Aq/i);
 
         if ($guess =~ /\D/ || length $guess != $size) {
             print "Bad guess\n";


### PR DESCRIPTION
* When prompted for a guess, "q" terminates the program
* If stdin is attached to a file/pipe, or I run moo interactively and hit ctrl-d I observe a repeated prompt
* The least confusing thing is to act like a "q" command was seen and terminate the program
* test: "ifconfig | perl moo" --> series of "bad guess" messages then the program ends