### PR TITLE
ed: support '^' address

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -112,7 +112,7 @@ my $NO_QUESTIONS_MODE = 0;
 my $PRINT_NUM = 1;
 my $PRINT_BIN = 2;
 
-our $VERSION = '0.15';
+our $VERSION = '0.16';
 
 my @ESC = (
     '\\000', '\\001', '\\002', '\\003', '\\004', '\\005', '\\006', '\\a',
@@ -963,7 +963,7 @@ sub edParse {
 
 sub getAddr {
     my $n;
-    if (s/\A([\-\+]+)//) { # '++--' == current+0
+    if (s/\A([\-\^\+]+)//) { # '++--' == current+0
         $n = $CurrentLineNum;
         foreach my $c (split //, $1) {
             $n += $c eq '+' ? 1 : -1;


### PR DESCRIPTION
* For greater compatibility with BSD, either '-' or '^' can be specified to mean CurrentLine - 1
* GNU ed 1.19 doesn't support '^'; I didn't test if v1.20 supports it
* Standards document mentions '^' is considered a historical feature; however POSIX does not prohibit it [1]

1. https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ed.html