### PR TITLE
tail: portable -f DIR

### DIFF
--- a/bin/tail
+++ b/bin/tail
@@ -29,6 +29,7 @@ $| = 1;
 use strict;
 
 use File::Basename qw(basename);
+use File::Spec;
 use Getopt::Long;  # because of some special handling on numeric options
 
 use constant EX_SUCCESS => 0;
@@ -246,10 +247,14 @@ sub get_existing_files(\@\@)
 
     my @files = grep { -e $_ } @$filelist;
 
-    for my $d(@$dirlist) {
-    opendir(DIR, $d) or die "can't open directory $d: $!";
-    push @files, map { "$d/$_" } grep { -f "$d/$_" } readdir(DIR);
-    closedir DIR;
+    for my $d (@$dirlist) {
+        opendir(DIR, $d) or die "can't open directory $d: $!\n";
+        while (my $ent = readdir(DIR)) {
+            my $path = File::Spec->catfile($d, $ent);
+            next unless -f $path;
+            push @files, $path;
+        }
+        closedir DIR;
     }
 
     # Remove the duplicates.


### PR DESCRIPTION
* tail -f flag changes how all the file arguments are handled, i.e. tail_f() function is called
* When passing directory arguments to tail -f, ```@dirlist``` contains all the directory args
* get_existing_files() is called for each directory
* Switch get_existing_files() to use catfile() to join directory name with filenames from readdir()---this removes the assumption that the OS uses '/' as a directory separator