### PR TITLE
grep: wrong exit code for grep -s

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -53,7 +53,7 @@ use File::Basename qw(basename);
 use File::Spec;
 use Getopt::Std;
 
-our $VERSION = '1.001';
+our $VERSION = '1.002';
 
 $| = 1;                   # autoflush output
 
@@ -333,7 +333,7 @@ FILE: while ( defined( $file = shift(@_) ) ) {
 				$file       = "$Compress{$ext} $file |";
 				$compressed = 1;
 				}
-			elsif ( !( -T $file || $opt->{a} ) ) {
+			elsif (!$opt->{'a'} && -B $file) {
 				warn qq($Me: skipping binary file "$file"\n) if $opt->{T};
 				next FILE;
 				}
@@ -353,11 +353,11 @@ FILE: while ( defined( $file = shift(@_) ) ) {
 			else {
 				$ok = open $fh, '<', $file;
 				}
-			if ( !$ok && !$opt->{'s'} ) {
-				warn "$Me: $file: $!\n";
+			if (!$ok) {
+				warn "$Me: $file: $!\n" unless $opt->{'s'};
 				$Errors++;
+				next FILE;
 				}
-			next FILE unless $ok;
 			}
 
 		$total = $Matches = 0;


### PR DESCRIPTION
* This version of grep skips binary files by default; this behaviour is inconsistent with GNU version but the difference could be addressed later
* If the file argument exists but cannot be opened, grep was skipping the file with a strange "binary file" message
* I found this when testing "grep -s", which is expected to exit with 2 if a file couldn't be opened
* I triggered open() error by removing file permissions on my Linux system
```
%chmod 0 a.c
%perl grep -T include a.c
grep: skipping binary file "a.c"
```

* Correct the binary file condition; skip the file argument if file is binary (filetest -B) and we're not running grep -a
* Correct the logic for exit code; $Errors should increment regardless of -s because exit code is determined from it
* Bump version
* With patch applied, grep (without -s) correctly prints the error from open() (Permission Denied for my test), and exits with code 2
* Regression test: "perl grep -s pat1 bad.file.name" --> exit 2, silent