### PR TITLE
rmdir: better error reporting

### DIFF
--- a/bin/rmdir
+++ b/bin/rmdir
@@ -30,11 +30,6 @@ if (!getopts('p', \%opt) || scalar(@ARGV) == 0) {
     exit EX_FAILURE;
 }
 foreach my $directory (@ARGV) {
-    unless (-d $directory) {
-        warn "$Program: '$directory': not a directory or does not exist\n";
-        $rc = EX_FAILURE;
-        next;
-    }
     unless (rmdir $directory) {
         warn "$Program: failed to remove '$directory': $!\n";
         $rc = EX_FAILURE;


### PR DESCRIPTION
* The old error message is not specific enough to be helpful
* Allow rmdir() to fail instead of performing file tests first
* $! will specifically say whether a file argument does not exist, or is not a directory