### PR TITLE
split: allow /0/ pattern split

### DIFF
--- a/bin/split
+++ b/bin/split
@@ -136,7 +136,7 @@ if ($opt{'b'}) {
 }
 
 ## Split on patterns.
-elsif ($opt{'p'}) {
+elsif (defined $opt{'p'}) {
     my $regex = $opt{p};
     my $fh = nextfile ($prefix);
 


### PR DESCRIPTION
* When splitting input file with -p PATTERN, allow pattern to be '0'
* Probably this is a bad pattern to use, but ignoring -p0 is not correct
```
%printf "aa\n0\nbb\n0\ncc\n" | perl split -p0
%for f in xaa*; do echo "$f:"; cat $f; done
xaaa:
aa
xaab:
0
bb
xaac:
0
cc
```