### PR TITLE
ed: save space in editor buffer

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -100,7 +100,7 @@ my $UndoLine;
 my $PRINT_NUM = 1;
 my $PRINT_BIN = 2;
 
-our $VERSION = '0.28';
+our $VERSION = '0.29';
 
 my @ESC = (
     '\\000', '\\001', '\\002', '\\003', '\\004', '\\005', '\\006', '\\a',
@@ -380,7 +380,7 @@ sub edPrint {
         if ($do_bin) {
             print escape_line($i);
         } else {
-            print $lines[$i];
+            print get_terminated_line($i);
         }
     }
     $CurrentLineNum = $adrs[-1];
@@ -390,10 +390,15 @@ sub edPrint {
 sub escape_line {
     my $idx = shift;
 
-    my @chars = unpack 'C*', $lines[$idx];
+    my @chars = unpack 'C*', get_terminated_line($idx);
     die 'internal error: unpack' unless @chars;
     my @s = map { $ESC[$_] } @chars;
     return join '', @s;
+}
+
+sub get_terminated_line {
+    my $i = shift;
+    return $lines[$i] . "\n";
 }
 
 # does not modify buffer
@@ -433,15 +438,12 @@ sub edJoin {
     if ($adrs[0] == $adrs[1]) { # nop
         return;
     }
-
-    my $buf = $lines[$adrs[0]];
-    my $start = $adrs[0] + 1;
-    for my $i ($start .. $adrs[1]) {
-        chomp $buf;
-        $buf .= $lines[$i];
-    }
-    $lines[$adrs[0]] = $buf;
-    splice @lines, $start, $adrs[1] - $adrs[0];
+    my $i = $adrs[0];
+    my $j = $adrs[1];
+    my $delcount = $j - $i;
+    my @tmp = splice @lines, $i + 1, $delcount;
+    my $buf = join '', @tmp;
+    $lines[$i] .= $buf;
     $NeedToSave = 1;
     $UserHasBeenWarned = 0;
     $CurrentLineNum = $adrs[0];
@@ -669,7 +671,8 @@ sub edWrite {
         }
     }
     $chars = 0;
-    for my $line (@lines[$adrs[0]..$adrs[1]]) {
+    for my $i ($adrs[0] .. $adrs[1]) {
+        my $line = get_terminated_line($i);
         print {$fh} $line;
         $chars += length($line);
     }
@@ -814,9 +817,9 @@ sub readin_lines {
         push @tmp, $_;
     }
     if (@tmp && substr($tmp[-1], -1, 1) ne "\n") {
-        $tmp[-1] .= "\n";
         print "Newline appended\n";
     }
+    chomp @tmp;
     return @tmp;
 }
 
@@ -885,8 +888,8 @@ sub edPrintLineNum {
 
 sub write_undo {
     my $fh = File::Temp->new;
-    foreach (@lines) {
-         print {$fh} $_;
+    for my $i (1 .. maxline()) {
+         print {$fh} get_terminated_line($i);
     }
     seek $fh, 0, 0;
     return $fh;
@@ -899,6 +902,7 @@ sub edUndo {
 
     $CurrentLineNum = $UndoLine;
     @lines = <$UndoFile>;
+    chomp @lines;
     unshift @lines, undef;
     $UserHasBeenWarned = 0;
     $NeedToSave = 1; # new tmpfile
@@ -950,7 +954,7 @@ sub edSetCurrentLine {
         $CurrentLineNum++;
     }
 
-    print $lines[$CurrentLineNum];
+    print get_terminated_line($CurrentLineNum);
     return;
 }
 


### PR DESCRIPTION
* The substitution s/\z/NEW/ produced the unwanted outcome of $lines[$x] containing two lines of text
* Address this by not including trailing newlines in the editor buffer anymore
* Introduce helper function get_terminated_line() which adds the newline
* Now s/\z/NEW/ is interpreted the same as s/$/NEW/, i.e. append NEW to end of line
* Bump version number in case of regressions
* Removing the newlines from the editor buffer also reduces memory usage, but that is not the main intent of this patch

Test...
1. Null command
```
*1
#include <stdio.h>
```

2. List command w/lineno
```
*1,2ln
1	#include <stdio.h>$
2	#include <stdlib.h>$
```

3. Print command
```
*1p
#include <stdio.h>
```

4. Join command
```
*1,2j    
*1
#include <stdio.h>#include <stdlib.h>
```

5. Transpose (copy) command
```
*4n
4	int
*4t0
*1,2n
1	int
2	#include <stdio.h>#include <stdlib.h>
```

6. Move command
```
*1,2m$   
*$-2,$n 
42	} // ddd?s
43	int
44	#include <stdio.h>#include <stdlib.h>
```

7. Substitute command
```
*$
#include <stdio.h>#include <stdlib.h>
*s/include/exclude/g
*.
#exclude <stdio.h>#exclude <stdlib.h>
```

8. Delete command
```
*$d
*$=
43
*.
int
```

9. Insert command
```
*0i    
start of buffer
.
*1n 
1	start of buffer
```

10. Append command
```
*1a    
2ND LINE!!!!!
.
*1,2n
1	start of buffer
2	2ND LINE!!!!!
```

11. Change command
```
*1,2c
BEGIN buffer     
second line 
.
*1,2n
1	BEGIN buffer
2	second line
```

12. Undo command
```
*u
*1,2n
1	start of buffer
2	2ND LINE!!!!!
```

13. EDIT command
```
*E a.s
790
*1,3n
1		.arch armv6
2		.eabi_attribute 28, 1
3		.eabi_attribute 20, 1
```

14. Filename command
```
*f 
a.s
```

15. Read command (linux ifconfig prints and extra empty line)
```
*0r !ifconfig lo 
387
*.=
9
```

16. Write command
```
*1,15w !cat -n 
     1	lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
     2	        inet 127.0.0.1  netmask 255.0.0.0
     3	        inet6 ::1  prefixlen 128  scopeid 0x10<host>
     4	        loop  txqueuelen 1000  (Local Loopback)
     5	        RX packets 30  bytes 2892 (2.8 KiB)
     6	        RX errors 0  dropped 0  overruns 0  frame 0
     7	        TX packets 30  bytes 2892 (2.8 KiB)
     8	        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
     9	
    10		.arch armv6
    11		.eabi_attribute 28, 1
    12		.eabi_attribute 20, 1
    13		.eabi_attribute 21, 1
    14		.eabi_attribute 23, 3
    15		.eabi_attribute 24, 1
524
```

17. Regex prefix + Number command
```
*/main/n 
32		.global	main
```

18. Repeat search with empty regex
```
*//
	.type	main, %function
```

19. Mark command (current addr saved as x)
```
*.kx
*$
	.section	.note.GNU-stack,"",%progbits
*'xs/function/F_U_N_K_T_O_W_N/
*n
37		.type	main, %F_U_N_K_T_O_W_N
```

20. HelpMode command
```
*-1000000000000000000000
?
*H
invalid address
*-----------
	.ascii	"yo\000"
*yo
?
unknown command
```

