### PR TITLE
chgrp: redundant file check

### DIFF
--- a/bin/chgrp
+++ b/bin/chgrp
@@ -98,12 +98,6 @@ sub modify_file {
         File::Find::find (\&modify_file, readlink $file);
         return;
     }
-    unless (-e $file) {
-        warn "$Program: '$file' does not exist\n";
-        $warnings++;
-        return;
-    }
-
     my @st = stat $file;
     unless (@st) {
         warn "$Program: failed to stat '$file': $!\n";


### PR DESCRIPTION
* In modify_file(), delete a -e file check immediately before stat()ing the file
* Allow stat() to fail; it will cover the case where the file argument doesn't exist
```
%perl chgrp root a/b/c/d
chgrp: failed to stat 'a/b/c/d': No such file or directory
```