### PR TITLE
patch: crash for invalid context diff input

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -159,6 +159,11 @@ while (<PATCH>) {
         my ($i_range, $i_start, $i_end, @i_hunk) = ($1, $2, $3 || $2);
         my ($o_range, $o_start, $o_end, @o_hunk);
         $patch->bless('context') or next PATCH;
+        if ($i_start > $i_end) {
+            $patch->note("Malformed input at line $.: $i_range\n");
+            $patch->reject($i_range);
+            last;
+        }
         my $o_hunk = qr/^$space(--- (\d+)(?:,(\d+))? ----\n)/;
         my $re = qr/^$space([ !-] )/;
         $_ = <PATCH>;


### PR DESCRIPTION
* I generated a Context diff with 2 hunks
* I manually swapped the 2 numbers at the top of hunk1, from "1,4" to "4,1" (the line number range for the hunk)
* GNU patch correctly rejected the invalid diff, but this version crashed with an ARRAY error
* Add validation to reject a backwards range (based on code previously added for Normal diffs)

```
%cat diff.ctx 
*** id	Wed Mar  5 09:16:33 2025
--- id2	Wed Mar  5 09:14:36 2025
***************
*** 4,1 ****
- #!/usr/bin/perl
  
  =begin metadata
  
--- 1,3 ----
***************
*** 12,24 ****
  =cut
  
  
- #
- # An implementation of the 'id' utility in Perl.  Written for the Perl Power
- # Tools (PPT) project by Theo Van Dinter (felicity@kluge.net).
- #
- # $Id: id,v 1.2 2004/08/05 14:17:43 cwest Exp $
- # - 
  use strict;
  
  use File::Basename qw(basename); --- 11,16 ----
%perl -Mwarnings -Mdiagnostics  patch -c id diff.ctx
Hmm...  Looks like a context diff to me...
Patching file id using Plan A...
Short hunk ignored...no second line range.
1 out of 1 hunks ignored--saving rejects to id.rej

Can't use an undefined value as an ARRAY reference at patch line 382, <$in_fh>
	line 249 (#1)
    (F) A value used as either a hard reference or a symbolic reference must
    be a defined value.  This helps to delurk some insidious errors.
    
Uncaught exception from user code:
	Can't use an undefined value as an ARRAY reference at patch line 382, <$in_fh> line 249.
	Patch::bless(Patch::Context=HASH(0x55908a4f50)) called at patch line 161
```