### PR TITLE
ed: re-add support for /re/ address-mode

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -958,6 +958,25 @@ sub getAddr {
         $n = $CurrentLineNum;
     } elsif (s/\A\$//) { # '$' == max line
         $n = maxline();
+    } elsif (s/\A\///) { # '/re/' == search
+        my $i;
+        my @chars = split //;
+        for ($i = 0; $i < scalar(@chars); $i++) {
+            my $j = $i - 1;
+            $j = 0 if $j < 0;
+            last if $chars[$i] eq '/' && $chars[$j] ne '\\';
+        }
+        my $re = substr $_, 0, $i;
+        if (length($re) == 0) {
+            if (defined $SearchPat) {
+	        $re = $SearchPat;
+            } else {
+	        edWarn(E_NOPAT);
+	        return 0;
+            }
+        }
+        $_ = substr $_, $i + 1;
+        $n = edSearchForward($re);
     }
     return $n;
 }


### PR DESCRIPTION
* Standard ed allows a regex to be placed in front of a command
* Previously CalculateLine() supported this but the function was replaced by getAddr()
* Add a new condition in getAddr() to allow resolving /re/ command prefix to a line number
* Be careful to support repeated search for empty pattern
* test1: /include/n  ---> search for /include/, resolve line number and run n command
* test2: //l ---> repeat search using saved /include/ pattern, then run l command on matching line
* test3: /return/  ---> no command given with pattern still works
* test4: ```/a\/b/p``` --> search pattern includes escaped slash; run p command on matching line