### PR TITLE
cp -i: continue on prompt

### DIFF
--- a/bin/cp
+++ b/bin/cp
@@ -80,10 +80,7 @@ sub run {
 			print { output_fh() } "$source -> $catdst\n" if $opts->{v};
 			if( -e $catdst and $opts->{i} and ! $opts->{f} ) {
 				my $answer = prompt( "overwrite $catdst? (y/n [n])", 'n' );
-				unless( $answer =~ m/\A\s*y/i ) {
-					print { error_fh() } "not overwritten";
-					return EX_FAILURE;
-					}
+				next unless $answer =~ m/\A\s*y/i;
 				}
 			if (File::Copy::copy($source, $catdst) == 0) {
 				print { error_fh() } "$0: $source -> $catdst: copy failed: $!\n";


### PR DESCRIPTION
* cp can copy multiple files to a destination
* It is not an error for the user to type "n" to not clobber an existing file when running "cp -i"
* Previously if I type "n", cp exits with a failure code and ignores the remaining files I want to copy
* This patch is for the scenario where an external cp command is not found

```
%mkdir dest && perl cp -v a.c ar dest && perl cp -i a.c ar dest
a.c -> dest/a.c
ar -> dest/ar
overwrite dest/a.c? (y/n [n]) [n] n
overwrite dest/ar? (y/n [n]) [n] y
%echo $?
0
```