### PR TITLE
grep: search results listed in lowercase

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -54,7 +54,7 @@ use File::Spec;
 use File::Temp qw();
 use Getopt::Std;
 
-our $VERSION = '1.007';
+our $VERSION = '1.008';
 
 $| = 1;                   # autoflush output
 
@@ -171,15 +171,15 @@ sub parse_args {
 		}
 	};
 	my $cls_fgrep_i = sub {
-		$_ = lc $_;
+		my $s = lc $_;
 		for my $pattern (@patterns) {
-			$Matches++ if index($_, lc $pattern) != -1;
+			$Matches++ if index($s, lc $pattern) != -1;
 		}
 	};
 	my $cls_fgrep_iv = sub {
-		$_ = lc $_;
+		my $s = lc $_;
 		for my $pattern (@patterns) {
-			$Matches++ if index($_, lc $pattern) == -1;
+			$Matches++ if index($s, lc $pattern) == -1;
 		}
 	};
 	my $cls_fgrep_x = sub {


### PR DESCRIPTION
* I noticed that "grep -Fi pattern" was incorrectly listing matching lines in all lowercase
* When reading the code, this issue had already been fixed in closures $cls_fgrep_xiv and $cls_fgrep_xi
* Apply same pattern in closures $cls_fgrep_i and $cls_fgrep_iv (avoid modification of $_ in match function)
* test1: "perl grep -Fin INCLUDE a.c" ---> exercise $cls_fgrep_i (including line numbers)
* test2: "perl grep -Fiv INT a.c" ---> exercise $cls_fgrep_iv