### PR TITLE
od: factor dump_line()

### DIFF
--- a/bin/od
+++ b/bin/od
@@ -198,17 +198,20 @@ sub emit_offset {
 }
 
 sub dump_line {
-    if (&diffdata || $opt_v) {
+    unless ($opt_v) {
+	if (diffdata()) {
+	    $lastline = $data . '|';
+	    $ml = 0;
+	} else {
+	    print "*\n" unless $ml;
+	    $ml = 1;
+	}
+    }
+    unless ($ml) {
 	emit_offset();
 	&$fmt;
 	printf "$strfmt\n", @arr;
-	$ml = 0;
     }
-    else {
-	print "*\n" unless $ml;
-	$ml = 1;
-    }
-    $lastline = $data . '|';
     $offset1 += length $data;
     undef $data;
 }


### PR DESCRIPTION
* The -v flag works the same as for hexdump command, displaying all lines including duplicated input
* diffdata() compares the current line with previous line; if the -v flag is given there's no need to call it
* Save $lastline if we're not in verbose mode and we saw a difference in the data
* $ml becomes true when we saw a duplicate; this prevents '*' from being printed multiple times