### PR TITLE
glob: normal vs debug output

### DIFF
--- a/bin/glob
+++ b/bin/glob
@@ -249,7 +249,7 @@ sub match_glob($) {
     }
 
     # debugging
-    print "regexp is $_\n" if ($verbose);
+    warn "regexp is $_\n" if $verbose;
 
     # now split it into directory components
     my @comps = split($dirsep);
@@ -287,7 +287,7 @@ sub recurseglob($ $ @) {
         # look for found, and if you find one, glob the rest of the
         # components. We eval the loop so the regexp gets compiled in,
         # making searches on large directories faster.
-        print "component re is qr($re)\n" if ($verbose);
+        warn "component re is qr($re)\n" if $verbose;
         my $regex = qr($re);
         foreach (@names) {
             if ( m{$regex} ) {


### PR DESCRIPTION
* When enabling debug environment variable, print debug output to STDERR
* Currently the debug output interferes with the regular items printed to STDOUT
```
%export DEBUG_FASTGLOB=1
%for f in $( perl glob 'x*' ); do echo "F=$f"; done
regexp is x.*
component re is qr(\Ax.*\Z)
F=x.bc
F=x.pl
F=xaaa
F=xaab
F=xaac
F=xargs
F=xx
F=xxx
F=xxyy
```