### PR TITLE
du: exit code 1 on error

### DIFF
--- a/bin/du
+++ b/bin/du
@@ -53,11 +53,13 @@ unless (@ARGV) {
   push @ARGV, '.';
 }
 
+my $rc = EX_SUCCESS;
 foreach (@ARGV) {
   %inodes = (); # clear this at the start of each traversal
   $grandtotal += traverse($_);
 }
 print "$grandtotal\ttotal\n" if $opt_c;
+exit $rc;
 
 sub traverse {
   my $fn = $_[0];
@@ -66,6 +68,7 @@ sub traverse {
   my @s = ($opt_L || $opt_H && $depth == 1) ? stat $fn : lstat $fn;
   unless (@s) {
     warn "$0: cannot access '$fn': $!\n";
+    $rc = EX_FAILURE;
     return 0;
   }
   # Check for cross-filesystem traversals (-x option)
@@ -99,6 +102,7 @@ sub traverse {
     print "$total\t$fn\n" unless $opt_s;
   } else {
     warn "$0: could not read directory $fn: $!\n";
+    $rc = EX_FAILURE;
   }
   print "$total\t$fn\n" if $opt_s && $depth == 1;
   return $total;


### PR DESCRIPTION
* Failure to access one file argument is considered a non-fatal error which deserves an exit(1) at end of program
* Tested against GNU version
```
%perl du -k  a aaaaaaaa
66	a
du: cannot access 'aaaaaaaa': No such file or directory
%echo $?
1
```