### PR TITLE
maze: reject fractional width/height

### DIFF
--- a/bin/maze
+++ b/bin/maze
@@ -51,14 +51,29 @@ usage() if @ARGV;
 
 sub get_number {
   my ($prompt, $value) = @_;
+  my $regmatch = 0;
+  my $inrange = 0;
 
-  while (!defined($value) or $value < 2) {
-    (defined $value) and ($value < 2) and print "$prompt too small.\n";
-    print "$prompt? ";
-    chomp($value = <STDIN>);
+  until ($regmatch && $inrange) {
+    if ($value =~ m/\A[0-9]+\Z/) {
+      $regmatch = 1;
+    } else {
+      print "expected an integer value, got '$value'\n";
+    }
+    if ($regmatch) {
+      if ($value >= 2) {
+        $inrange = 1;
+      } else {
+        print "$prompt too small\n";
+      }
+    }
+    if (!$regmatch || !$inrange) {
+      print "$prompt? ";
+      chomp($value = <STDIN>);
+      die "unexpected eof\n" unless defined $value;
+    }
   }
-
-  $value;
+  return $value;
 }
 
 $width  = &get_number('width',  $width);


### PR DESCRIPTION
* The size of the maze is counted in whole numbers; fractions don't maze sense
* get_number() is used for input validation
* Make get_number() reject the input if the number contains non-digits
* Numbers don't allow a '+' prefix as in some commands
* If EOF was seen when prompting for a number, terminate the program
* test1: ```perl maze 11 11``` --> valid, no prompt
* test2: ```perl maze 12.34 12.6666666666666666666``` --> invalid, will prompt for both width & height