### PR TITLE
patch: fix external ed invocation

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -912,8 +912,7 @@ sub apply {
 
     # Pipe to ed.
     eval {
-        my $cmd =  'ed -s ' . $self->{'i_file'};
-        open ED, '|-', $cmd or die "Couldn't fork ed: $!";
+        open ED, '|-', 'ed', '-s', $self->{'i_file'} or die "Couldn't fork ed: $!";
         print ED map @$_, @cmd               or die "Couldn't print ed: $!";
         print ED "wq $self->{o_file}\n"     or die "Couldn't print ed: $!";
         close ED                             or die "Couldn't close ed: $?";

--- a/bin/patch
+++ b/bin/patch
@@ -24,7 +24,7 @@ use constant EX_SUCCESS => 0;
 use constant EX_REJECTS => 1;
 use constant EX_FAILURE => 2;
 
-my $VERSION = '0.30';
+my $VERSION = '0.31';
 
 $|++;
 
@@ -912,16 +912,17 @@ sub apply {
 
     # Pipe to ed.
     eval {
-        local $SIG{PIPE} = sub { die 'Pipe broke...' };
-        local $SIG{CHLD} = sub { die 'Bad child...' };
-        open ED, '|-', qw(ed - -s), $self->{i_file} or die "Couldn't fork ed: $!";
+        my $cmd =  'ed -s ' . $self->{'i_file'};
+        open ED, '|-', $cmd or die "Couldn't fork ed: $!";
         print ED map @$_, @cmd               or die "Couldn't print ed: $!";
-        print ED "1,\$w $self->{o_file}"     or die "Couldn't print ed: $!";
+        print ED "wq $self->{o_file}\n"     or die "Couldn't print ed: $!";
         close ED                             or die "Couldn't close ed: $?";
     };
 
     # Did pipe to ed work?
-    unless ($@ or <$out> ne $magic) {
+    seek($out, 0, 0)  or throw("Couldn't seek OUT: $!");
+    my $testline = <$out>;
+    if (!$@ && $testline ne $magic) {
         $self->note("Hunk #$self->{hunk} succeeded at 1.\n");
         return 1;
     }


### PR DESCRIPTION
* This version of patch first attempts to process an ed diff by running an external ed command, then falls back to processing the ed commands directly
* I noticed the external ed code was always failing but I didn't debug it until now
* Problem1: SIGCHLD happens normally when ed exits but it was being treated as an error (removing signal handlers fixes it)
* Problem2: write command sent to ed was not terminated by a newline, so ed would never run the command
* Problem3: after writing to o_file, the offset of filehandle $out was at byte 26, so the test line comparison wasn't correct
* With this patch I can process a simple ed diff on Linux without the code reaching PLAN_J

```
%cat ab.diff # change a.c into b.c
9,14d
%cp a.c acopy.c
%perl patch -e acopy.c ab.diff
Hmm...  Looks like an ed diff to me...
Patching file acopy.c using Plan A...
Hunk #1 succeeded at 1.
done
%cmp acopy.c b.c
%cmp acopy.c a.c
acopy.c a.c differ: byte 84, line 9
```