### PR TITLE
tar: fail early for bad options

### DIFF
--- a/bin/tar
+++ b/bin/tar
@@ -13,6 +13,7 @@ License:
 
 use strict;
 
+use Compress::Zlib qw(gzopen);
 use File::Basename qw(basename);
 use Getopt::Std;
 use IO::File;
@@ -20,27 +21,13 @@ use IO::File;
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
-use vars qw($opt);
-
 my $Program = basename($0);
 
-BEGIN
- {
-  $opt = 'ctxvmf:';
-  eval { require Compress::Zlib };
-  if ($@)
-   {
-    warn "No decompression available: $@\n";
-   }
-  else
-   {
-    Compress::Zlib->import;
-    $opt .= 'zZ';
-   }
- }
-
 my %opt;
-getopts($opt,\%opt);
+getopts('ctxvmf:Zz', \%opt) or do {
+  warn "usage: tar {-tx} [-mvZz] [-f archive] [file ...]\n";
+  exit EX_FAILURE;
+};
 
 sub fatal
 {

--- a/bin/tar
+++ b/bin/tar
@@ -13,7 +13,6 @@ License:
 
 use strict;
 
-use Compress::Zlib qw(gzopen);
 use File::Basename qw(basename);
 use Getopt::Std;
 use IO::File;
@@ -212,7 +211,8 @@ else
 
   if ($opt{'z'} || $opt{'Z'})
    {
-    # quick and dirty till we sort out Compress::Zlib
+    eval { require Compress::Zlib } or fatal('Compress::Zlib not found');
+    Compress::Zlib->import;
     my $gz = gzopen($fh, 'rb') or fatal("Cannot gzopen: $Compress::Zlib::gzerrno");
     $read = sub { $gz->gzread($_[0],$_[1]) < 0 ? $Compress::Zlib::gzerrno : 0 };
    }


### PR DESCRIPTION
* Add missing getopts() return value check
* This version of tar didn't have a usage string, so add one
* Don't list -c in usage string for now because archive creation isn't implemented
* Unconditionally use Compress::Zlib because it is a core library

```
%perl tar -x -f yo -L
Unknown option: L
usage: tar {-tx} [-mvZz] [-f archive] [file ...]
```