### PR TITLE
grep: implement -x for fixed strings

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -53,7 +53,7 @@ use File::Basename qw(basename);
 use File::Spec;
 use Getopt::Std;
 
-our $VERSION = '1.002';
+our $VERSION = '1.003';
 
 $| = 1;                   # autoflush output
 
@@ -199,15 +199,26 @@ sub parse_args {
 		}
 
 	if ($no_re) {
-		if ($opt{'w'} || $opt{'x'} || $opt{'H'} || $opt{'u'}) {
-			die("$Me: -H, -u, -w and -x are incompatible with -F\n");
+		if ($opt{'H'} || $opt{'u'} || $opt{'w'}) {
+			die "$Me: -H, -u and -w are incompatible with -F\n";
 		}
-		my $testop = $opt{'v'} ? '==' : '!=';
-		if ($opt{'i'}) {
-			$match_code = "for my \$pat (\@patterns) { \$Matches++ if (index(lc \$_, lc \$pat) $testop -1) }";
+		if ($opt{'x'}) { # exact match
+			my $testop = $opt{'v'} ? 'ne' : 'eq';
+			if ($opt{'i'}) {
+				$match_code = "my \$c=\$_; chomp \$c; for my \$pat (\@patterns) {\$Matches++ if (lc(\$c) $testop lc(\$pat)) }";
+			}
+			else { # case sensitive
+				$match_code = "my \$c=\$_; chomp \$c; for my \$pat (\@patterns) {\$Matches++ if (\$c $testop \$pat) }";
+			}
 		}
-		else { # case sensitive
-			$match_code = "for my \$pat (\@patterns) { \$Matches++ if (index(\$_, \$pat) $testop -1) }";
+		else { # regular match
+			my $testop = $opt{'v'} ? '==' : '!=';
+			if ($opt{'i'}) {
+				$match_code = "for my \$pat (\@patterns) { \$Matches++ if (index(lc \$_, lc \$pat) $testop -1) }";
+			}
+			else { # case sensitive
+				$match_code = "for my \$pat (\@patterns) { \$Matches++ if (index(\$_, \$pat) $testop -1) }";
+			}
 		}
 		$matcher = eval "sub { $match_code }";
 		die if $@;


### PR DESCRIPTION
* Standards document mentions that option -x should work with fixed strings [1]
* This version didn't allow -x with -F; add it now for better compliance with standard
* I have a small test file with some C code
* test1: "perl grep int a.c" --> matches "int\n" and "printf(...);\n"
* test2: "perl grep -i Int a.c" --> same match as test1
* test3: "perl grep -iv Int a.c" --> matches all except "int\n" and "printf(...);\n"
* test4: "perl grep -v Int a.c" --> matches all lines because Int doesn't appear at all
* test5: "perl grep -F -x int a.c" --> matches only "int\n"
* test6: "perl grep -Fxi Int a.c" --> same match as test5
* test7: "perl grep -Fxiv Int a.c" --> matches all except "int\n"
* test8: "perl grep -Fxv Int a.c" --> matches all lines because Int doesn't appear at all

1. https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html