### PR TITLE
mail: more reliably find vi command

### DIFF
--- a/bin/mail
+++ b/bin/mail
@@ -680,10 +680,7 @@ sub listing {
 }
 sub vipath {
 	return $ENV{'VISUAL'} if (defined $ENV{'VISUAL'});
-	my $default = '/usr/bin/vi';
-	return $default if (-x $default);
-	warn "No VISUAL in environment\n";
-	return;
+	return 'vi';
 }
 sub shell {
 	# How to get an interactive shell in Perl.  Hmmm...


### PR DESCRIPTION
* On Android I have Termux, and vi is installed as /data/data/com.termux/files/usr/bin/vi
* Remove the assumption that vi is installed under /usr/bin
* With this patch, perl will look for vi within $PATH
* Tested on OpenBSD and Termux/Android
* Environment variable $VISUAL still takes precedence if it is set