### PR TITLE
dirname: pod typo

### DIFF
--- a/bin/dirname
+++ b/bin/dirname
@@ -85,7 +85,6 @@ B<OpenBSD> implementation.
 This implementation of I<dirname> was adapted by Michael Mikonos.
 
 The original version was written by Abigail, but the code was completely replaced.
-Most of the documeantion is the original version.
 
 =head1 COPYRIGHT and LICENSE
 


### PR DESCRIPTION
* Spell checker found a typo in the dirname manual
* The sentence containing the typo is not very useful because it talks about the author of the original manual; I'd prefer to remove it than correct the typo