### PR TITLE
glob: unused function

### DIFF
--- a/bin/glob
+++ b/bin/glob
@@ -422,34 +422,6 @@ sub glob($) {
     @globbed;
 }
 
-sub globtest(;$) {
-        my $fh = shift || \*ARGV;
-        my(@t0, @t1, $udiffm, $sdiffm, $udiffg, $sdiffg, @list);
-        local($,);
-
-        $, = " ";
-        while (<$fh>) {
-                chomp;
-
-                @t0 = times();
-                @list =  &glob($_);
-                @t1 = times();
-                $udiffm = ($t1[0] + $t1[2]) - ($t0[0] + $t0[2]);
-                $sdiffm = ($t1[1] + $t1[3]) - ($t0[1] + $t0[3]);
-                print "@list\n";
-
-                @t0 = times();
-                @list =  glob($_);
-                @t1 = times();
-                $udiffg = ($t1[0] + $t1[2]) - ($t0[0] + $t0[2]);
-                $sdiffg = ($t1[1] + $t1[3]) - ($t0[1] + $t0[3]);
-                print "@list\n";
-
-                print "mine: [${udiffm}u\t${sdiffm}s]\n";
-                print "glob: [${udiffg}u\t${sdiffg}s]\n";
-        }
-}
-
 #
 # If we are a script then return glob with each cmdline-arg
 #


### PR DESCRIPTION
* globtest() wasn't called and this kind of test probably belongs in a separate harness script

```
%for glb in 'x*' 'y*'; do echo -n 'A: '; echo $(perl glob "$glb"); echo -n 'B: '; echo $glb; echo; done
A: x.bc x.pl xaaa xaab xaac xargs xx xxx xxyy
B: xaaa xaab xaac xargs x.bc x.pl xx xxx xxyy

A: yes yo2 yoooo
B: yes yo2 yoooo
```