### PR TITLE
ar: binmode for writing archives

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -351,6 +351,7 @@ sub writeAr {
 	my $putmagic = !$append || !-e $archive;
 	my $arfh     = FileHandle->new( $archive, $mode )
 		or die "$0: failed to open '$archive': $!\n";
+	binmode($arfh);
 	$arfh->print(MAGIC) if $putmagic;
 
 	# loop through each member of the archive and write to filehandle


### PR DESCRIPTION
* I noticed there were 4 calls to FileHande->new() to open files, but only 3 calls to binmode()
* The function missing the binmode() call was writeAr(); this is responsible for writing a modified archive to disk, or creating a brand new archive
* Archives are allowed to contain binary files so enabling binmode() here seems like a good idea
* I didn't test this on Windows but I didn't see any regression with patch applied on Linux
```
%cc a.c
%perl ar -qv A.a a.out # create new archive with just the binary a.out
a - a.out
```