### PR TITLE
ed: e! should not set filename

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -105,7 +105,7 @@ my $NO_QUESTIONS_MODE = 0;
 my $PRINT_NUM = 1;
 my $PRINT_BIN = 2;
 
-our $VERSION = '0.25';
+our $VERSION = '0.26';
 
 my @ESC = (
     '\\000', '\\001', '\\002', '\\003', '\\004', '\\005', '\\006', '\\a',
@@ -706,9 +706,15 @@ sub edEdit {
         }
     }
 
+    my $do_pipe = 0;
     if (defined $args[0]) {
         return E_FNAME unless (length $args[0]);
-        $filename = $RememberedFilename = $args[0];
+        if ($args[0] =~ s/\A\!//) {
+            $do_pipe = 1;
+        } else {
+            $RememberedFilename = $args[0];
+        }
+        $filename = $args[0];
     } elsif (defined $RememberedFilename) {
         $filename = $RememberedFilename;
     } else {
@@ -717,13 +723,13 @@ sub edEdit {
         return;
     }
 
-    if (-d $filename) {
-        warn "$filename: is a directory\n";
-        return E_READ;
-    }
-    if ($filename =~ s/\A\!//) {
+    if ($do_pipe) {
         return unless (open $fh, "$filename |"); # no error
     } else {
+        if (-d $filename) {
+            warn "$filename: is a directory\n";
+            return E_READ;
+        }
         unless (open $fh, '<', $filename) {
             warn "$filename: $!\n";
             return E_OPEN;


### PR DESCRIPTION
* I hadn't tested this scenario before
* First I start ed with a file a.c
* The command "e !ifconfig" then replaces the buffer with the output of ifconfig
* Listing current filename with "f" command after this should still show "a.c" (this is how GNU and OpenBSD versions behave)
* The directory check should not happen for "e !..." case