### PR TITLE
rm: chmod not needed

### DIFF
--- a/bin/rm
+++ b/bin/rm
@@ -259,7 +259,7 @@ sub remove_file {
 		$self->message( "$filename: ? " );
 		return OP_SUCCEEDED if <STDIN> =~ /^[Nn]/;
     }
-    elsif( ! -w $filename && !$self->is_force ) {
+    elsif( !$self->is_force && ! -w $filename ) {
 		$self->message( "$filename: Read-only ? " );
 		return OP_SUCCEEDED if <STDIN> =~ /^[Nn]/;
     }

--- a/bin/rm
+++ b/bin/rm
@@ -255,16 +255,14 @@ sub remove_file {
     my( $self, $filename ) = @_;
 
 	# Answering no to skip a file is not an error
-    if( ! -w $filename && $self->is_interactive ) {
-		$self->message( "$filename: Read-only ? " );
-		return OP_SUCCEEDED if <STDIN> =~ /^[Nn]/;
-    }
-    elsif( $self->is_interactive ) {
+    if( $self->is_interactive ) {
 		$self->message( "$filename: ? " );
 		return OP_SUCCEEDED if <STDIN> =~ /^[Nn]/;
     }
-
-    chmod '0777', $filename if $self->is_force;
+    elsif( ! -w $filename && !$self->is_force ) {
+		$self->message( "$filename: Read-only ? " );
+		return OP_SUCCEEDED if <STDIN> =~ /^[Nn]/;
+    }
 
     unless( unlink $filename ) {
 		$self->error( "$Program: cannot remove '$filename': $!\n" ) unless $self->is_force;


### PR DESCRIPTION
* Previously chmod() was being passed a string as the first argument, which didn't look right
* I studied the OpenBSD version and it doesn't do any chmod() so remove it here too
* For non-interactive mode (neither -i nor -f), print a special prompt if a file is non-writable
* For interactive mode, print a normal prompt for every file
* For force mode, do not check if a file is writable or print a prompt
* To test this I created a new file and set the permissions to 0 with chmod before "rm x", "rm -i x" and "rm -f x"