### PR TITLE
grep: retire study()

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -182,7 +182,7 @@ sub parse_args {
 
 		eval {                     # try to look up escapes for stand-out
 			require POSIX;         # or underline via Term::Cap
-			use Term::Cap;
+			require Term::Cap;
 
 			my $termios = POSIX::Termios->new();
 			$termios->getattr;
@@ -241,8 +241,6 @@ sub parse_args {
 	$opt{1}   += $opt{l};                                                                     # that's a one and an ell
 	$opt{H}   += $opt{u};
 	$opt{c}   += $opt{C};
-
-	$match_code .= 'study;' if @patterns > 5;    # might speed things up a bit
 
 	foreach (@patterns) {s(/)(\\/)g}
 


### PR DESCRIPTION
* Current perl treats study() call as no-op so delete it [1]
* grep was the only caller of study(); no other scripts need updating
* While here, convert a "use" statement within a condition to a "require" (found by perlcritic)
* Regression test: "perl grep -Hn include a.c b.c" --> still highlights the matching part of each line on my Linux system

1. https://perldoc.perl.org/functions/study