### PR TITLE
ls: list file arguments in columns

### DIFF
--- a/bin/ls
+++ b/bin/ls
@@ -114,7 +114,7 @@ my $Now = time;		# time we were invoked
 my %Options = ();	# option/flag arguments
 my $SixMonths =		# long listing time if < 6 months, else year
  60*60*24*(365/2);
-our $VERSION = '0.70';	# because we're V7-compatible :)
+our $VERSION = '0.71';
 my $WinCols;		# window columns of output
 
 # ------ compensate for lack of getpwuid/getgrgid on some platforms
@@ -517,10 +517,15 @@ if ($#ARGV < 0) {
 	for my $Arg (@Files) {
 		$Attributes{$Arg} = stat($Arg);
 	}
-	for my $Arg (Order(\%Options, \%Attributes, @Files)) {
+	if (@Files) {
 		$First = 0;
-		List($Arg, \%Options, 0, 0,
-		 DirEntries(\%Options, $Arg));
+		my %attrs;
+		foreach (@Files) {
+			my @ret = DirEntries(\%Options, $_);
+			%attrs = (%attrs, %{ $ret[-1] });
+		}
+		my @sorted = Order(\%Options, \%Attributes, @Files);
+		List('.', \%Options, 0, 0, @sorted, \%attrs);
 	}
 	for my $Arg (@Dirs) {
 		$Attributes{$Arg} = stat($Arg);


### PR DESCRIPTION
* Test case: "perl ls spell ar ar ."
* The argument list is split into files and directories
* File arguments are listed first in multi-column output, followed by each directory argument
* Previously List() was called once per file argument; this was incorrect because List() is unable to format the arguments together in columns
* Fix this by preparing a sorted file list and attribute hash (containing stat() data), then calling List() once
* DirEntries() has to be called once per file, then the stat data returned is merged into a single hash
* Bump version

```
%perl  ls spell ar ar .
ar     ar     spell                                                                                                           

.:
YES.diff        clear           fish            ls.diffe        ppt             spell           unpar
_die.log        cmp             fmt             ls.orig         pr              split           unshar
addbib          col             fold            ls2             prices          strings         uudecode
apply           colrm           fortune         mail            primes          sum             uuencode
ar              comm            from            maze            printenv        tac             wc
arch            cp              glob            mimedecode      printf          tail            what
arithmetic      cut             grep            mkdir           pwd             tar             which
asa             date            hangman         mkfifo          rain            tee             whoami
awk             dc              head            moo             random          test            whois
bad.diffe       deroff          hexdump         morse           rev             test.pl         words
banner          diff            id              morse2          rm              time            wump
base64          dirname         install         names           rmdir           touch           xargs
basename        du              join            nl              rnd.bin         tr              yes
bc              echo            kill            od              robots          true            yes.ORig
bcd             ed              ln              par             rot13           tsort           yes.Orig
cal             env             lock            paste           s.ORig          tty             yes.diff
cat             expand          look            patch           s.Orig          txt1            yes.orig
chgrp           expr            ls              perldoc         s.orig          uname           yes.rej
chgrp.orig      factor          ls.ORIG         perlpowertools  seq             unexpand        yes2
ching           false           ls.ORIg         pig             shar            uniq            
chmod           file            ls.ORig         ping            sleep           units           
chown           find            ls.Orig         pom             sort            unlink          

%ls spell ar ar . # GNU output is equivalent, aside from different column widths
ar  ar  spell

.:
addbib      cat         dc        find     kill      mimedecode      pig       rmdir    sum      uname     words
apply       chgrp       deroff    fish     ln        mkdir           ping      rnd.bin  tac      unexpand  wump
ar          chgrp.orig  _die.log  fmt      lock      mkfifo          pom       robots   tail     uniq      xargs
arch        ching       diff      fold     look      moo             ppt       rot13    tar      units     yes
arithmetic  chmod       dirname   fortune  ls        morse           pr        seq      tee      unlink    yes2
asa         chown       du        from     ls2       morse2          prices    shar     test     unpar     yes.diff
awk         clear       echo      glob     ls.diffe  names           primes    sleep    test.pl  unshar    YES.diff
bad.diffe   cmp         ed        grep     ls.orig   nl              printenv  s.orig   time     uudecode  yes.orig
banner      col         env       hangman  ls.Orig   od              printf    s.Orig   touch    uuencode  yes.Orig
base64      colrm       expand    head     ls.ORig   par             pwd       s.ORig   tr       wc        yes.ORig
basename    comm        expr      hexdump  ls.ORIg   paste           rain      sort     true     what      yes.rej
bc          cp          factor    id       ls.ORIG   patch           random    spell    tsort    which
bcd         cut         false     install  mail      perldoc         rev       split    tty      whoami
cal         date        file      join     maze      perlpowertools  rm        strings  txt1     whois
```
