### PR TITLE
expr: remove manual word breaks in pod

### DIFF
--- a/bin/expr
+++ b/bin/expr
@@ -360,8 +360,8 @@ to an empty string or zero; otherwise, returns zero.
 =item expr1 {=, >, >=, <, <=, !=} expr2
 
 Returns the results of integer comparison if both arguments are
-integers; otherwise, returns the results of string comparison us-
-ing the locale-specific collation sequence.  The result of each
+integers; otherwise, returns the results of string comparison
+using the locale-specific collation sequence.  The result of each
 comparison is 1 if the specified relation is true, or 0 if the
 relation is false.
 
@@ -372,8 +372,8 @@ arguments.
 
 =item expr1 {*, /, %} expr2
 
-Returns the results of multiplication, integer division, or re-
-mainder of integer-valued arguments.
+Returns the results of multiplication, integer division, or
+remainder of integer-valued arguments.
 
 =item expr1 : expr2
 
@@ -382,10 +382,10 @@ a regular expression.  The regular expression is anchored to
 the beginning of the string with an implicit ``^''.  The
 regular expression language is perlre(1).
 
-If the match succeeds and the pattern contains at least one regu-
-lar expression subexpression ``(...)'', the string correspond-
-ing to ``$1'' is returned; otherwise the matching operator re-
-turns the number of characters matched.  If the match fails and
+If the match succeeds and the pattern contains at least one regular
+expression subexpression ``(...)'', the string corresponding
+to ``$1'' is returned; otherwise the matching operator
+returns the number of characters matched.  If the match fails and
 the pattern contains a regular expression subexpression the null
 string is returned; otherwise 0.
 


### PR DESCRIPTION
* Similar to recent commit for uniq: 4d22ee8cc8e9b843b4365c1dd096c482841bda06
* Breaking up words like "re-\nturn" gets in the way of the pod formatter

```
--- pod0	2025-01-07 12:33:58.825372933 +0800
+++ pod1	2025-01-07 12:35:15.441604917 +0800
@@ -24,8 +24,8 @@
 
     expr1 {=, >, >=, <, <=, !=} expr2
         Returns the results of integer comparison if both arguments are
-        integers; otherwise, returns the results of string comparison us-
-        ing the locale-specific collation sequence. The result of each
+        integers; otherwise, returns the results of string comparison using
+        the locale-specific collation sequence. The result of each
         comparison is 1 if the specified relation is true, or 0 if the
         relation is false.
 
@@ -34,8 +34,8 @@
         arguments.
 
     expr1 {*, /, %} expr2
-        Returns the results of multiplication, integer division, or re-
-        mainder of integer-valued arguments.
+        Returns the results of multiplication, integer division, or
+        remainder of integer-valued arguments.
 
     expr1 : expr2
         The ``:'' operator matches expr1 against expr2, which must be a
@@ -43,9 +43,9 @@
         beginning of the string with an implicit ``^''. The regular
         expression language is perlre(1).
 
-        If the match succeeds and the pattern contains at least one regu-
-        lar expression subexpression ``(...)'', the string correspond- ing
-        to ``$1'' is returned; otherwise the matching operator re- turns the
+        If the match succeeds and the pattern contains at least one regular
+        expression subexpression ``(...)'', the string corresponding to
+        ``$1'' is returned; otherwise the matching operator returns the
         number of characters matched. If the match fails and the pattern
         contains a regular expression subexpression the null string is
         returned; otherwise 0.
```