### PR TITLE
rm: simplify process_options()

### DIFF
--- a/bin/rm
+++ b/bin/rm
@@ -196,8 +196,6 @@ sub process_options {
 		);
 	usage() unless $ret;
 
-	$opts{'R'} = 1 if $opts{'r'};
-
 	$self->{options} = { map { defined $_ ? $_ : 0 } %opts };
 	$self->{files}   = $self->{args};
 


### PR DESCRIPTION
* is_recursive() is already smart enough to check both -R and -r, so manually setting ```$opts{R}``` is not required
* As a regression test I removed some subdirectories, first using -r, then -R