### PR TITLE
lock: re-enable term echo

### DIFF
--- a/bin/lock
+++ b/bin/lock
@@ -164,6 +164,7 @@ sub handler
     if ( $sig eq 'ALRM' )
       {
 	print "lock: timeout\n";
+	echo();
 	exit 0;
       }
     else


### PR DESCRIPTION
* When testing lock with a 1 minute timeout, my terminal text was invisible after lock times out and exits
* In the alarm handler, be careful to enable echo before the program finishes