### PR TITLE
diff: fix output_ed_diff() param declaration

### DIFF
--- a/bin/diff
+++ b/bin/diff
@@ -472,9 +472,7 @@ sub store_ed_diff {
 
 sub output_ed_diff {
 # This sub is used for ed ('diff -e') OR reverse_ed ('diff -f').
-# last arg is type of diff
-    my $diff_type = $_[-1];
-    my ($hunk, $fileref1, $fileref2) = @_;
+    my ($hunk, $fileref1, $fileref2, $diff_type) = @_;
     my %op_hash = ('+' => 'a', '-' => 'd', '!' => 'c');
 
     # Can't be any context for this kind of diff, so each hunk has one block


### PR DESCRIPTION
* The number of parameters for Hunk::output_ed_diff() doesn't vary, i.e. $diff_type always follows after $fileref2
* Remove comment which adds more confusion than clarity
* Stack trace for diff -f
```
. = Hunk::output_ed_diff(ref(Hunk), ref(ARRAY), ref(ARRAY), 'REVERSE_ED') called from file 'diff' line 340
. = Hunk::output_diff(ref(Hunk), ref(ARRAY), ref(ARRAY), 'REVERSE_ED') called from file 'diff' line 185
```

* Stack trace for diff -e
```
. = Hunk::output_ed_diff(ref(Hunk), ref(ARRAY), ref(ARRAY), 'ED') called from file 'diff' line 190
```
