### PR TITLE
wc: inconsistent byte counts

### DIFF
--- a/bin/wc
+++ b/bin/wc
@@ -169,8 +169,9 @@ sub wc_fh {
             }
         }
         if ($opt{'w'}) {
-            s/\A\s+//;
-            @words = split /\s+/;
+            my $ln = $_;
+            $ln =~ s/\A\s+//;
+            @words = split /\s+/, $ln;
             $words += scalar @words;
         }
         if ($opt{'m'}) {


### PR DESCRIPTION
* The byte count reported by wc was different depending on whether the -w option is set (-w is set by default)
* The the code for $opt_w was modifying the line string to calculate a word count before the code for the other options is able to inspect the line
* This patch makes the code $opt_w modify its own copy of the line
```
%stat aaa.c # stat shows the correct size too
  File: aaa.c
  Size: 470       	Blocks: 8          IO Block: 4096   regular file
Device: b302h/45826d	Inode: 1034312     Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1000/      pi)   Gid: ( 1000/      pi)
Access: 2024-11-18 12:56:23.329998345 +0800
Modify: 2024-11-18 12:56:23.329998345 +0800
Change: 2024-11-18 12:56:23.329998345 +0800
 Birth: 2024-11-18 12:56:23.329998345 +0800
%perl wc  aaa.c # -w enabled by default
        30        66       454 aaa.c
%perl wc -c  aaa.c # -w disabled
       470 aaa.c
```