### PR TITLE
ed: allow repeated search with // and ??

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -1284,6 +1284,22 @@ Quit program
 
 Read named FILE into buffer
 
+=item /PATTERN
+
+Search for PATTERN in the buffer, starting from the current line.
+If no pattern is given the previous search is repeated.
+
+=item ?PATTERN
+
+Search backwards for PATTERN in the buffer, starting from the current line.
+If no pattern is given the previous search is repeated.
+
+=item g/PATTERN/CMD
+
+Search globally in buffer for PATTERN and run command CMD on each matching line.
+CMD is a single command letter of the following: 'l', 'n' and 'p'.
+CMD can be omitted.
+
 =item s///
 
 Substitute text with a regular expression

--- a/bin/ed
+++ b/bin/ed
@@ -886,14 +886,14 @@ sub edSetCurrentLine {
 
 sub edParse {
     s/\A\s+//;
-    if (m/\A(\/|\?)\z/) {
+    if (m/\A(\/|\?)\z/ || m/\A(\/{2}|\?{2})\s*\z/) {
         unless (defined $SearchPat) {
             edWarn(E_NOPAT);
             $command = 'nop';
             return 1;
         }
         my $found;
-        if ($1 eq '/') {
+        if ($1 eq '/' || $1 eq '//') {
             $found = edSearchForward($SearchPat);
         } else {
             $found = edSearchBackward($SearchPat);


### PR DESCRIPTION
* In commit 78d54294099cfab729e156e8a0f123939da14179, repeat search was only implemented for "/" and "?"
* Add support for empty patterns specified as "??" and "//" (these may be followed by whitespace, but single "?" and "/" may not)
* test1: "/\n" --> repeat search down
* test2: "/ \n" --> start new search (down) for " "
* test3: "// \n" --> repeat search down
* test4: "?\n" --> repeat search up
* test5: "? \n"--> start new search (up) for " "
* test6: "?? \n --> repeat search up
* Entering //n doesn't seem to work for repeating search then issuing n command (this could be supported later)