### PR TITLE
what: -s flag prints out of order

### DIFF
--- a/bin/what
+++ b/bin/what
@@ -39,7 +39,7 @@ sub printWhat
     {
         next unless $line =~ m/\@\(#\)/;
 
-        if ((! $stop_flag) && ($line =~ /\0/)) ## there may be more than 1 in here
+        if ($line =~ m/\0/) ## there may be more than 1 in here
         {
             my @F = split(/\0/, $line);
             my @match = grep { m/\@\(#\)/ } @F;
@@ -49,6 +49,7 @@ sub printWhat
                 $f =~ s|[">\0\\].*||; ##BSD spec says print to 1st " > \ or null
                 chomp $f;
                 print "        $f\n";
+                return if $stop_flag;
             }
         }
         else
@@ -57,8 +58,8 @@ sub printWhat
             $line =~ s|[">\0\\].*||; ##BSD spec says print to 1st " > \ or null
             chomp $line;
             print "        $line\n";
+            return if $stop_flag;
         }
-        last if $stop_flag;
     }
 }
 


### PR DESCRIPTION
* -s flag means to stop searching the current file argument, and move to the next file argument, after the first match
* Input loop reads lines, and a line might contain NUL
* NUL is expected to terminate patterns in the same way as newline, but NUL was only handled correctly if -s flag was not set
* I found this when comparing the output with and without -s
```
%perl strings /usr/bin/cvs | perl grep -Fi miros  # string order = lowercase miros 1st
@(#)rcsid_bron: $miros: src/gnu/usr.bin/cvs/lib/getdate.y,v 1.14 2021/01/30 02:28:27 tg Exp $
@(#)rcsid_code: $MirOS: src/gnu/usr.bin/cvs/lib/getdate.c,v 1.19 2021/01/30 02:30:17 tg Exp $

%perl what /usr/bin/cvs # all matches
/usr/bin/cvs:
        rcsid_bron: $miros: src/gnu/usr.bin/cvs/lib/getdate.y,v 1.14 2021/01/30 02:28:27 tg Exp $
        rcsid_code: $MirOS: src/gnu/usr.bin/cvs/lib/getdate.c,v 1.19 2021/01/30 02:30:17 tg Exp $

%perl what -s /usr/bin/cvs # one match (patch applied)
/usr/bin/cvs:
        rcsid_bron: $miros: src/gnu/usr.bin/cvs/lib/getdate.y,v 1.14 2021/01/30 02:28:27 tg Exp $
```