### PR TITLE
ed: start breaking up edParse()

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -143,9 +143,6 @@ my @ESC = (
 );
 
 my %WANT_FILE = (
-    'e' => 1,
-    'E' => 1,
-    'f' => 1,
     'r' => 1,
     'w' => 1,
     'W' => 1,
@@ -568,12 +565,9 @@ sub edFilename {
         edWarn(E_ADDREXT);
         return;
     }
-
     if (defined($args[0])) {
         $RememberedFilename = $args[0];
-        return;
     }
-
     if (defined($RememberedFilename)) {
         print "$RememberedFilename\n";
     }
@@ -909,7 +903,7 @@ sub edParse {
         $_ = $found . 'p';
         return edParse();
     }
-    if (s/\A(g|v)\///) {
+    if (s/\A([gv])\///) {
         my $invert = $1 eq 'v';
         my $end = rindex $_, '/';
         return 0 if $end == -1; # g/re/p needs trailing /
@@ -924,6 +918,18 @@ sub edParse {
             push @inbuf, $i . $repcmd;
         }
         $command = 'nop';
+        return 1;
+    }
+    if (s/\A([Eef])//) { # 0-address file commands
+        $command = $1;
+        return 0 if m/\A\S/; # space before optional argument
+        s/\A\s+//;
+        $args[0] = $_ if length;
+        return 1;
+    }
+    if (s/\A([HhPQq])//) { # 0-address flag commands
+        $command = $1;
+        return 0 if m/\S/; # no argument
         return 1;
     }
 
@@ -941,7 +947,7 @@ sub edParse {
                   (([+-])?(\d+))?         # [+]num | -num
                   (([\+]+)|([-^]+))?        # + | -
                 )?
-                 ([acdeEfhHijlmnpPqQrstwW=\!])?        # command char
+                 ([acdijlmnprstwW=\!])?        # command char
                  ([a-z])?                # command suffix
                  (\s*)(.+)?                # argument (filename, etc.)
                  )$/x);


### PR DESCRIPTION
* Unhook commands E, e, f, H, h, P, Q and q from the large regex in edParse(); the idea is to remove the large regex entirely
* Commands E, e and f allow zero or one argument; the other commands require no argument
* None of these commands allows an address prefix, e.g. 1,2P is invalid
* When testing against GNU ed I discovered "f FILENAME" should still print the filename when setting it
* Later the remaining commands can be removed from the large regex if calculateLine() function strips address prefix from $_ at start of edParse()
```
%perl ed # empty buffer and no saved filename
P     ---> toggle * prompt
*e a.c   ---> start editing a file
197
*H   --->  toggle auto-help
*123d
?
invalid address  ---> error message displays by itself
*H  ---> disable auto-help
*,d   ---> delete all lines
*h  ---> display previous error saved from 123d command
invalid address
*E   ---> reload a.c because I don't want to delete all lines
197
*f  ---> show saved filename
a.c
*f a.c.copy ---> set new filename to write to
a.c.copy
*1,2d ---> delete first two lines
*w ---> write changes to a.c.copy
158
*q
```