### PR TITLE
chown: allow numeric UID argument

### DIFF
--- a/bin/chown
+++ b/bin/chown
@@ -20,7 +20,7 @@ use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
 my $Program = basename($0);
-my ($VERSION) = '1.2';
+my ($VERSION) = '1.3';
 
 my $rc = EX_SUCCESS;
 
@@ -54,6 +54,9 @@ usage() unless @ARGV;
 my ($owner, $group) = split /:/ => $mode, 2;
 
 my $uid = getpwnam $owner;
+unless (defined $uid) {
+    $uid = $owner if $owner =~ m/\A[0-9]+\z/;
+}
 unless (defined $uid) {
     warn "$Program: invalid user: '$owner'\n";
     exit EX_FAILURE;
@@ -103,11 +106,13 @@ sub modify_file {
         return;
     }
     unless (defined $group) {
-        $gid = (stat $file)[5] or do {
+        my @st = stat $file;
+        unless (@st) {
             warn "$Program: failed to stat '$file': $!\n";
             $rc = EX_FAILURE;
             return;
-        };
+        }
+        $gid = $st[5];
     }
     unless (chown $uid, $gid, $file) {
         warn "$Program: '$file': $!\n";
@@ -137,7 +142,7 @@ is changed as well.
 =head2 OPTIONS
 
 I<chown> accepts the options described below. The options I<-L>,
-I<-H> and I<-P> are mutally exclusive, and only the last given
+I<-H> and I<-P> are mutually exclusive, and only the last given
 option will be honoured. All of I<-L>, I<-H> and I<-P> require the
 I<-R> option to be set first.
 


### PR DESCRIPTION
* This is similar to the patch for chgrp command
* Fall back to treating numeric argument as a uid if username resolution failed
* The code surrounding stat() had the same bug as for chgrp, i.e. existing uid=0 was treated as a failed stat()