### PR TITLE
addbib: avoid interpolated params to system()

### DIFF
--- a/bin/addbib
+++ b/bin/addbib
@@ -106,7 +106,7 @@ while (1) {
 	$_ = <>;
 	while (/^\s*(edit|ex|vi|view|emacs)\s*/) {
 		close $DATABASE or die "can't close $database: $!";
-		system("$1 $database") == 0
+		system($1, $database) == 0
 		 or die "system '$1 $database' failed: $?";
 		open my $DATABASE, '>>', $database or die "can't open $database: $!";
 		print "Continue? (y) ";


### PR DESCRIPTION
* When entering "vi" at the Continue prompt, perl would execute a shell instead of executing vi directly
* The filename ";halt" combined with vi produces two commands passed to the shell
* There is still a problem in the loop where the filehandle is closed before hitting "y" to continue, but this can be addressed separately
```
%perl addbib ";halt"
Instructions? (n) n
Author name: a
Title: a
Journal: a
Volume: a
Pages: a
Publisher: a
City: a
Date: a
Other: a
Keywords: a
Abstract: a
a
^D
Continue? (y) vi
Failed to halt system via logind: Interactive authentication required. Failed to open initctl fifo: Permission denied
Failed to talk to init daemon.
system 'vi ;halt' failed: 256 at addbib line 109, <> line 1.
```