### PR TITLE
spell: variable name alias

### DIFF
--- a/bin/spell
+++ b/bin/spell
@@ -20,9 +20,9 @@ use Getopt::Std qw(getopts);
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
-my $Program = basename($0);
+use constant DICT_FILE => '/usr/dict/words';
 
-my $dict_file = "/usr/dict/words";      # Filename (path) for standard dict
+my $Program = basename($0);
 
 my (
     %words,    # words from dictionary
@@ -47,8 +47,8 @@ getopts('cd:ixv', \%opt) or usage();
 $check = 1 if $opt{'c'} || $opt{'x'};
 $suff = 1 if $opt{'v'};
 $inter = 1 if $opt{'i'};
-$dict_file = $opt{'d'} if defined $opt{'d'};
-@supp = ($dict_file);
+@supp = ( DICT_FILE );
+@supp = ( $opt{'d'} ) if defined $opt{'d'};
 for (0 .. $#ARGV) {
   if ($ARGV[$_] =~ m/\A\+./) {
     push @supp, substr($ARGV[$_], 1);


### PR DESCRIPTION
* Avoid having two variables called $dict_file, one global and one in a loop
* The default path for dictionary becomes DICT_FILE
* Argument "+dict2" scans an extra dictionary as well as DICT_FILE
* Option "-d dict2" scans dict2 instead of DICT_FILE
