### PR TITLE
ed: r command should not update saved filename

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -711,7 +711,8 @@ sub edEdit {
         return E_FNAME unless (length $args[0]);
         if ($args[0] =~ s/\A\!//) {
             $do_pipe = 1;
-        } else {
+        }
+        if (!$InsertMode && !$do_pipe) {
             $RememberedFilename = $args[0];
         }
         $filename = $args[0];


### PR DESCRIPTION
* edEdit() implements r and e, but r doesn't technically change the file being edited; it only adds more content to the file's buffer
* r command was updating $RememberedFilename, which is undesirable
* edEdit() is too complicated and I'd like to split it soon into 2 functions: edEdit() for e and edRead() for r (currently edRead() is a helper function calling edEdit())
* test1: open a one.c file, "r" a two.s, then verify with "f" command that the editor file is still one.c  
* test1: open a one.c file, "r !ifconfig" to include command output in buffer, then verify with "f" command as before