### PR TITLE
kill: reject undocumented -L

### DIFF
--- a/bin/kill
+++ b/bin/kill
@@ -24,7 +24,7 @@ my @signals = getsigs();
 my %hsignals = map { $_ => 1 } @signals;
 my $signal = 'TERM';
 
-if ( $ARGV[0] =~ /^-l$/i ) { # list signals
+if ($ARGV[0] eq '-l') { # list signals
 	siglist();
 	exit 0;
 }
@@ -73,7 +73,7 @@ sub usage {
 }
 
 sub siglist {
-	for(my($i)=1;$i<=$#signals;$i++){
+	foreach my $i (1 .. $#signals) {
 		printf "%2d:%-6s%s",$i,$signals[$i],
 			( ($i % 8 == 0) || ($i == $#signals) )?"\n":" ";
 	}


### PR DESCRIPTION
* The pod manual doesn't mention -L
* Follow BSD version and raise an error for -L, which is not standardised [1]
* With this patch kill will exit(1) but it will show signal listing (by default for bad signal spec)
* While here, write siglist() loop in a less noisy way

1. https://pubs.opengroup.org/onlinepubs/009696799/utilities/kill.html