### PR TITLE
date: catch invalid date arguments

### DIFF
--- a/bin/date
+++ b/bin/date
@@ -16,7 +16,7 @@ License: artistic2
 
 use POSIX;
 
-my $VERSION = '1.0.4';
+my $VERSION = '1.0.5';
 
 # set this if we do anything to select a timezone abbreviation, then
 # prefer this if it is defined.
@@ -80,8 +80,19 @@ sub run {
 	}
 
 sub select_format {
-	my( $supplied ) = grep { /\A\+/ } @_;
-	return $1 if $supplied =~ /\A\+(.+)/;
+	my $supplied;
+	foreach (@_) {
+		unless (s/\A\+//) {
+			print STDERR "Invalid date: $_\n";
+			exit 1;
+		}
+		if (defined $supplied) {
+			print STDERR "Extra operand: '+$_'\n";
+			exit 1;
+		}
+		$supplied = $_;
+	}
+	return $supplied if defined $supplied;
 
 	my $formats = get_formats();
 


### PR DESCRIPTION
* Extra format string arguments are ambiguous and should result in an error
* select_format() is meant to select only one format; the use of grep() as a filter prevented it from catching invalid arguments
* Arguments which are not a valid format string should result in an error
* Found when testing against GNU date
* test1: perl date    # default in select_format()
* test2: perl date yo+%a   # not a valid date format
* test3: perl date +%a +%a    # too many formats
* test4: perl date +%a%a   # still works