### PR TITLE
cmp: 0X and 0x are valid hex prefix

### DIFF
--- a/bin/cmp
+++ b/bin/cmp
@@ -219,7 +219,7 @@ exit $saw_difference;
 
 sub skipnum {
     my $n = shift;
-    return hex($n) if ($n =~ m/\A0x/);
+    return hex($n) if ($n =~ m/\A0[Xx]/);
     return int($n) if ($n =~ m/\A[0-9]+\z/);
     warn "$Program: invalid offset number '$n'\n";
     usage();
@@ -261,7 +261,7 @@ I<skip1> and I<skip2> are optional byte offsets into I<file1> and
 I<file2>, respectively, that determine where the file comparison
 will begin.  Offsets may be given in decimal, octal, or hexadecimal
 form.  Indicate octal notation with a leading '0', and hexadecimal
-notation with a leading '0x'.
+notation with a leading '0x' or '0X'.
 
 file1 or file2 may be given as '-', which reads from standard input.
 


### PR DESCRIPTION
* Skip numbers (optional arguments 3 & 4) can be specified in decimal or hex
* When testing on OpenBSD and Linux, "0X" hex prefix is supported, so add it to this version too
* I didn't test on NetBSD, but the NetBSD version calls the C strotoll() function, which is documented to accept "0X" [1] [2]
* Tweak POD manual

1. https://cvsweb.netbsd.org/bsdweb.cgi/src/usr.bin/cmp/cmp.c?annotate=1.21  line128
2. https://man.netbsd.org/strtoll.3

```
%ifconfig > F1
%cp F1 F2
%perl cmp F1 F2
%perl cmp F1 F2 0x1 0X1 # same skip, different prefix, same day
%perl cmp F1 F2 0x1 0X2
F1 F2 differ: char 1, line 1
```