### PR TITLE
ls: runtime error for non-existent file argument

### DIFF
--- a/bin/ls
+++ b/bin/ls
@@ -522,9 +522,10 @@ if ($#ARGV < 0) {
 		my %attrs;
 		foreach (@Files) {
 			my @ret = DirEntries(\%Options, $_);
+			next unless @ret; # stat() failed
 			%attrs = (%attrs, %{ $ret[-1] });
 		}
-		my @sorted = Order(\%Options, \%Attributes, @Files);
+		my @sorted = Order(\%Options, \%Attributes, keys %attrs);
 		List('.', \%Options, 0, 0, @sorted, \%attrs);
 	}
 	for my $Arg (@Dirs) {

--- a/bin/ls
+++ b/bin/ls
@@ -520,12 +520,14 @@ if ($#ARGV < 0) {
 	if (@Files) {
 		$First = 0;
 		my %attrs;
+		my @okfiles;
 		foreach (@Files) {
 			my @ret = DirEntries(\%Options, $_);
 			next unless @ret; # stat() failed
 			%attrs = (%attrs, %{ $ret[-1] });
+			push @okfiles, $_;
 		}
-		my @sorted = Order(\%Options, \%Attributes, keys %attrs);
+		my @sorted = Order(\%Options, \%Attributes, @okfiles);
 		List('.', \%Options, 0, 0, @sorted, \%attrs);
 	}
 	for my $Arg (@Dirs) {


### PR DESCRIPTION
* When testing ls today I discovered the error: Can't use an undefined value as a HASH reference at ls line 525.
* Test case: ```perl ls xxx ar a.x pig```  ...where files xxx and a.x don't exist
* I broke this in the previous commit around where DirEntries() is called for ```@Files``` list
* Add the correct return value guard
* DirEntries() prints a warning and returns an empty list if stat() fails on its file argument
* Avoid listing filenames where stat() failed by storing good arguments in ```@okfiles``` list

```
%perl ls  xxx ar a.x pig # with change applied
ls: can't access 'xxx': No such file or directory
ls: can't access 'a.x': No such file or directory
ar   pig
```
