### PR TITLE
ls: incorrect column widths in -R mode

### DIFF
--- a/bin/ls
+++ b/bin/ls
@@ -110,7 +110,6 @@ sub format_mode {
 # ------ define variables
 my $Getgrgid = "";	# getgrgid() for this platform
 my $Getpwuid = "";	# getpwuid() for this platform
-my $Maxlen = 1;		# longest string we've seen
 my $Now = time;		# time we were invoked
 my %Options = ();	# option/flag arguments
 my $SixMonths =		# long listing time if < 6 months, else year
@@ -314,12 +313,11 @@ sub List {
 	my $Expand = shift;	# do 1 level of dir expansion,
 				# for "ls DIRNAME"
 	my $Attributes = "";	# entry attributes hashref
-	my $BlockSize =		# block size in 512-byte units
-	 exists($Options->{'k'}) ? 2 : 1;
 	my $Cols = 0;		# output columns for this List()
 	my $Entry = "";		# directory entry
 	my @Dirs = ();		# directories from -R and DirEntries
 	my $Mask = "";		# sprintf() format/mask
+	my $Maxlen = 1;		# longest string for current directory
 	my $Mylen = 0;		# current entry length
 	my $Path = "";		# path for subdirectories
 	my $Piece = "";		# piece of entry list


### PR DESCRIPTION
* The column widths for "ls -R" didn't always look right
* List() is called for each directory/subdirectory
* Global variable $Maxlen is increased by 1 unconditionally, despite the value being saved from the previous call
* When I tested "perl ls -R .." I observed $Maxlen values from 21-59, incrementing by 1 for each directory
* The entries for the subdirectories are printed with too much space
* When I compare the output of GNU ls, the column widths are calculated for each directory listed
* Fix this by making $Maxlen a non-global; it is only used in List() and the value between calls should not be saved
* Extra: remove unused variable $BlockSize

```
%# BEFORE: maxlen of ../bin takes value from previous .. then adds 1
%perl ls -R ..
maxlen[21]
..:
CNAME                 LICENSE-BSD2          Makefile.PL           data                  util
CONTRIBUTING.md       LICENSE-GPL2          PROGRAMMING_STYLE.md  lib                   xt
Changes               MANIFEST              README.pod            packed                
INSTALL.SKIP          MANIFEST.SKIP         TODO                  packer                
LICENSE-ARTISTIC2     META.yml              bin                   t                     

maxlen[22]
../bin:
YES.diff               dc                     ln                     pwd                    txt1
_die.log               deroff                 lock                   rain                   uname
addbib                 diff                   look                   random                 unexpand
apply                  dirname                ls                     rev                    uniq
ar                     du                     mail                   rm                     units
arch                   echo                   maze                   rmdir                  unlink
arithmetic             ed                     mimedecode             rnd.bin                unpar
asa                    env                    mkdir                  robots                 unshar
awk                    expand                 mkfifo                 rot13                  uudecode
banner                 expr                   moo                    seq                    uuencode
base64                 factor                 morse                  shar                   wc
basename               false                  morse2                 sleep                  what
bc                     file                   names                  sort                   which
bcd                    find                   nl                     spell                  whoami
cal                    fish                   od                     split                  whois
cat                    fmt                    par                    strings                words
chgrp                  fold                   paste                  sum                    wump
chgrp.orig             fortune                patch                  tac                    xargs
ching                  from                   perldoc                tail                   yes
chmod                  fuzz_pike.sh           perlpowertools         tar                    yes.ORig
chown                  glob                   pig                    tee                    yes.Orig
clear                  grep                   ping                   test                   yes.diff
cmp                    hangman                pom                    test.pl                yes.orig
col                    head                   ppt                    time                   yes.rej
colrm                  hexdump                pr                     touch                  yes2
comm                   id                     prices                 tr                     
cp                     install                primes                 true                   
cut                    join                   printenv               tsort                  
date                   kill                   printf                 tty                    
<SNIP>

%# AFTER: maxlen of "../bin" is less than for "..", which means we can fit more text columns
%perl ls -R ..
maxlen[21]
..:
CNAME                 LICENSE-BSD2          Makefile.PL           data                  util
CONTRIBUTING.md       LICENSE-GPL2          PROGRAMMING_STYLE.md  lib                   xt
Changes               MANIFEST              README.pod            packed                
INSTALL.SKIP          MANIFEST.SKIP         TODO                  packer                
LICENSE-ARTISTIC2     META.yml              bin                   t                     

maxlen[15]
../bin:
YES.diff        clear           find            maze            primes          tail            wc
_die.log        cmp             fish            mimedecode      printenv        tar             what
addbib          col             fmt             mkdir           printf          tee             which
apply           colrm           fold            mkfifo          pwd             test            whoami
ar              comm            fortune         moo             rain            test.pl         whois
arch            cp              from            morse           random          time            words
arithmetic      cut             fuzz_pike.sh    morse2          rev             touch           wump
asa             date            glob            names           rm              tr              xargs
awk             dc              grep            nl              rmdir           true            yes
banner          deroff          hangman         od              rnd.bin         tsort           yes.ORig
base64          diff            head            par             robots          tty             yes.Orig
basename        dirname         hexdump         paste           rot13           txt1            yes.diff
bc              du              id              patch           seq             uname           yes.orig
bcd             echo            install         perldoc         shar            unexpand        yes.rej
cal             ed              join            perlpowertools  sleep           uniq            yes2
cat             env             kill            pig             sort            units           
chgrp           expand          ln              ping            spell           unlink          
chgrp.orig      expr            lock            pom             split           unpar           
ching           factor          look            ppt             strings         unshar          
chmod           false           ls              pr              sum             uudecode        
chown           file            mail            prices          tac             uuencode        
```
