### PR TITLE
patch: add paths to error messages

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -24,7 +24,7 @@ use constant EX_SUCCESS => 0;
 use constant EX_REJECTS => 1;
 use constant EX_FAILURE => 2;
 
-my $VERSION = '0.31';
+my $VERSION = '0.32';
 
 $|++;
 
@@ -434,11 +434,12 @@ sub bless {
     }
 
     # Open original file.
-    local *IN;
-    open IN, '<', $in or $self->skip("Couldn't open INFILE: $!\n");
-    binmode IN;
-    $self->{i_fh} = *IN;    # input filehandle
-    $self->{i_file} = $in;  # input filename
+    my $in_fh;
+    open $in_fh, '<', $in
+        or $self->skip("Cannot open input file '$in': $!\n");
+    binmode $in_fh;
+    $self->{'i_fh'} = $in_fh;
+    $self->{'i_file'} = $in;
 
     # Open output file.
     if ($self->{check}) {
@@ -448,13 +449,14 @@ sub bless {
         $self->{'o_file'} = '-';
         $self->{'d_fh'} = length $self->{'ifdef'} ? *STDOUT : File::Temp->new;
     } else {
-        local *OUT;
-        open OUT, '+>', $out or $self->skip("Couldn't open OUTFILE: $!\n");
-        binmode OUT;
-        $|++, select $_ for select OUT;
-        $self->{o_fh}   = *OUT;
-        $self->{o_file} = $out;
-        $self->{d_fh}   = length $self->{ifdef} ? *OUT : File::Temp->new();
+        my $out_fh;
+        open $out_fh, '+>', $out
+            or $self->skip("Cannot open output file '$out': $!\n");
+        binmode $out_fh;
+        $|++, select $_ for select $out_fh;
+        $self->{'o_fh'}   = $out_fh;
+        $self->{'o_file'} = $out;
+        $self->{'d_fh'}   = length $self->{'ifdef'} ? $out_fh : File::Temp->new();
     }
 
     $self->{'reject-file'} = "$out.rej" unless defined $self->{'reject-file'};


### PR DESCRIPTION
* Improve error messages if open() fails
* INFILE was listed instead of the original file path
* OUTFILE was listed instead of the path provided to -o, e.g. if I specify an invalid argument
* Style: switch filehandles to my-variables
* Style: add more quotes for hash keys

```
%perl diff env.c env2.c | perl tee env.diff
61d60
< 	setprogname(*argv);
79d77
< 		case '?':
%perl patch -o /G/G env.c env.diff 
Hmm...  Looks like a normal diff to me...
Patching file env.c using Plan B...
Couldn't open OUTFILE: No such file or directory
Skipping patch...

% chmod 0 env.c
%perl patch -o NEW_ENV env.c env.diff
Hmm...  Looks like a normal diff to me...
Patching file env.c using Plan B...
Couldn't open INFILE: Permission denied
Skipping patch...
```