### PR TITLE
chgrp: fail early for empty string

### DIFF
--- a/bin/chgrp
+++ b/bin/chgrp
@@ -11,8 +11,6 @@ License: perl
 
 =cut
 
-
-
 use strict;
 
 use File::Basename qw(basename);
@@ -53,6 +51,10 @@ usage() unless @ARGV > 1;
 
 my $group = shift;
 
+if (length($group) == 0) {
+    warn "$Program: '' is an invalid group\n";
+    exit EX_FAILURE;
+}
 my $gid = getgrnam $group;
 unless (defined $gid) {
     $gid = $group if $group =~ m/\A[0-9]+\z/;
@@ -65,8 +67,6 @@ unless (defined $gid) {
 my %ARGV;
 %ARGV = map {$_ => 1} @ARGV if $options {H};
 
-sub modify_file;
-
 if (exists $options {R}) {
     # Recursion.
     require File::Find;
@@ -74,9 +74,10 @@ if (exists $options {R}) {
 }
 else {
     foreach my $file (@ARGV) {
-        modify_file $file;
+        modify_file($file);
     }
 }
+exit ($warnings ? EX_FAILURE : EX_SUCCESS);
 
 # File::Find is weird. If called with a directory, it will call
 # the sub with "." as file name, while having chdir()ed to the
@@ -110,8 +111,6 @@ sub modify_file {
 	$warnings++;
     }
 }
-
-exit ($warnings ? EX_FAILURE : EX_SUCCESS);
 
 __END__
 


### PR DESCRIPTION
* Similar to commit 471e64b3e0ec3a1fd9c85ecec085d97fabe47417 for bin/chown
* Fail early if the 1st (group) argument is an empty string to avoid unnecessary getgrnam('') call
* style: forward declaration of modify_file() is not needed if the method is called with parens
* style: move default exit() statement above the subroutine declarations, as done in other scripts