### PR TITLE
ed: allow address ranges with g command

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -1033,8 +1033,24 @@ sub edSearchBackward {
 sub edSearchGlobal {
     my($pattern, $invert) = @_;
 
+    my $end = maxline();
+    my $start = 1;
+    if (defined $adrs[0]) {
+        if ($adrs[0] == 0) {
+            edWarn(E_ADDRBAD);
+            return;
+        }
+        $start = $end = $adrs[0];
+    }
+    if (defined $adrs[1]) {
+        if ($adrs[1] == 0) {
+            edWarn(E_ADDRBAD);
+            return;
+        }
+        $end = $adrs[1];
+    }
     my @found;
-    for my $i (1 .. maxline()) {
+    for my $i ($start .. $end) {
         my $match;
         if ($invert) {
             $match = $lines[$i] !~ m/$pattern/;


### PR DESCRIPTION
* When testing "g" command against BSD version I discovered 1- and 2-address prefix is accepted
* Implement this by looking at ```@adrs``` in edSearchGlobal(); address list has been populated earlier in edParse()
* test1: g/include/p ---> process lines 1 to $Max
* test2: 1g/include/p ---> process only line 1
* test3: 1,2g/include/p ---> process lines 1 to 2
* test4: ,2g/include/p ---> same as test3