### PR TITLE
perlpowertools: add hexdump tool

### DIFF
--- a/bin/perlpowertools
+++ b/bin/perlpowertools
@@ -22,7 +22,7 @@ use Cwd 'abs_path';
 
 our $VERSION = qw( 1.024 );
 my $program  = 'perlpowertools';
-my @tools    = qw( addbib apply ar arch arithmetic asa awk banner basename bc cal cat chgrp ching chmod chown clear cmp col colrm comm cp cut date dc deroff diff dirname du echo ed env expand expr factor false file find fish fmt fold fortune from glob grep hangman head id install join kill ln lock look ls mail man maze mimedecode mkdir mkfifo moo morse nl od par paste patch perldoc pig ping pom ppt pr primes printenv printf pwd rain random rev rm rmdir robots rot13 shar sleep sort spell split strings sum tac tail tar tee test time touch tr true tsort tty uname unexpand uniq units unpar unshar uudecode uuencode wc what which whois words wump xargs yes );
+my @tools    = qw( addbib apply ar arch arithmetic asa awk banner basename bc cal cat chgrp ching chmod chown clear cmp col colrm comm cp cut date dc deroff diff dirname du echo ed env expand expr factor false file find fish fmt fold fortune from glob grep hangman head hexdump id install join kill ln lock look ls mail man maze mimedecode mkdir mkfifo moo morse nl od par paste patch perldoc pig ping pom ppt pr primes printenv printf pwd rain random rev rm rmdir robots rot13 shar sleep sort spell split strings sum tac tail tar tee test time touch tr true tsort tty uname unexpand uniq units unpar unshar uudecode uuencode wc what which whois words wump xargs yes );
 my $usage    = <<EOF;
 
 Usage: $program [-hVl]


### PR DESCRIPTION
* Launcher program perlpowertools didn't recognise hexdump as a tool (probably because it was added more recently)
* test1: ```perl perlpowertools -l``` ...now lists hexdump
* test2: ```perl perlpowertools hexdump -C $(which perl) | perl head -n7``` ...run hexdump via launcher