### PR TITLE
ed: disallow trailing '/' when setting filename

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -579,9 +579,8 @@ sub edFilename {
         return E_ADDREXT;
     }
     if (defined($args[0])) {
-        if ($args[0] =~ m/\A\!/) {
-            return E_FNAME;
-        }
+        return E_FNAME if $args[0] =~ m/\A\!/;
+        return E_FNAME if $args[0] =~ m/\/\Z/;
         $RememberedFilename = $args[0];
     }
     if (defined($RememberedFilename)) {


### PR DESCRIPTION
* The usage "f abc/" is technically invalid because it would point to a directory
* Subsequent "e" or "w" commands fail because ed does not operate on directories
* GNU ed 1.20 added validation to prevent this usage; add it here because it would flag bad user input slightly earlier