### PR TITLE
what: compatible output text for match

### DIFF
--- a/bin/what
+++ b/bin/what
@@ -56,7 +56,7 @@ sub printWhat
             $f =~ s|.*\@\(#\)||;
             $f =~ s|[">\0\\].*||; ##BSD spec says print to 1st " > \ or null
             chomp $f;
-            print "        $f\n";
+            print "\t$f\n";
             return if $stop_flag;
         }
     }


### PR DESCRIPTION
* My Linux system doesn't have a "what" command
* The OpenBSD version prints each match on a separate line with a tab character prefix
* The standards document is clear about ```printf("\t%s\n", id_string)```, so follow that

1. https://pubs.opengroup.org/onlinepubs/9699919799/utilities/what.html