### PR TITLE
expr: allow '--' prefix

### DIFF
--- a/bin/expr
+++ b/bin/expr
@@ -33,6 +33,14 @@ if (scalar(@ARGV) == 0) {
     warn "usage: expr expression\n";
     exit EX_ERROR;
 }
+if ($ARGV[0] eq '--') {
+    if (scalar(@ARGV) > 1) {
+        shift @ARGV;
+    } else {
+        warn "expr: syntax error\n";
+        exit EX_ERROR;
+    }
+}
 
 # check that it is a number
 sub num($) {


### PR DESCRIPTION
* Compat change; GNU and OpenBSD versions do this
* If the first argument is '--' and it's not the only argument, ignore it
* test1: perl expr -- # invalid
* test2: perl expr -- -- # evaluates string "--"
* test3: perl expr -- 2 - 2 # evaluates number 0