### PR TITLE
morse: fold case bug

### DIFF
--- a/bin/morse
+++ b/bin/morse
@@ -16,7 +16,7 @@ use strict;
 
 use Getopt::Std qw(getopts);
 
-my ($VERSION) = '1.3';
+my ($VERSION) = '1.4';
 
 my %chartab = (
      0   => '-----',   1   => '.----',   2   => '..---',   3   => '...--',
@@ -93,7 +93,12 @@ sub txt2word {
     foreach my $c (split //, $line) {
         if ($c eq "\n") {
             print "\n";
-        } elsif (exists $chartab{$c}) {
+            next;
+        }
+        if ($c =~ m/[A-Z]/) {
+            $c = lc $c;
+        }
+        if (exists $chartab{$c}) {
             my $w = $chartab{$c};
             $w =~ s/\./dit /g;
             $w =~ s/\-/daw /g;


### PR DESCRIPTION
* Sometimes letter case was being folded and sometimes it was not
* When debugging, txt2mors() handled the folding but txt2word() was missing this logic; both of these functions lookup values in %chartab

```
%perl  morse aia
dit daw 
dit dit 
dit daw 
%perl  morse AIA
%perl  morse -s aia
.-
..
.-
%perl  morse -s AIA
.-
..
.-
```