### PR TITLE
chown: avoid getpwnam(undef)

### DIFF
--- a/bin/chown
+++ b/bin/chown
@@ -51,6 +51,10 @@ while (@ARGV && $ARGV [0] =~ /^-/) {
 my $mode = shift;
 usage() unless @ARGV;
 
+if (length($mode) == 0) {
+    warn "$Program: invalid user: ''\n";
+    exit EX_FAILURE;
+}
 my ($owner, $group) = split /:/ => $mode, 2;
 
 my $uid = getpwnam $owner;


### PR DESCRIPTION
* If the 1st argument (user) of chown is an empty string, splitting the string results in an empty list
* Terminate the program before calling getpwnam()

```
%perl -Mwarnings -Mdiagnostics chown '' file # before patch
Use of uninitialized value $owner in getpwnam at chown line 56 (#1)
    (W uninitialized) An undefined value was used as if it were already
    defined.  It was interpreted as a "" or a 0, but maybe it was a mistake.
    To suppress this warning assign a defined value to your variables.
    
    To help you figure out what was undefined, perl will try to tell you
    the name of the variable (if any) that was undefined.  In some cases
    it cannot do this, so it also tells you what operation you used the
    undefined value in.  Note, however, that perl optimizes your program
    and the operation displayed in the warning may not necessarily appear
    literally in your program.  For example, "that $foo" is usually
    optimized into "that " . $foo, and the warning will refer to the
    concatenation (.) operator, even though there is no . in
    your program.
    
Use of uninitialized value $owner in pattern match (m//) at chown line 58 (#1)
Use of uninitialized value $owner in concatenation (.) or string at chown line
	61 (#1)
chown: invalid user: ''
```
