### PR TITLE
cmp: restore octal skip values

### DIFF
--- a/bin/cmp
+++ b/bin/cmp
@@ -220,6 +220,7 @@ exit $saw_difference;
 sub skipnum {
     my $n = shift;
     return hex($n) if ($n =~ m/\A0[Xx]/);
+    return oct($n) if ($n =~ m/\A0o?/);
     return int($n) if ($n =~ m/\A[0-9]+\z/);
     warn "$Program: invalid offset number '$n'\n";
     usage();
@@ -259,9 +260,9 @@ in the shorter of the two file.
 
 I<skip1> and I<skip2> are optional byte offsets into I<file1> and
 I<file2>, respectively, that determine where the file comparison
-will begin.  Offsets may be given in decimal, octal, or hexadecimal
-form.  Indicate octal notation with a leading '0', and hexadecimal
-notation with a leading '0x' or '0X'.
+will begin.  The offsets value is decimal by default.
+An octal value can be entered with a leading '0' or '0o'.
+A hexadecimal value can be entered with a leading '0x' or '0X'.
 
 file1 or file2 may be given as '-', which reads from standard input.
 


### PR DESCRIPTION
* The POD manual stated that octal values were supported for options skip1 and skip2, but it didn't work
* Previously cmp used eval() to convert user input into a number; I suspect the octal support was broken when the eval() code was removed
* Octal is supported by NetBSD's cmp

```
%cp ar ar2
%strace perl cmp ar ar2 0X4f 0117 2> trace
%fgrep '79,' trace
lseek(4, 79, SEEK_SET)                  = 79
lseek(5, 79, SEEK_SET)                  = 79
```