### PR TITLE
cp: unused import

### DIFF
--- a/bin/cp
+++ b/bin/cp
@@ -15,7 +15,6 @@ package PerlPowerTools::cp;
 
 use strict;
 
-use Cwd;
 use Config;
 use ExtUtils::MakeMaker   qw(prompt);
 use File::Basename        qw(basename);


### PR DESCRIPTION
* No *cwd() functions are used in bin/cp