### PR TITLE
ed: fix append bug

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -83,7 +83,7 @@ my $Error = undef;              # saved error string for h command
 my $Prompt = undef;             # saved prompt string for -p option
 my $SearchPat;                  # saved pattern for repeat search
 my $Scripted = 0;
-my @lines;                      # buffer for file being edited.
+my @lines = ( 0 );              # buffer for file being edited.
 my $command;                    # single letter command entered by user
 my $commandsuf;                 # single letter modifier of command
 my @adrs;                       # 1 or 2 line numbers for commands to operate on
@@ -105,7 +105,7 @@ my $NO_QUESTIONS_MODE = 0;
 my $PRINT_NUM = 1;
 my $PRINT_BIN = 2;
 
-our $VERSION = '0.24';
+our $VERSION = '0.25';
 
 my @ESC = (
     '\\000', '\\001', '\\002', '\\003', '\\004', '\\005', '\\006', '\\a',


### PR DESCRIPTION
* It is valid usage to start ed with a filename that doesn't exist; ed is expected to start with an empty buffer and the default filename variable set
* Today I found that commands 0i and 0a were resulting in the first line of input being lost
* When debugging, I discovered the ```@lines``` list was empty when ed was started with a non-existent file
* A placeholder item $lines[0] is expected to be populated, but edEdit() was returning early because the file doesn't exist
* Fix this by initialising $lines[0] at start of program, i.e. before the 1st edEdit() call