### PR TITLE
chmod: symbolic file permissions

### DIFF
--- a/bin/chmod
+++ b/bin/chmod
@@ -19,7 +19,7 @@ use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
 my $Program = basename($0);
-my $VERSION = '1.5';
+my $VERSION = '1.6';
 
 my $rc = EX_SUCCESS;
 
@@ -68,7 +68,7 @@ if (exists $options {R}) {
 }
 else {
     foreach my $file (@ARGV) {
-        modify_file $file;
+        modify_file($file);
     }
 }
 exit $rc;
@@ -134,18 +134,12 @@ sub modify_file {
 #
 #
 
-sub mod ($$) {
+sub mod {
     my $symbolic     = shift;
     my $file         = shift;
 
-    # Initialization.
-    # The 'user', 'group' and 'other' groups.
-    my @ugo          = qw /u g o/;
-    # Bit masks for '[sg]uid', 'sticky', 'read', 'write' and 'execute'.
-    # Can't use qw // cause silly Perl doesn't know '2' is a number
-    # when dealing with &= ~$bit.
-    my %bits         = (s => 8, t => 8, r => 4, w => 2, x => 1);
-
+    my @ugo          = qw/u g o/;
+    my %bits         = ('s' => 8, 't' => 8, 'r' => 4, 'w' => 2, 'x' => 1);
 
     # For parsing.
     my $who_re       = '[augo]*';
@@ -153,7 +147,13 @@ sub mod ($$) {
 
 
     # Find the current permissions. This is what we start with.
-    my $mode         = sprintf "%04o" => (stat $file) [2] || 0;
+    my $mode = '000';
+    if ($symbolic =~ m/[\-\+]/) {
+        my @st = stat $file;
+        if (@st) {
+            $mode = sprintf '%04o', $st[2];
+        }
+    }
     my $current      = substr $mode => -3;  # rwx permissions for ugo.
 
     my %perms;
@@ -237,6 +237,9 @@ sub mod ($$) {
                 else      {%perms             = %umask;}
                 next;
             }
+            if ($operator eq '=') {
+                $perms{$who} = 0;
+            }
 
             # If we arrive here, $perms is a string.
             # We can iterate over the characters.
@@ -297,9 +300,8 @@ sub mod ($$) {
 
                 # Apply.
                 foreach my $s (@set) {
-                    do {$perms {$s} |=  $bit; next} if $operator eq '+';
+                    do {$perms {$s} |=  $bit; next} if ($operator eq '+' || $operator eq '=');
                     do {$perms {$s} &= ~$bit; next} if $operator eq '-';
-                    do {$perms {$s}  =  $bit; next} if $operator eq '=';
                     die "Weird operator `$operator' found\n";
                                                             # Should not happen.
                 }


### PR DESCRIPTION
* Sync mod() changes with bin/install
* chmod would get some of the following symbolic permissions wrong...
```
perl chmod a= A               (0000/----------)
perl chmod a=rwx A            (0777/-rwxrwxrwx)
perl chmod u=rw A             (0600/-rw-------)
perl chmod u=rwx,g=w A        (0720/-rwx-w----)
perl chmod u=rx,g=r,o=r A     (0544/-r-xr--r--)
```