### PR TITLE
random: small tidy

### DIFF
--- a/bin/random
+++ b/bin/random
@@ -17,7 +17,6 @@ use Getopt::Std;
 
 my ($VERSION) = '1.3';
 
-my $warnings = 0;
 my %options;
 getopts('er', \%options) or usage();
 my $denominator = shift;
@@ -32,8 +31,7 @@ $| = 1 if exists $options {r};
 my $frac = 1 / $denominator;
 
 while (<>) {print if $frac >= rand;}
-
-exit $warnings;
+exit 0;
 
 sub usage {
     warn "usage: $0 [-er] [denominator]\n";


### PR DESCRIPTION
Variable $warnings does not vary so delete it.

```
%# regress1
%printf "a\nb\nc\n" | perl random 2
a
%# regress2 (exit code of zero is correct)
%for i in `perl seq 50`; do perl random -e 100; echo -n "$? "; done; echo;
74 47 57 8 58 80 23 86 60 68 89 60 8 5 51 31 39 99 66 89 9 67 96 30 48 78 48 20 39 18 96 92 12 92 3 75 38 19 57 55 0 49 25 82 43 64 56 87 25 96 
```