### PR TITLE
grep: fix logic for empty patterns

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -269,7 +269,7 @@ sub parse_args {
 	if ($opt_f && scalar(@patterns) == 0) { # empty -f file allowed
 		exit EX_NOMATCH;
 	}
-	unless (length $pattern) {
+	unless (@patterns) {
 		$pattern = shift @ARGV;
 		usage() unless defined $pattern;
 		push @patterns, $pattern;


### PR DESCRIPTION
* Checking length of $pattern is unreliable because it is valid for a pattern to have zero-length (meaning match-all)
* I found this when testing the -f option but the logic applies to other usages of grep
```
%md5sum a.c
c9fd7ff4cb5b01981a2a362f82f44c89  a.c
%perl grep -F '' a.c | md5sum 
c9fd7ff4cb5b01981a2a362f82f44c89  -
%printf "\n" > pat0 && perl grep -f pat0 a.c | md5sum
c9fd7ff4cb5b01981a2a362f82f44c89  -
%perl grep -e '' a.c | md5sum 
c9fd7ff4cb5b01981a2a362f82f44c89  -
```