### PR TITLE
primes: raise error for start>end

### DIFF
--- a/bin/primes
+++ b/bin/primes
@@ -15,12 +15,15 @@ License: perl
 
 use strict;
 #use integer; # faster, but cuts the maxint down
+
+use constant MAX => 2**32 - 1;
+
 $|++;
 my @primes = (2, 3, 5, 7, 11);          # None have been tested
 my @next_primes = ();                   # Avoid redoing work
 
 
-my $VERSION = '1.001';
+my $VERSION = '1.002';
 
 END {
   close STDOUT || die "$0: can't close stdout: $!\n";
@@ -32,10 +35,10 @@ if (scalar(@ARGV) > 2) {
     Pod::Usage::pod2usage({ -exitval => 1, -verbose => 0 });
 }
 chomp(my $start = @ARGV ? $ARGV[0] : <STDIN>);
-my $end   = $ARGV[1] || 2**32 - 1;
+my $end = defined $ARGV[1] ? $ARGV[1] : MAX;
 for ($start, $end) {
   s/\A\s*\+?(\d{1,10})\Z/$1/ || die "$0: $_: illegal numeric format\n";
-  $_ > 2**32 - 1 && die "$0: $_: Numerical result out of range\n";
+  $_ > MAX && die "$0: $_: Numerical result out of range\n";
 }
 die "$0: start value must be less than stop value\n" if ($end < $start);
 primes ($start, $end);


### PR DESCRIPTION
* If run with 2 arguments, primes are displayed for a range from Start to End
* Normally an error was raised if End was smaller than Start, but the value of 0 was resulting in a default value unexpectedly
* Convert maximum to a constant so it could be changed easier to 64 bits (no dynamic size calculation is being done but at least the user can patch the one constant)
* Original test: perl primes 10 0