### PR TITLE
addbib: support ed editor

### DIFF
--- a/bin/addbib
+++ b/bin/addbib
@@ -104,7 +104,7 @@ while (1) {
 } continue {
 	print "Continue? (y) ";
 	$_ = <>;
-	while (/^\s*(edit|ex|vi|view|emacs)\s*/) {
+	while (/^\s*(ed|edit|ex|vi|view|emacs)\s*/) {
 		close $DATABASE or die "can't close $database: $!";
 		system($1, $database) == 0
 		 or die "system '$1 $database' failed: $?";


### PR DESCRIPTION
* BSD version of addbib allows vi, ex, edit and ed [1] [2]
* This version supported emacs (keep it) but not ed

1. https://github.com/AaronJackson/2.11BSD/blob/main/usr.bin/refer/addbib.c#L215
2. https://man.freebsd.org/cgi/man.cgi?query=addbib&apropos=0&sektion=0&manpath=FreeBSD+14.1-RELEASE+and+Ports&arch=default&format=html