### PR TITLE
fmt: avoid space before newline

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -147,6 +147,7 @@ sub fmt_line {
     my $s = ' ' x $out[0]->{'indent'};
     print $s;
 
+    $out[-1]->{'suffix'} = 0;
     foreach $tok (@out) {
         $s = $tok->{'word'};
         $s .= ' ' x $tok->{'suffix'};


### PR DESCRIPTION
* In fmt_line(), the ```@out``` list describes one line of text
* Each word token keeps a record of trailing spaces after the word (i.e. "suffix" number in the code)
* Trailing space should be ignored for the final word on the line because it gets terminated by a newline