### PR TITLE
patch: improve validation of normal diffs

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -24,7 +24,7 @@ use constant EX_SUCCESS => 0;
 use constant EX_REJECTS => 1;
 use constant EX_FAILURE => 2;
 
-my $VERSION = '0.34';
+my $VERSION = '0.35';
 
 $|++;
 
@@ -200,8 +200,15 @@ while (<PATCH>) {
     } elsif (/^(\s*)((\d+)(?:,(\d+))?([acd])(\d+)(?:,(\d+))?\n)/) {
         # NORMAL DIFF
         my ($space, $range, $i_start, $i_end, $cmd, $o_start, $o_end) =
-           ($1,     $2,     $3,     $4 || $3, $5,   $6,       $7 || $6);
+           ($1,     $2,     $3,       $4,     $5,   $6,       $7 || $6);
         $patch->bless('normal') or next PATCH;
+        if ($cmd eq 'a' && defined($i_end)) { # invalid input "X,YaZ"
+            my $input = $_;
+            chomp $input;
+            $patch->note("Malformed input at line $.: $input\n");
+            $patch->reject($range);
+            last;
+        }
         my (@d_hunk, @a_hunk);
         my $d_re = qr/^$space< /;
         my $a_re = qr/^$space> /;
@@ -278,8 +285,9 @@ if (ref $patch eq 'Patch') {
     $patch->end;
 }
 
+exit(EX_REJECTS) if $patch->error;
 $patch->note("done\n");
-exit($patch->error ? EX_REJECTS : EX_SUCCESS);
+exit EX_SUCCESS;
 
 END {
     close STDOUT || die "$0: can't close stdout: $!\n";

--- a/bin/patch
+++ b/bin/patch
@@ -209,6 +209,7 @@ while (<PATCH>) {
             $patch->reject($range);
             last;
         }
+        $i_end = $i_start unless defined $i_end; # for input "XcY,Z" and "XdY,Z"
         my (@d_hunk, @a_hunk);
         my $d_re = qr/^$space< /;
         my $a_re = qr/^$space> /;


### PR DESCRIPTION
* A normal diff can contain (a)dd, (c)hange and (d)elete commands
* For the Add command, a single target address is expected to be prefixed before "a"
* Diff utils output data in form of XaY,Z and not X,YaZ (so in practice the error condition should not happen)
* GNU diffutils manual described and Add command as "LaR", where L is a single line number and R is a range (e.g. 3,4) [1]
* Make this version of patch reject malformed Add commands
* Print the offending input data and line number
* Calling $patch->reject() is needed for setting the correct exit code
* When exiting on failure, avoid printing "done" message after preceding error messages
* I created an invalid input file manually to test this

1. https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Normal.html

```
%cat YES.diff  
34,31a35
> new line
%perl patch -C -n yes YES.diff 
Hmm...  Looks like a normal diff to me...
Checking patch against file yes using Plan C...
Malformed input at line 1: 34,31a35
1 out of 1 hunks ignored--saving rejects to .rej
%echo $?
1
```
