### PR TITLE
ed: compatible \Z and \z in substitute

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -548,6 +548,9 @@ sub edSubstitute {
     }
 
     $args[0] =~ s/\\n/n/g; # newline is not permitted
+    $args[0] =~ s/\\z/z/g;
+    $args[0] =~ s/\\Z/Z/g;
+
     for my $lineno (@adrs) {
         my $evalstring = "\$lines[\$lineno] =~ s$args[0]";
 
@@ -561,7 +564,7 @@ sub edSubstitute {
     return E_NOMATCH unless defined $LastMatch;
     $CurrentLineNum = $LastMatch;
 
-    print $lines[$LastMatch] if ($PrintLastLine);
+    print get_terminated_line($LastMatch) if $PrintLastLine;
     return;
 }
 


### PR DESCRIPTION
* Avoid special meaning of \Z and \z escapes when substituting text
* The special meaning of \n was already prevented in this way
* Add a missing call to get_terminated_line() in edSubstitute() that was found when testing this (the result of the s command is conditionally printed)
* It is still possible to bind a substitution to the end of a line using ```s/$/text/```
* Tested against GNU ed