### PR TITLE
mail: add --version

### DIFF
--- a/bin/mail
+++ b/bin/mail
@@ -633,7 +633,6 @@ EDLOOP: {
 1;
 package main;
 
-use English;
 use File::Temp;
 use Getopt::Std;
 use vars qw($opt_f $opt_s $opt_c $opt_b $opt_v);
@@ -975,7 +974,6 @@ sub Interactive {
 	my $current=1;
 
 	select STDOUT; $|=1;
-	print "Mail [$VERSION Perl] [$OSNAME]\n";   # This is fluff.
 	my $cmd = "Init";
 
 CMDS:	{
@@ -1035,6 +1033,11 @@ sub Batch {
 	chomp(@BODY);
 	$message->add_to_body(@BODY);
 	$mailer->send($message);
+}
+
+sub VERSION_MESSAGE {
+	print "$0 version $VERSION\n";
+	exit;
 }
 
 getopts("f:s:c:b:v") || die <<USAGE;

--- a/bin/mail
+++ b/bin/mail
@@ -633,14 +633,18 @@ EDLOOP: {
 1;
 package main;
 
+use File::Basename qw(basename);
 use File::Temp;
 use Getopt::Std;
+
 use vars qw($opt_f $opt_s $opt_c $opt_b $opt_v);
 
 our $VERSION = '0.04';
 our $ROWS = 23;         # Screen Dimensions.  Yeah, this sucks.
 our $COLS = 80;
 our $BUFFERL = 2;	  # Lines needed for "fluff"
+
+my $Program = basename($0);
 my $box;
 
 my %commands=(
@@ -1036,13 +1040,13 @@ sub Batch {
 }
 
 sub VERSION_MESSAGE {
-	print "$0 version $VERSION\n";
+	print "$Program version $VERSION\n";
 	exit;
 }
 
 getopts("f:s:c:b:v") || die <<USAGE;
-$0 [-f mailbox]
-$0 [-s subject] [-c cc-addrs] [-b bcc-addrs] to-addr [..toaddr..]
+usage: $Program [-s subject] [-c cc-addrs] [-b bcc-addrs] to-addr [..toaddr..]
+   or: $Program [-f mailbox]
 USAGE
 
 if (@ARGV) {   # Assume batch-mode


### PR DESCRIPTION
* Declare VERSION_MESSAGE() as done in other scripts which use getopts()
* It is not necessary to print a splash message when the program starts; displaying the mailbox is enough
* Printing os in version message is not required (English.pm was only used for $OSNAME which disappears in this patch)
* The -v option is for toggling debug information, and it doesn't change
