### PR TITLE
ed: -s silences warning in edEdit()

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -462,7 +462,7 @@ sub edPrintBin { edPrint($PRINT_BIN); }
 sub edQuitAsk { edQuit(1); }
 sub edAppend { edInsert(1); }
 sub edWriteAppend { edWrite(1); }
-sub edEditAsk { edEdit($QUESTIONS_MODE,$NO_INSERT_MODE); }
+sub edEditAsk { edEdit(!$SupressCounts, $NO_INSERT_MODE); }
 sub edRead { edEdit($QUESTIONS_MODE,$INSERT_MODE); }
 
 #
@@ -1201,7 +1201,7 @@ By default no prompt is displayed.
 
 =item -s
 
-Suppress byte counts
+Suppress byte counts and diagnostics
 
 =back
 


### PR DESCRIPTION
* Go with the BSD treatment of -s flag: allow e command to open a new file (replacing the line buffer) without warning if the buffer was modified
* This is more correct because in script mode (-s) ed is not being used interactively
* This difference was discovered when testing OpenBSD version