### PR TITLE
ed: avoid literal newline in s///

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -550,7 +550,7 @@ sub edSubstitute {
         $PrintLastLine = 1;
     }
 
-    # do the search and substitution
+    $args[0] =~ s/\\n/n/g; # newline is not permitted
     for my $lineno (@adrs) {
         my $evalstring = "\$lines[\$lineno] =~ s$args[0]";
 


### PR DESCRIPTION
* Yesterday when editing a file I discovered the escape sequence "\n" was expanded to a newline when used in a substitution command
* This has the unintended result of updating one or more elements of the lines-list to contain multiple newline characters
* GNU and OpenBSD versions treat "\n" as a regular "n"; follow this for compatibility, and to avoid the problem of line x containing many lines

```
%perl ed.old -p 'ed>' a.c
623
ed>1
#include <stdio.h>
ed>s/h/\nH\nI\n\nJ\n/
ed>p
#include <stdio.
H
I

J
>
ed>Q
%perl ed.new -p 'ed>' a.c
623
ed>1
#include <stdio.h>
ed>s/h/\nH\nI\n\nJ\n/
ed>p
#include <stdio.nHnInnJn>
ed>Q
```