### PR TITLE
ed: 0k is not OK

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -346,6 +346,7 @@ sub edMark {
     my $ad = $adrs[1];
     $ad = $adrs[0] unless defined $ad;
     $ad = $CurrentLineNum unless defined $ad;
+    return E_ADDRBAD if $ad == 0;
     $marks{$c} = $ad;
     return;
 }


### PR DESCRIPTION
* Avoid saving address 0 as a "marked address"
* When edMark() was first written I didn't pick up that this usage was not allowed in other versions of ed
* test1: 1kx --> save address 1 as mark "k", valid if the buffer is not empty
* test2: 0ky --> save address 0, invalid
* test3: kz --> save current address as mark "z", valid if the buffer is not empty
