### PR TITLE
hangman: consistently handle eof

### DIFF
--- a/bin/hangman
+++ b/bin/hangman
@@ -34,6 +34,7 @@ while( $cont =~ /^y/io ) {
 	while( ($num_wrong < 6) && ($num_corr < $tot_letters) ) {
 		print "\nEnter a letter:  ";
 		$letter = <STDIN>;
+		exit unless defined $letter;
 		chomp( $letter );
 		$letter = lc( $letter );
 		if( $letter =~ /^[a-z]$/o ) {


### PR DESCRIPTION
* If you reach the end of a game and see the PLAY AGAIN prompt, eof will cause the program to terminate
* Do the same if eof occurs after the GUESS A LETTER prompt; the NetBSD version handles this in getguess() [1]
* test: echo sword > wordlist.txt  && echo hi | perl hangman # now terminates 

1. http://cvsweb.netbsd.org/bsdweb.cgi/src/games/hangman/getguess.c?annotate=1.10