### PR TITLE
pwd: don't raise error for -- terminator

### DIFF
--- a/bin/pwd
+++ b/bin/pwd
@@ -13,30 +13,16 @@ License: perl
 
 
 use strict;
-use Cwd;
 
-my ($VERSION) = '1.3';
+use Cwd qw(cwd getcwd);
+use Getopt::Std qw(getopts);
 
-my $dir;
-my $opt = pop @ARGV;
+my ($VERSION) = '1.4';
 
-if (not defined $opt)
-{
-	$dir = getcwd;
-}
-elsif ($opt eq '-L')
-{
-	$dir = cwd;
-}
-elsif ($opt eq '-P')
-{
-	$dir = getcwd;
-}
-else
-{
-	die "Usage: pwd [-L|-P]\n";
-}
-
+my %opt;
+getopts('LP', \%opt) or usage();
+usage() if @ARGV;
+my $dir = $opt{'L'} ? cwd() : getcwd(); # default -P
 unless (defined $dir) {
 	warn "pwd: $!\n";
 	exit 1;
@@ -46,6 +32,11 @@ if ($^O =~ m/Win32/) {
 }
 print $dir . "\n";
 exit;
+
+sub usage {
+	warn "usage: pwd [-L|-P]\n";
+	exit 1;
+}
 
 __END__
 


### PR DESCRIPTION
* This version of pwd already acted like the BSD version because it would raise an error if any non-option arguments are provided
* When testing against OpenBSD, the usage ```pwd -L --``` is valid; this version raised an error because '--' was interpreted as an argument instead of option terminator
* getopts() handles -- internally, so switch over to it as done in other scripts