### PR TITLE
fortune: bad assumption in find_path()

### DIFF
--- a/bin/fortune
+++ b/bin/fortune
@@ -15,11 +15,12 @@ License: gpl
 use strict;
 use FindBin qw($Bin);
 use File::Basename;
+use File::Spec;
 use Getopt::Std;
 
 $|++;
 
-my ($VERSION) = '2.1';
+my ($VERSION) = '2.2';
 
 my $home = $Bin;
 $home =~ s|/[^/]*/?$||;
@@ -232,8 +233,11 @@ sub find_path
 
     return $name if -d $name || is_fortune_file( $name );
 
-    foreach ( fortune_dirs() ) {
-	    return "$_/$name" if is_fortune_file( "$_/$name" );
+    unless (File::Spec->file_name_is_absolute($name)) {
+	    foreach ( fortune_dirs() ) {
+		    my $abs = File::Spec->catfile($_, $name);
+		    return $abs if is_fortune_file($abs);
+	    }
     }
 
     die "fortune: $name not a fortune file or directory\n";


### PR DESCRIPTION
* This version of fortune can be passed a file argument, which will be used as the fortune file
* In find_path(), if the direct path check fails a loop is entered where the file argument is appended to each search directory
* When the file argument is an absolute path, entering this loop is incorrect because the absolute path will be prefixed with the search directory path
* fortune's debug (-d) option makes the file search easy to see
* While here, use catfile() to join relative paths with the search directory

```
%perl fortune -d /dev/null # BEFORE: 2nd is_fortune_file() call shouldn't happen
opts are:
d == 1
Building file list. Containers are Percent specified and Percent unspecified

@ARGV (1 arguments):
/dev/null


trying to add item /dev/null to Percent unspecified
is_fortune_file(/dev/null) returns FALSE (can't read file)
is_fortune_file(/home/x/PerlPowerTools/fortunes//dev/null) returns FALSE (can't read file)
fortune: /dev/null not a fortune file or directory


%perl fortune -d /dev/null # AFTER: single is_fortune_file() call for abs path
opts are:
d == 1
Building file list. Containers are Percent specified and Percent unspecified

@ARGV (1 arguments):
/dev/null


trying to add item /dev/null to Percent unspecified
is_fortune_file(/dev/null) returns FALSE (can't read file)
fortune: /dev/null not a fortune file or directory

%perl fortune -d heh # AFTER: relpath converted to absolute in 2nd is_fortune_file() call
opts are:
d == 1
Building file list. Containers are Percent specified and Percent unspecified

@ARGV (1 arguments):
heh


trying to add item heh to Percent unspecified
is_fortune_file(heh) returns FALSE (can't read file)
is_fortune_file(/home/x/PerlPowerTools/fortunes/heh) returns FALSE (can't read file)
fortune: heh not a fortune file or directory
```
