### PR TITLE
ed: w command should not update current filename

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -655,7 +655,7 @@ sub edWrite {
             $fh = init_pipe($args[0], 1);
             return E_OPEN unless $fh;
         } else {
-            $filename = $RememberedFilename = $args[0];
+            $filename = $args[0];
         }
     } elsif (defined $RememberedFilename) {
         $filename = $RememberedFilename;


### PR DESCRIPTION
* When writing a file, w command takes an optional filename argument
* If no filename argument is provided, the "current" filename is used
* If a filename argument is provided, write to that file but don't update the current filename
* Found when testing against GNU and OpenBSD versions
* NB: OpenBSD version calls get_filename() with Save param set to false
```
%perl ed -p 'PROMPT...' # f command still shows original a.s after write to b.s
PROMPT...e a.s
839
PROMPT...f
a.s
PROMPT...w b.s
839
PROMPT...f
a.s
PROMPT...q
```
