### PR TITLE
ed: simplify edMove()

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -485,13 +485,11 @@ sub edMove {
 
     my $count = $end - $start + 1;
     my @copy = @lines[$start .. $end];
-    if ($start > $dst && $end > $dst) {
-        splice(@lines, $start, $count) if $delete;
-        splice @lines, $dst + 1, 0, @copy;
-    } else {
-        # avoid $dst referring to the wrong line
-        splice @lines, $dst + 1, 0, @copy;
-        splice(@lines, $start, $count) if $delete;
+    splice @lines, $dst + 1, 0, @copy;
+    if ($delete) {
+        my $i = $start;
+        $i += $count if $dst < $start; # lines moved up
+        splice @lines, $i, $count;
     }
 
     $NeedToSave = 1;


### PR DESCRIPTION
* The code was more complicated than it needed to be
* Copy & delete operations can always be done in the same order; first copy, then delete
* Delete happens for "m" command but not for "t" command (edMove() handles both)
* If lines were copied before the start address, the address of the lines to be delete was increased by the number of lines copied
* test1: 17,18m5 --> after copy, original lines to delete are now at 19,20
* test2: 17,18m29 --> no address adjustment needed before deleting original lines