### PR TITLE
ed: m command accepts address argument

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -113,7 +113,7 @@ my $NO_QUESTIONS_MODE = 0;
 my $PRINT_NUM = 1;
 my $PRINT_BIN = 2;
 
-our $VERSION = '0.19';
+our $VERSION = '0.20';
 
 my @ESC = (
     '\\000', '\\001', '\\002', '\\003', '\\004', '\\005', '\\006', '\\a',
@@ -436,8 +436,13 @@ sub edMove {
     if ($start == 0 || $end == 0) { # allowed for $dst only
         return E_ADDRBAD;
     }
-    my $dst = $args[0];
-    unless (defined $dst) {
+    $_ = $args[0];
+    my $dst = getAddr();
+    if (defined $dst) {
+        return E_NOMATCH if $dst == A_NOMATCH;
+        return E_NOPAT if $dst == A_NOPAT;
+        return E_ADDRBAD if $dst < 0 || $dst > maxline();
+    } else {
         $dst = $CurrentLineNum;
     }
     if ($delete) {


### PR DESCRIPTION
* Argument parsing within edMove() was a bit broken
* edMove() implements the "t" and "m" commands
* I noticed that bogus values for $args[0] were being accepted, e.g. n > maxline()
* The argument is supposed to be any valid address, not just an address specified as a number
* getAddr() already contains the functionality we want, so call it

Tests:
1,2m/main/ ---> append selected lines after regex match
1,2m/mainxxxxxx/ ---> nomatch error
1,2m// ---> use saved pattern for search (fails if no pattern was saved yet)
1,2m. ---> append lines after current address (explicit)
1,2m ---> append lines after current address (default)
1,2m$ ---> append lines after last line
1,2m'x ---> append lines after marked line x (fails if nothing was marked for x yet)
24,25m0 --> move selected lines to start of editor buffer