### PR TITLE
mail: fatal error for message id 0

### DIFF
--- a/bin/mail
+++ b/bin/mail
@@ -470,12 +470,8 @@ sub write {
 }
 sub messagex {
 	my $self=shift;
-
 	my $num=shift;
-	if ($num<=0) {
-		die "Invalid message specification, $num (Should Not Happen)";
-	}
-
+	return if $num <= 0;
 	return(${$self->{messages}}[$num]);
 }
 sub replace {


### PR DESCRIPTION
* When testing OpenBSD's mail command I viewed a mailbox with 2 items
* Typing "0" and "3" results in the same "invalid message id" error (1 and 2 are valid IDs in this test)
* This version treats 0 and 3 differently, terminating the program for ID 0
* It is inconvenient having to start mail command again, so avoid fatal error

```
%perl mail # patch applied
Loading the mailfile /home/bob/mbox
Mail [0.02 Perl] [linux]
 N  1                                    154/ 904 (no subject)
    2           nobody  Mon Sep 17 00:00  41/1036 [PATCH] another patch
    3           nobody  Mon Sep 17 00:00  32/ 706 re: [PATCH] another patch
    4           nobody  Sat Aug 27 23:07 120/3138 [PATCH 1/2] GIT: Try all addr
    5           nobody  Sat Aug 27 23:07 107/3764 [PATCH] Fixed two bugs in git
    6           nobody  Mon Sep 17 00:00  72/2926 [PATCH] a commit.
    7           nobody  Mon Sep 17 00:00   8/ 194 [PATCH] another patch
    8           nobody  Mon Sep 17 00:00  12/ 297 re: [PATCH] another patch
    9           nobody  Mon Sep 17 00:00  24/ 866 (no subject)
   10 b9704a518e211584  Mon Sep 17 00:00  36/1214 Re: discussion that lead to t
   11           nobody  Fri Aug  8 22:24  37/ 905 [PATCH 3/3 v2] Xyzzy
   12    bda@mnsspb.ru  Wed Nov 12 17:54  53/1727 [Navy-patches] [PATCH]	=?utf-
   13           nobody  Mon Sep 17 00:00   7/ 152 [PATCH] a patch
   14           nobody  Mon Sep 17 00:00  90/2363 Why doesn't git-am does not l
   15           nobody  Mon Sep 17 00:00  17/ 304 check bogus body header (from
   16           nobody  Mon Sep 17 00:00  18/ 296 check bogus body header (date
> 17
Invalid message number: 17
> 0
Invalid message number: 0
> -1
Unknown command
> q
```