### PR TITLE
patch: improve validation of ed diffs

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -988,7 +988,14 @@ sub apply {
         shift(@hunk) =~ m!^(\d+)(?:,(\d+))?([acds])!
             or $self->throw('Unable to parse ed script');
 
-        my ($start, $end, $cmd) = ($1, $2 || $1, $3);
+        my ($start, $end, $cmd) = ($1, $2, $3);
+        $end = $start unless defined $end; # 0 can appear
+        if ($start > $end) {
+            $self->throw("Invalid address range: $start,$end\n");
+        }
+        if ($start == 0 && $cmd ne 'a') {
+            $self->throw("Address zero invalid for command: $start,$end$cmd\n");
+        }
 
         # We don't parse substitution commands and assume they all mean
         # s/\.\././ even if they really mean s/\s+// or such.  And we


### PR DESCRIPTION
* Make more of an effort to reject patches where line addresses are not valid
* Reading over the ed command parser in Patch::Ed::apply(), the regex assignment was not always correct
* test1: invalid command "19,0d" was incorrectly interpreted as (valid) "19,19d" thanks to the '||' operator
* test2: "19,18d" command was accepted, but the range is backwards
* test3: "0,19d" command was accepted, but address 0 is not allowed for "d"
* test4: "0,19c" command was accepted, but address 0 is not allowed for "c"
* I tested this by skipping to PLAN_J, using a diff with an update on line1 (ed command 0a is valid and means append after line 0)
* Modifying elements of the diff input, I could trigger the new validation errors

```
%perl diff -e env env2 | perl tee env.diff # original test input
19,20d
5,8c
META DATA
AND MORE
.
0a
#NEW LINE 1!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
.
```