### PR TITLE
what: bypass readline for directory argument

### DIFF
--- a/bin/what
+++ b/bin/what
@@ -22,6 +22,10 @@ getopts('s', \%opt) or usage();
 
 for my $file (@ARGV)
     {
+        if (-d $file) {
+            print $file, ":\n";
+            next;
+        }
         my $fh;
         unless (open $fh, '<', $file) {
             warn "Unable to open '$file': $!\n";


### PR DESCRIPTION
* Directory arguments are treated as a file that doesn't contain any matches
* Add explicit directory handling code to avoid reading a line from a directory, which would always fail
* Tested against OpenBSD
```
%perl what .. /bin/bash not-exist
..:
/bin/bash:
	Bash version 5.1.4(1) release GNU
Unable to open 'not-exist': No such file or directory
%echo $?  # bash contained a match
0
```