### PR TITLE
ed: reject filename of '.' or '..'

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -581,6 +581,7 @@ sub edFilename {
     if (defined($args[0])) {
         return E_FNAME if $args[0] =~ m/\A\!/;
         return E_FNAME if $args[0] =~ m/\/\Z/;
+        return E_FNAME if ($args[0] eq '.' || $args[0] eq '..');
         $RememberedFilename = $args[0];
     }
     if (defined($RememberedFilename)) {


### PR DESCRIPTION
* Extending from commit 5f9377d8b67fbbb8dfbd745566bf3a9ea3299309, we know that filenames '.' and '..' are reserved for directories so make these names also raise an error in edFilename()
* The filename '...' is not reserved