### PR TITLE
patch: -D argument validation

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -54,6 +54,13 @@ sub type_conflict {
     return;
 }
 
+sub ifdef_id_check {
+    my $id = shift;
+    return if (length($id) != 0 && $id =~ m/\A[A-Za-z]\w*\Z/);
+    warn "$0: argument to -D is not an identifier\n";
+    exit EX_FAILURE;
+}
+
 my ($patchfile, @options);
 
 if (@ARGV) {
@@ -93,6 +100,7 @@ if (@ARGV) {
         my %opts;
         Getopt::Long::GetOptions(\%opts, @desc) or die("Bad options\n");
         type_conflict(\%opts);
+        ifdef_id_check($opts{'ifdef'}) if defined $opts{'ifdef'};
         $opts{origfile} = shift;
         $_ = \%opts;
         $patchfile = shift unless $next++;


### PR DESCRIPTION
* When patching a file with -D option (aka --ifdef), "-Did" and "-D id" usages are accepted
* I found that an empty string argument is sometimes ignored, and sometimes raises an error
* The OpenBSD version raises an error if the argument to -D is not a valid identifier, i.e. starts with alpha followed by alphanumeric & underscore
* Add validation in this version; as a benefit the invalid empty string usage is rejected
* test1: ```perl patch -D''```   ---> already caught by Getopt::Long
* test2: ```perl patch -D '' file```   ---> now errors; previously ignored
* test3: ```perl patch -DValid_id0 file```  ---> ifdef name accepted as before
* test4: ```perl patch -D 'd/e;f~ine#' file``` ---> now errors; previously accepted