### PR TITLE
rm: unexpected confirmation prompt

### DIFF
--- a/bin/rm
+++ b/bin/rm
@@ -259,7 +259,7 @@ sub remove_file {
 		$self->message( "$filename: ? " );
 		return OP_SUCCEEDED if <STDIN> =~ /^[Nn]/;
     }
-    elsif( !$self->is_force && ! -w $filename ) {
+    elsif( !$self->is_force && -e $filename && ! -w $filename ) {
 		$self->message( "$filename: Read-only ? " );
 		return OP_SUCCEEDED if <STDIN> =~ /^[Nn]/;
     }


### PR DESCRIPTION
* When attempting to remove a file that doesn't exist, rm shows a prompt about the file being read-only
* If I then confirm by typing "y", I see the unlink() error which explains the file wasn't found
* Bypass the prompt by adding an -e file check; the "-w FILE" is false if FILE doesn't exist

```
%perl ls not-exist
ls: can't access 'not-exist': No such file or directory
%perl rm not-exist
not-exist: Read-only ? y
rm: cannot remove 'not-exist': No such file or directory
%perl rm -f not-exist
%echo $?
0
```