### PR TITLE
grep -r should not sort directory entries

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -58,7 +58,7 @@ use constant EX_MATCHED => 0;
 use constant EX_NOMATCH => 1;
 use constant EX_FAILURE => 2;
 
-our $VERSION = '1.018';
+our $VERSION = '1.019';
 
 $| = 1;                   # autoflush output
 
@@ -367,7 +367,7 @@ sub matchfile {
 	$opt     = shift;    # reference to option hash
 	$matcher = shift;    # reference to matching sub
 
-	my ( $file, @list, $total, $name );
+	my ( $file, $total, $name );
 	local ($_);
 	$total = 0;
 
@@ -397,13 +397,12 @@ FILE: while ( defined( $file = shift(@_) ) ) {
 					}
 				next FILE;
 				}
-			@list = ();
+			my @list;
 			for (readdir $dh) {
 				next if $_ eq '.' or $_ eq '..';
 				push @list, File::Spec->catfile($file, $_);
 				}
 			closedir $dh;
-			@list = sort @list;
 			matchfile( $opt, $matcher, @list );    # process files
 			next FILE;
 			}


### PR DESCRIPTION
* A directory might have 1000s of entries and sorting would make ```grep -r``` invocation slower (there is no standard option to toggle sort)
* Be consistent with OpenBSD and GNU versions by processing directory entries in the order they appear
* As part of verification, I compared output of ```grep -r``` on OpenBSD (filenames not sorted) with ```ls -1a``` (filenames sorted)
* Clarification: ```@list``` variable is only for setting up argument list for recursive matchfile() call. Declare it within if-block scope to avoid potential of old entries appearing between loop iterations.

```
%pwd
/home/x/PerlPowerTools
%# GNU filename matches are unsorted
%grep -r perl bin | cut -d ':' -f 1  | uniq | head -n 15
bin/uniq
bin/cal
bin/expand
bin/basename
bin/primes
bin/ls
bin/uname
bin/kill
bin/diff
bin/hexdump
bin/asa
bin/pwd
bin/whois
bin/expr
bin/patch
```