### PR TITLE
patch: don't reject final hunk in context diff

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -185,6 +185,7 @@ while (<PATCH>) {
             print PATCH;
             for ($o_start..$o_end) {
                 $_ = <PATCH>;
+                last unless defined $_; # EOF: no further hunks
                 unless (s/$re/$1/) {
                     $patch->note("Short hunk ignored.\n");
                     $patch->reject($i_range, @i_hunk, $o_range, @o_hunk);


### PR DESCRIPTION
* If EOF is seen, process hunk items seen so far, then terminate
* I was debugging why a "short hunk ignored" error occurred for the last hunk in a 2-hunk diff
* undef was being matched against valid-diff-line regex, but undef means there are no more lines in the diff to process