### PR TITLE
addbib: correctly re-open database

### DIFF
--- a/bin/addbib
+++ b/bin/addbib
@@ -45,7 +45,8 @@ if (defined $opt_p) {
 }
 
 my $database = shift;
-open my $DATABASE, '>>', $database or die "can't append to $database: $!";
+my $DATABASE;
+open $DATABASE, '>>', $database or die "can't append to $database: $!";
 
 my $inst = <<_EOINST;
 	Addbib will prompt you for various bibliographic fields.
@@ -108,7 +109,7 @@ while (1) {
 		close $DATABASE or die "can't close $database: $!";
 		system($1, $database) == 0
 		 or die "system '$1 $database' failed: $?";
-		open my $DATABASE, '>>', $database or die "can't open $database: $!";
+		open $DATABASE, '>>', $database or die "can't open $database: $!";
 		print "Continue? (y) ";
 		$_ = <>;
 	}


### PR DESCRIPTION
* I discovered the cause of the close() error I was seeing when editing a database entry with vi, then hitting y to continue
* When continuing a new entry is expected to be appended to the database
* The file was closed and re-opened between executing vi; however, due to the "my" declaration in the open() call an alias of the global filehandle $DATABASE was made
* Make sure there is only one $DATABASE variable; now I can correctly append new entries after editing an entry with vi

```
%perl addbib 123c
Instructions? (n) n
Author name: 123
Title: 123
Journal: 123
Volume: 123
Pages: 123
Publisher: 123
City: 123
Date: 123
Other: 123
Keywords: 123
Abstract: 123
Continue? (y) vi
Continue? (y) y
Author name: this 
Title: 234
Journal: 234
Volume: 234
Pages: 234
Publisher: 234
City: 234
Date: 234
Other: 234
Keywords: 234
Abstract: 23444
Continue? (y) n
%cat 123c # empty line1 had been deleted from 1st database entry with vi
%A	123
%T	123
%J	123
%V	123
%P	123
%I	123
%C	123
%D	123
%O	123
%K	123
%X	123

%A	this
%T	234
%J	234
%V	234
%P	234
%I	234
%C	234
%D	234
%O	234
%K	234
%X	23444
```