### PR TITLE
mkdir: suppress multiple errors for non-directory argument

### DIFF
--- a/bin/mkdir
+++ b/bin/mkdir
@@ -14,7 +14,8 @@ License: perl
 
 use strict;
 
-use File::Basename qw(basename dirname);
+use File::Basename qw(basename);
+use File::Spec;
 use Getopt::Std qw(getopts);
 
 our $VERSION = '1.6';
@@ -51,13 +52,15 @@ if (defined $options{'m'}) {
 }
 
 my $rc = EX_SUCCESS;
-foreach my $dir (@ARGV) {
+DIRS: foreach my $dir (@ARGV) {
     if ($options{'p'}) {
         my @subdir = split_dir($dir);
 	$dir = shift @subdir;
-	create_dir($dir, 0);
+	my $ok = create_dir($dir, 0);
+        next DIRS unless $ok;
 	foreach my $d (@subdir) {
-            create_dir($d, 1);
+            $ok = create_dir($d, 1);
+            next DIRS unless $ok;
 	}
     } else {
         create_dir($dir, 0);
@@ -69,7 +72,7 @@ sub create_dir {
     my ($dir, $intermediate) = @_;
 
     # Existing directories don't create a warning when -p is in effect.
-    return if $options{'p'} && -d $dir;
+    return 1 if $options{'p'} && -d $dir;
 
     # Umask is applied on mkdir.
     mkdir $dir => 0777 or do {
@@ -105,10 +108,10 @@ sub create_dir {
         };
 
         # -m has no effect on intermediate directories created due to -p.
-        return;
+        return 1;
     }
 
-    return unless exists $options{'m'};
+    return 1 unless exists $options{'m'};
 
     my $realmode = $options{'m'};
     if ($symbolic) {
@@ -116,22 +119,19 @@ sub create_dir {
                        die "invalid mode: $options{m}\n";
     }
     chmod oct($realmode) => $dir or warn "$!\n";
-    return;
+    return 1;
 }
 
 sub split_dir {
     my $dir = shift;
 
-    my @parts;
-    while ($dir ne dirname($dir)) {
-        push @parts, $dir;
-        $dir = dirname($dir);
+    my (@parts, @dirs);
+    @parts = File::Spec->splitdir($dir);
+    for (0 .. $#parts) {
+        push @dirs, File::Spec->catfile(@parts[0 .. $_]);
     }
-    @parts = reverse @parts;
-    if (-e $parts[0] && ! -d $parts[0]) { # drop intermediate for non-directory
-        @parts = splice @parts, 0, 1;
-    }
-    return @parts;
+    shift @dirs if (@dirs && $dirs[0] eq ''); # absolute path
+    return @dirs;
 }
 
 #

--- a/bin/mkdir
+++ b/bin/mkdir
@@ -69,7 +69,7 @@ sub create_dir {
     my ($dir, $intermediate) = @_;
 
     # Existing directories don't create a warning when -p is in effect.
-    return if !$intermediate && $options{'p'} && -d $dir;
+    return if $options{'p'} && -d $dir;
 
     # Umask is applied on mkdir.
     mkdir $dir => 0777 or do {

--- a/bin/mkdir
+++ b/bin/mkdir
@@ -17,7 +17,7 @@ use strict;
 use File::Basename qw(basename dirname);
 use Getopt::Std qw(getopts);
 
-our $VERSION = '1.5';
+our $VERSION = '1.6';
 my $Program = basename($0);
 
 $SIG{__WARN__} = sub { warn "$Program: @_\n" };
@@ -50,39 +50,32 @@ if (defined $options{'m'}) {
 	$symbolic = 1 if $options{'m'} =~ /[^0-7]/;
 }
 
-# Pay attention before you get lost. The argument list will be turned
-# into a list of anon arrays. Each anon array has 2 elements, a directory
-# name, and a flag to indicate whether it's an "intermediate" directory
-# or not. "intermediate" directories are the directories interfered by
-# -p, but not given on the command line.
-if (exists $options{'p'}) {
-    my @ARGV2;
-    while (@ARGV) {
-        my $dir = pop @ARGV;
-        my $intermediate = 0;
-        while( $dir ne dirname($dir) ) {
-            push @ARGV2 => [$dir, $intermediate ++];
-            $dir = dirname($dir);
-        }
+my $rc = EX_SUCCESS;
+foreach my $dir (@ARGV) {
+    if ($options{'p'}) {
+        my @subdir = split_dir($dir);
+	$dir = shift @subdir;
+	create_dir($dir, 0);
+	foreach my $d (@subdir) {
+            create_dir($d, 1);
+	}
+    } else {
+        create_dir($dir, 0);
     }
-    @ARGV = reverse @ARGV2;
 }
-else {
-    @ARGV = map {[$_ => 0]} @ARGV;
-}
+exit $rc;
 
-my $err = 0;
-foreach my $directory (@ARGV) {
-    my($dir, $intermediate) = @$directory;
+sub create_dir {
+    my ($dir, $intermediate) = @_;
 
     # Existing directories don't create a warning when -p is in effect.
-    next if -d $dir && exists $options{'p'};
+    return if !$intermediate && $options{'p'} && -d $dir;
 
     # Umask is applied on mkdir.
     mkdir $dir => 0777 or do {
         warn "cannot create directory '$dir': $!\n";
-        $err++;
-        next;
+        $rc = EX_ERROR;
+        return;
     };
 
     # Special case the intermediate directories.
@@ -95,27 +88,27 @@ foreach my $directory (@ARGV) {
             shift while @ARGV && $ARGV[0][1];
             shift if    @ARGV;
             warn "stat on $dir failed: $!\n";
-            $err++;
-            next;
+            $rc = EX_ERROR;
+            return;
         }
         # Turn on write and search permission for the user.
         my $mode = $st[2];
         $mode |= 3 << 6;
         chmod $mode => $dir or do {
             warn "chmod on $dir failed: $!\n";
-            $err++;
+            $rc = EX_ERROR;
             # Skip to next directory of arg list.
             # The tests for @ARGV aren't really necessary.
             shift while @ARGV && $ARGV[0][1];
             shift if    @ARGV;
-            next;
+            return;
         };
 
         # -m has no effect on intermediate directories created due to -p.
-        next;
+        return;
     }
 
-    next unless exists $options{'m'};
+    return unless exists $options{'m'};
 
     my $realmode = $options{'m'};
     if ($symbolic) {
@@ -123,8 +116,23 @@ foreach my $directory (@ARGV) {
                        die "invalid mode: $options{m}\n";
     }
     chmod oct($realmode) => $dir or warn "$!\n";
+    return;
 }
-exit($err ? EX_ERROR : EX_SUCCESS);
+
+sub split_dir {
+    my $dir = shift;
+
+    my @parts;
+    while ($dir ne dirname($dir)) {
+        push @parts, $dir;
+        $dir = dirname($dir);
+    }
+    @parts = reverse @parts;
+    if (-e $parts[0] && ! -d $parts[0]) { # drop intermediate for non-directory
+        @parts = splice @parts, 0, 1;
+    }
+    return @parts;
+}
 
 #
 # $Id: SymbolicMode.pm,v 1.1 2004/07/23 20:10:01 cwest Exp $


### PR DESCRIPTION
* Previously if running "mkdir -p" and the 1st part of an argument is not a directory, the program would incorrectly call mkdir() on the intermediate paths under it
* If I have a regular file 0, "mkdir -p 0/1/2" would show 3 errors because of mkdir("0/1") and mkdir("0/1/2")
* Restructure the program so ARGV can remain as a list of directories (now we don't need the explanation comment for the old confusing code)
* For -p flag, split directory into parts, calling a create_dir() function for each part
* split_dir() handles the case where the 1st part is not a directory, and drops the sub-directory parts

```
%touch 0
%perl mkdir -p 0/1/2 00 aa/bb/cc # only one error for 0/1/2 argument
mkdir: cannot create directory '0': File exists

%find 00 aa # everything was created except for 0/...
00
aa
aa/bb
aa/bb/cc
```