### PR TITLE
ed: buffer is dirty unless all lines were written

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -679,8 +679,12 @@ sub edWrite {
         warn "$filename: $!\n";
         return E_CLOSE;
     }
-
-    $NeedToSave = $UserHasBeenWarned = 0;
+    unless ($do_pipe) {
+        my $lcount = $adrs[1] - $adrs[0] + 1;
+        if ($lcount == maxline()) {
+            $NeedToSave = $UserHasBeenWarned = 0;
+        }
+    }
     print "$chars\n" unless $Scripted;
     exit getrc() if $qflag;
     return;


### PR DESCRIPTION
* I found a case where ed allowed unsaved changes to be lost
* The default behaviour of "w" command is to write all lines from the editor buffer
* In the case of 1w or 1,2w command, only the selected lines are written and there may be unsaved changes on other lines, so don't unset the "dirty" flag
* The flag should be unmodified also in the case of "w !cat", where all buffer lines are written to a pipe
* This patch makes ed consistent with BSD and GNU versions

```
%perl ed -p 'edmond>' a.s # desired behaviour
839
edmond>10d 
edmond>1w tmp.txt
13
edmond>q
?
edmond>h
buffer modified
edmond>Q
```