### PR TITLE
grep: make space after -e or -f optional

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -54,7 +54,7 @@ use File::Spec;
 use File::Temp qw();
 use Getopt::Std;
 
-our $VERSION = '1.014';
+our $VERSION = '1.015';
 
 $| = 1;                   # autoflush output
 
@@ -219,13 +219,13 @@ sub parse_args {
 	my @tmparg;
 	while (@ARGV) {
 		my $arg = shift @ARGV;
-		if ($arg eq '-e') {
-			$pattern = shift @ARGV;
+		if ($arg =~ s/\A\-e//) {
+			$pattern = length($arg) ? $arg : shift(@ARGV);
 			usage() unless defined $pattern;
 			push @patterns, $pattern;
 		}
-		elsif ($arg eq '-f') {
-			my $file = shift @ARGV;
+		elsif ($arg =~ s/\A\-f//) {
+			my $file = length($arg) ? $arg : shift(@ARGV);
 			usage() unless defined $file;
 			die "$Me: $file: is a directory\n" if -d $file;
 			my $fh;
@@ -246,7 +246,7 @@ sub parse_args {
 	@ARGV = @tmparg;
 
 	$opt{'p'} = $opt{'P'} = ''; # argument to print()
-	getopts('IinC:cwsxvHhe:f:LlgurpP:aqTFZm:A:B:', \%opt) or usage();
+	getopts('IinC:cwsxvHhLlgurpP:aqTFZm:A:B:', \%opt) or usage();
 
 	if (defined $opt{'m'} && $opt{'m'} !~ m/\A[0-9]+\z/) {
 		die "$Me: invalid max count\n";


### PR DESCRIPTION
* BSD and GNU versions do not require a space between -e/-f and the option argument
* This version did not raise an error, but option arguments without a space resulted in incorrect behaviour
* Remove -e and -f from getopts() option string because they are handled earlier
* test1: perl grep -e0 -e 1 ar ---> patterns 0 and 1 in file ar
* test2: grep -fwordlist.txt.old -f pat1 xargs ---> patterns from file wordlist.txt.old and pat1, searching against file xargs