### PR TITLE
ar: best-effort extract & delete

### DIFF
--- a/bin/ar
+++ b/bin/ar
@@ -83,7 +83,7 @@ for my $file (@ARGV) {
 			print "d - $name\n" if $opt_v;
 			}
 		else {
-			die "$0: $name: not found in archive\n";
+			warn "$0: $name: not found in archive\n";
 			}
 		}
 	elsif ($opt_m) {
@@ -150,7 +150,7 @@ for my $file (@ARGV) {
 			extractMember( $name, $pAr, $opt_v, $opt_o, $opt_u );
 			}
 		else {
-			die "$0: $name: not found in archive\n";
+			warn "$0: $name: not found in archive\n";
 			}
 		}
 	}


### PR DESCRIPTION
* If extracting or deleting multiple archive members, process all arguments even if some members are not found
* This patch follows how binutils version works
```
%ar -t test2.a # list archive members
words
wordlist.txt.ol
%ar -xv test2.a not1 not2 words # extract 3 files (1 is extracted)
no entry not1 in archive
no entry not2 in archive
x - words
%ar -dv test2.a test test2 words # delete 3 files (1 is deleted)
No member named `test'
No member named `test2'
d - words
```