### PR TITLE
what: reduce code nesting

### DIFF
--- a/bin/what
+++ b/bin/what
@@ -30,45 +30,35 @@ for my $file (@ARGV)
 #### pass in file handle, file name, and whether to stop printing after 1st "what"
 sub printWhat
 {
-    my $file_handle = $_[0];
-    my $file_name   = $_[1];
-    my $stop_flag   = $_[2];
+    my $file_handle = shift;
+    my $file_name   = shift;
+    my $stop_flag   = shift;
+    my $line;
     print "$file_name:\n" if $file_name ne "";
-    my $done = 0;
-    while (! $done)
+    while (defined($line = <$file_handle>))
     {
-        my $line = <$file_handle>;
-        if (defined $line)
+        next unless $line =~ m/\@\(#\)/;
+
+        if ((! $stop_flag) && ($line =~ /\0/)) ## there may be more than 1 in here
         {
-            if ($line =~ /\@\(#\)/)
+            my @F = split(/\0/, $line);
+            my @match = grep { m/\@\(#\)/ } @F;
+            for my $f (@match)
             {
-                if ((! $stop_flag) && ($line =~ /\0/)) ## there may be more than 1 in here
-                {
-                    my @F = split(/\0/,$line);
-                    for my $f (@F)
-                    {
-                        last if $done;
-                        if ($f =~ /\@\(#\)/)
-                        {
-                            $f =~ s|.*\@\(#\)||;
-                            $f =~ s|[">\0\\].*||; ##BSD spec says print to 1st " > \ or null
-                            chomp $f;
-                            print "        $f\n";
-                            $done = 1 if $stop_flag;
-                        }
-                    }
-                }
-                else
-                {
-                    $line =~ s|.*\@\(#\)||;
-                    $line =~ s|[">\0\\].*||; ##BSD spec says print to 1st " > \ or null
-                    chomp $line;
-                    print "        $line\n";
-                }
-                $done = 1 if $stop_flag;
+                $f =~ s|.*\@\(#\)||;
+                $f =~ s|[">\0\\].*||; ##BSD spec says print to 1st " > \ or null
+                chomp $f;
+                print "        $f\n";
             }
         }
-        else { $done = 1; }
+        else
+        {
+            $line =~ s|.*\@\(#\)||;
+            $line =~ s|[">\0\\].*||; ##BSD spec says print to 1st " > \ or null
+            chomp $line;
+            print "        $line\n";
+        }
+        last if $stop_flag;
     }
 }
 


### PR DESCRIPTION
* Rewrite printWhat() function with fewer levels of nesting
* Input loop is restructured to no longer require $done variable
* Replace if-regex-matches loop with grep()
* I verified that the output, with and without -s flag, matches the output of an older commit when running command across all of /usr/bin on my Linux system
* I also ran a diff of output between -s and not-s to show that -s only lists one match per input file

```
%perl what /usr/bin/* > whatnew 
%perl ~/PerlPowerTools3/bin/what /usr/bin/* > whatold 
%cmp whatold whatnew 
%perl what -s /usr/bin/* > whatsnew 
%perl ~/PerlPowerTools3/bin/what -s /usr/bin/* > whatsold 
%cmp whatsnew whatsold  
%diff -U1 whatsnew whatnew 
--- whatsnew	2024-09-30 22:32:43.669989040 +0800
+++ whatnew	2024-09-30 22:31:50.659989071 +0800
@@ -282,2 +282,3 @@
 /usr/bin/crontab:
+         Copyright 1988,1989,1990,1993,1994 by Paul Vixie
          All rights reserved
@@ -300,2 +301,3 @@
 /usr/bin/cvs:
+        rcsid_bron: $miros: src/gnu/usr.bin/cvs/lib/getdate.y,v 1.14 2021/01/30 02:28:27 tg Exp $
         rcsid_code: $MirOS: src/gnu/usr.bin/cvs/lib/getdate.c,v 1.19 2021/01/30 02:30:17 tg Exp $
@@ -433,2 +435,3 @@
          dvi2tty.c 6.0.0 20160305 M.J.E. Mol (c) 1989-2010, and contributors (c) -2016
+         dvistuff.c  6.0.0 20101027 M.J.E. Mol (c) 1989-2010
 /usr/bin/dviasm:
@@ -542,2 +545,3 @@
 /usr/bin/file:
+        $File: file.c,v 1.187 2020/06/07 17:38:30 christos Exp $
         $File: seccomp.c,v 1.15 2020/05/30 23:56:26 christos Exp $
@@ -1372,2 +1376,3 @@
 /usr/bin/pbyacc:
+        yaccpar 1.8 (Berkeley) 01/20/91 (JAKE-P5BP-0.6 04/26/98)
         yaccpar 1.8 (Berkeley) 01/20/91
```