### PR TITLE
ed: w doesn't print byte count

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -108,7 +108,7 @@ my $NO_QUESTIONS_MODE = 0;
 my $PRINT_NUM = 1;
 my $PRINT_BIN = 2;
 
-our $VERSION = '0.4';
+our $VERSION = '0.5';
 
 my %ESC = (
     7  => '\a',
@@ -179,8 +179,7 @@ if (defined $opt{'p'}) {
 $args[0] = shift;
 $args[0] = undef if (defined($args[0]) && $args[0] eq '-');
 Usage() if @ARGV;
-$SupressCounts = 1 if ($opt{'s'} || !defined($args[0]));
-
+$SupressCounts = $opt{'s'};
 edEdit($NO_QUESTIONS_MODE, $NO_APPEND_MODE);
 input() while 1;
 


### PR DESCRIPTION
* Today I noticed that when starting ed without a file argument, writing a file with "w file.name" didn't print a byte count
* I confirmed that BSD and GNU versions of ed do print a byte count in this case
* When reading the code, the flag $SupressCounts should only be set when running ed in "script" mode (ed -s)
* The code setting the flag for no file argument is not correct (w command will fail unless a filename has either been provided directly as argument, or set earlier with f command)
* Bump version
```
%perl ed
a
this is ok
.
w some.file 
11
q
```