### PR TITLE
ar: -t lists files not in archive

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -200,8 +200,13 @@ sub printMember {
 # writes a directory-style listing for the specified archive member
 sub printList {
     my ($name, $pAr, $verbose) = @_;
+
+    my $attr = $pAr->{$name};
+    unless (defined $attr) {
+	warn "entry not found in archive: '$name'\n";
+	return;
+    }
     if ($verbose) {
-	my $attr = $pAr->{$name};
 	printf "%9s %7d/%-7d %7d %s %s\n",
 		strmode($attr->[4]),
 		$attr->[2],


### PR DESCRIPTION
* The -t option lists all archive members by default, otherwise only the files specified as arguments
* printList() was incorrectly printing a name that was not found in the archive
* binutils ar prints a warning in this case (printMember() follows this but printList() did not)
```
%perl ar -t test.a # test archive contains 2 files words
wordlist.txt.old
%perl ar -t test.a words words2 # output indicates words2 exists in archive
words
words2
%ar -t test.a words words2 # binutils comparison
words
no entry words2 in archive
```