### PR TITLE
patch: improve validation of normal diffs (2)

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -210,6 +210,14 @@ while (<PATCH>) {
             last;
         }
         $i_end = $i_start unless defined $i_end; # for input "XcY,Z" and "XdY,Z"
+
+        if ($cmd ne 'a' && $i_start > $i_end) { # bad range "2,1c" and "2,1d"
+            my $input = $_;
+            chomp $input;
+            $patch->note("Malformed input at line $.: $input\n");
+            $patch->reject($range);
+            last;
+        }
         my (@d_hunk, @a_hunk);
         my $d_re = qr/^$space< /;
         my $a_re = qr/^$space> /;


### PR DESCRIPTION
* In a Normal diff the commands c and d operate on a line number range written as x,y
* The range 2,1 is not valid
* Reject a diff if a backwards range is seen to avoid incorrectly processing a file, then reporting "successful patch"
* diff tools would not output diffs with incorrect ranges like this; the new validation is to protect against mangled input
* I found this when testing against the GNU version
```
%patch m del.diff # GNU
patching file m
patch: **** malformed patch at line 1: 10,6d5

%perl patch m del.diff 
Hmm...  Looks like a normal diff to me...
Patching file m using Plan A...
Malformed input at line 1: 10,6d5
1 out of 1 hunks ignored--saving rejects to m.rej
```