### PR TITLE
expr: allow unary plus

### DIFF
--- a/bin/expr
+++ b/bin/expr
@@ -36,7 +36,7 @@ if (scalar(@ARGV) == 0) {
 
 # check that it is a number
 sub num($) {
-    $_[0] =~ /^-?[0-9]+$/ or die "non numeric-argument\n";
+    $_[0] =~ /^[+-]?[0-9]+$/ or die "non numeric-argument\n";
     $_[0];
 }
 


### PR DESCRIPTION
* When testing OpenBSD expr, +n and -n numbers are allowed, so permit them here
* I didn't test NetBSD version, but since it calls strtoll() I suspect it also permits +n and -n [1]
* Test: ```perl expr 2 \* \( -2 + +43 \)``` ---> 82


http://cvsweb.netbsd.org/bsdweb.cgi/src/bin/expr/expr.y?annotate=1.46