### PR TITLE
pr: -a flag not recognised

### DIFF
--- a/bin/pr
+++ b/bin/pr
@@ -91,7 +91,7 @@ while (@ARGV && $ARGV[0] =~ /^-(.+)/ && (shift, ($_ = $1), 1)) {
 
     # Simple flags
     if (s/^m//) { warn "-m flag already set" if $multimerge++; redo OPTION; }
-    if (s/^s//) { warn "-a flag already set" if $roundrobin++; redo OPTION; }
+    if (s/^a//) { warn "-a flag already set" if $roundrobin++; redo OPTION; }
     if (s/^d//) { warn "-d flag already set" if $doublespace++; redo OPTION; }
     if (s/(^F)//i) { warn "-$1 flag already set" if $formfeed++; redo OPTION; }
     if (s/^r//) { warn "-r flag already set" if $quietskip++; redo OPTION; }


### PR DESCRIPTION
* A typo in the options handling code prevented $roundrobin from being set
* This patch allows the round-robin logic to be verified (I haven't investigated the output for -a yet)