### PR TITLE
grep: parse_args() tweak

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -237,8 +237,7 @@ sub parse_args {
 			my $line;
 			while (defined($line = <$fh>)) {
 				chomp $line;
-				$pattern = $line;
-				push @patterns, $pattern;
+				push @patterns, $line;
 			}
 			close $fh;
 


### PR DESCRIPTION
* When running "grep -f patfile file", ```@patterns``` list is populated from patfile
* Setting the value of $pattern to the final pattern in patfile is not needed
* Regression test: ```printf "this\nthat\n" > patfile && perl grep -n -f patfile ar```