### PR TITLE
chmod: list filename in warning if chmod() fails

### DIFF
--- a/bin/chmod
+++ b/bin/chmod
@@ -11,10 +11,12 @@ License: perl
 
 =cut
 
-
 use strict;
 
-my ($VERSION) = '1.2';
+use File::Basename qw(basename);
+
+my $Program = basename($0);
+my $VERSION = '1.3';
 
 my $warnings = 0;
 
@@ -22,22 +24,18 @@ my $warnings = 0;
 # Requires my patch to Getopt::Std of 25 Feb 1999.
 $SIG {__WARN__} = sub {
     if (substr ($_ [0], 0, 14) eq "Unknown option") {die "Usage"};
-    require File::Basename;
-    $0 = File::Basename::basename ($0);
     $warnings = 1;
-    warn "$0: @_";
+    warn "$Program: @_";
 };
 
 $SIG {__DIE__} = sub {
-    require File::Basename;
-    $0 = File::Basename::basename ($0);
     if (substr ($_ [0], 0,  5) eq "Usage") {
         die <<EOF;
-$0 (Perl bin utils) $VERSION
-$0 [-R [-H | -L | -P]] mode file [files ...]
+$Program (Perl bin utils) $VERSION
+$Program [-R [-H | -L | -P]] mode file [files ...]
 EOF
     }
-    die "$0: @_";
+    die "$Program: @_";
 };
 
 # Get the options.
@@ -47,7 +45,10 @@ while (@ARGV && $ARGV [0] =~ /^-/) {
     my $opt = reverse shift;
     chop $opt;
     last if ($opt eq '-');
-    die "Usage" unless $opt =~ /^[RHLP]+$/;
+    unless ($opt =~ /^[RHLP]+$/) {
+        warn "$Program: invalid option -- $opt\n";
+        die 'Usage';
+    }
     local $_;
     while (length ($_ = chop $opt)) {
         /R/ && do {$options {R} = 1; next};
@@ -115,7 +116,7 @@ sub modify_file {
         $realmode = mod($mode, $file) or
                        die "invalid mode: $mode\n";
     }
-    chmod oct ($realmode), $file or warn "$!\n";
+    chmod oct ($realmode), $file or warn "failed to change mode for '$file': $!\n";
 }
 
 exit $warnings;
@@ -342,7 +343,7 @@ options is permission the files should be given.
 =head2 OPTIONS
 
 B<chmod> accepts the options described below. The options B<-L>,
-B<-H> and B<-P> are mutally exclusive, and only the last given
+B<-H> and B<-P> are mutually exclusive, and only the last given
 option will be honoured. All of B<-L>, B<-H> and B<-P> require the
 B<-R> option to be set first.
 


### PR DESCRIPTION
* Address the same issue as for previous chgrp commit: 420f8b2a12025bb609e33f0c1741116433263abe
* The argument list could have 3 files, and chmod() is successful for one but the remaining args fail
* It would be nice to introduce a regular usage() function in chmod later
```
%perl chmod 600 /etc/motd wordlist.txt /etc/passwd
chmod: failed to change mode for '/etc/motd': Operation not permitted
chmod: failed to change mode for '/etc/passwd': Operation not permitted
```
