### PR TITLE
ed: +n and -n relative addresses

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -105,7 +105,7 @@ my $NO_QUESTIONS_MODE = 0;
 my $PRINT_NUM = 1;
 my $PRINT_BIN = 2;
 
-our $VERSION = '0.22';
+our $VERSION = '0.23';
 
 my @ESC = (
     '\\000', '\\001', '\\002', '\\003', '\\004', '\\005', '\\006', '\\a',
@@ -974,7 +974,12 @@ sub edParse {
 
 sub getAddr {
     my $n;
-    if (s/\A([\-\^\+]+)//) { # '++--' == current+0
+    if (s/\A([\-\+])([0-9]+)//) { # '+1' or '-1'
+        my $is_neg = $1 eq '-';
+        my $x = $2;
+        $x = -$x if $is_neg;
+        $n = $CurrentLineNum + $x;
+    } elsif (s/\A([\-\^\+]+)//) { # '++--' == current+0
         $n = $CurrentLineNum;
         foreach my $c (split //, $1) {
             $n += $c eq '+' ? 1 : -1;


### PR DESCRIPTION
* When testing ed I found getAddr() was missing the code to handle +n and -n addresses relative to currentLine
* This is useful for constructing ranges
* For the tests I 1st jump to line 12 by typing "12"
* test1: -10,.nl    ---> list lines 2-12
* test2: .,+10nl  ---> list lines 12-22