### PR TITLE
hexdump: warn for directories

### DIFF
--- a/bin/hexdump
+++ b/bin/hexdump
@@ -216,6 +216,10 @@ sub xd {
     if (@ARGV) {
         while (@ARGV) {
             my $path = shift @ARGV;
+            if (-d $path) {
+                warn "$Program: $path: is a directory\n";
+                next;
+            }
             unless (open $curf, '<', $path) {
                 warn "$Program: $path: $!\n";
                 exit EX_FAILURE;


### PR DESCRIPTION
* Avoid fatal error for directory arguments
* Print a warning for a directory, then proceed to next argument
* Use case tested: hexdump -C . .. file.txt