### PR TITLE
patch: raise error for incompatible format options

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -24,7 +24,7 @@ use constant EX_SUCCESS => 0;
 use constant EX_REJECTS => 1;
 use constant EX_FAILURE => 2;
 
-my $VERSION = '0.32';
+my $VERSION = '0.33';
 
 $|++;
 
@@ -38,6 +38,20 @@ sub version {
         Perl Artistic License.
     ];
     exit EX_SUCCESS;
+}
+
+sub type_conflict {
+    my $opts = shift;
+    my @types;
+    my $i = 0;
+    for (qw(context ed normal unified)) {
+        push @types, '--' . $_ if $opts->{$_};
+    }
+    if (scalar(@types) > 1) {
+        warn "$0: incompatible input type specifiers: @types\n";
+        exit EX_FAILURE;
+    }
+    return;
 }
 
 my ($patchfile, @options);
@@ -76,7 +90,9 @@ if (@ARGV) {
     my $next = 0;
     for (@options) {
         local @ARGV = @$_;
-        Getopt::Long::GetOptions(\my %opts, @desc) or die("Bad options\n");
+        my %opts;
+        Getopt::Long::GetOptions(\%opts, @desc) or die("Bad options\n");
+        type_conflict(\%opts);
         $opts{origfile} = shift;
         $_ = \%opts;
         $patchfile = shift unless $next++;


### PR DESCRIPTION
* The Getopt library makes the original order of options invisible, i.e. we can't tell if -e comes before or after -c
* By default, patch attempts to guess the type of the input diff
* Options -c, -e, -n & -u direct the program to look for a certain diff format
* Specifying -c and -e results in undefined behaviour in this version so raise an error
* In GNU patch, the order of -c and -e matters, i.e. -e will win if it appears after -c
* type_conflict() function will print the long-option names of the conflicting diff types

```
%perl patch -C  -c -e  env.c env.diff  
patch: incompatible input type specifiers: --context --ed
```