### PR TITLE
patch: correctly parse two-address append in ed-diff

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -997,6 +997,8 @@ sub apply {
             $cmd[$i] = '';
             s/\.\././ for @{$cmd[$i-1][3]};
             next;
+        } elsif ($cmd eq 'a') {
+            $start = $end if $start < $end; # "1,10a" takes 10 as target
         }
 
         # Remove '.' line used to terminate hunks.


### PR DESCRIPTION
* When processing an append ("a") command in an ed-style diff, line number ranges are not parsed correctly
* If a range (e.g. "1,2") is given as a prefix to "a", the 2nd address ("2") is used as the target address
* Regular diff tools don't output "a" commands with 2 addresses so this is a corner case
* ed-style diffs can be pasted from a previous ed editor session or typed manually, so having extra validation here is helpful
* To test this, I bypassed the code for running an external ed program
* I modified a diff generated by "diff -e", changing the "322a" command to "1,322a"... the file is patched successfully

```
%cat bad.diffe 
1,322a
	my $Maxlen = 1;		# longest string for current directory
.
317,318d
113d
%perl patch -e ls bad.diffe 
Hmm...  Looks like an ed diff to me...
Patching file ls using Plan A...
Hunk #1 succeeded at 113
Hunk #2 succeeded at 317
Hunk #3 succeeded at 322
done
%cmp ls ls2
```