### PR TITLE
clear: handling OSPEED is not needed

### DIFF
--- a/bin/clear
+++ b/bin/clear
@@ -11,21 +11,13 @@ License: perl
 
 =cut
 
-
-use Term::Cap;
 use strict;
 
-my $OSPEED = 9600;
-eval {
-	require POSIX;
-	my $termios = POSIX::Termios->new();
-	$termios->getattr;
-	$OSPEED = $termios->getospeed;
-};
+use Term::Cap;
 
-my $terminal = Term::Cap->Tgetent({OSPEED=>$OSPEED});
 my $cl = "";
 eval {
+	my $terminal = Term::Cap->Tgetent;
 	$terminal->Trequire("cl");
 	$cl = $terminal->Tputs('cl', 1);
 };


### PR DESCRIPTION
* The OSPEED option being passed to Tgetent() is not required for clearing the screen
* Win32 perl might not have a working Term::Cap, so move the Tgetent() call into the eval just in case
* Tested on Linux and OpenBSD