### PR TITLE
chown: allow numeric group argument

### DIFF
--- a/bin/chown
+++ b/bin/chown
@@ -20,7 +20,7 @@ use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
 my $Program = basename($0);
-my ($VERSION) = '1.3';
+my ($VERSION) = '1.4';
 
 my $rc = EX_SUCCESS;
 
@@ -64,6 +64,9 @@ unless (defined $uid) {
 my $gid;
 if (defined $group) {
     $gid = getgrnam $group;
+    unless (defined $gid) {
+        $gid = $group if $group =~ m/\A[0-9]+\z/;
+    }
     unless (defined $gid) {
         warn "$Program: invalid group: '$group'\n";
         exit EX_FAILURE;


### PR DESCRIPTION
* Previously the usage "chown USER file" was changed to allow numeric user ID for USER
* When testing against GNU version, the usage "chown USER:GROUP file" should handle a group ID or a group name
* test1: perl chown 0:0 file ---> user=root, group=root on my Linux system
* test2: perl chown root:8 ---> also valid, where gid 8 resolves to "mail" here