### PR TITLE
tsort: allow independent nodes

### DIFF
--- a/bin/tsort
+++ b/bin/tsort
@@ -68,6 +68,7 @@ while (@input) {
     next if defined $pairs{$l}{$r};
     $pairs{$l}{$r}++;
     $npred{$l} += 0;
+    next if $l eq $r;
     ++$npred{$r};
     push @{$succ{$l}}, $r;
 }


### PR DESCRIPTION
* When a node refers to itself in a pair it means the node exists but does not depend on anything
* Previously, this input would result in a "cycle" error
* In my test file, allow node 'd' to be added to hash ```%npred``` with predecessor count of zero, so it then appears in list ```@list```
* The inner "foreach" loop does not execute for node 'd' because it has no dependency; it has no need for an entry in hash ```%succ```

```
%perl cat in.tsort2
a b
b
  c
d d
%perl tsort.old in.tsort2
a
b
c
tsort.old: cycle detected
%perl tsort in.tsort2 # patched
a
b
c
d
%perl cat in.tsort3
a a
%perl tsort in.tsort3 # output agrees with GNU tsort
a
```