### PR TITLE
file: -f option doesn't work properly

### DIFF
--- a/bin/file
+++ b/bin/file
@@ -123,12 +123,16 @@ GetOptions(
     ) or usage();
 
 # the names of the files are in $fileList.
-if ($fileList) {
+if (defined $fileList) {
     my $fileListFH = FileHandle->new($fileList, 'r') or do {
       warn "$F: $fileList: $!\n";
       exit EX_FAILURE;
     };
-    unshift(@ARGV,<$fileListFH>);
+    my $line;
+    while (defined($line = <$fileListFH>)) {
+      chomp $line;
+      push @ARGV, $line;
+    }
     $fileListFH->close();
 }
 


### PR DESCRIPTION
* Non-standard option -f takes a path argument to read a list of paths to check
* Problem1: "file -f 0" is valid but incorrect truth check did not recognise -f
* Problem2: lines read from file are terminated by newlines, and these newlines were incorrectly being added into ARGV as part of the string (resulting in open() failure)
```
%cat 0
comm
ar
%perl file -f 0
comm: executable /usr/bin/perl script text
ar: executable /usr/bin/perl script text
```