### PR TITLE
install: -m MODE validation

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -54,6 +54,10 @@ if ($opt{d} and grep($_, @opt{qw/ C c D p /}) > 0) {
     warn "$Program: -d not allowed with -[CcDp]\n";
     usage();
 }
+if (defined $opt{'m'} && length($opt{'m'}) == 0) {
+    warn "$Program: invalid file mode: ''\n";
+    exit 1;
+}
 
 $opt{C}++ if $opt{p};
 $Debug = 1 if $opt{D};


### PR DESCRIPTION
* Passing an empty string as a mode was being accepted and interpreted as -m0
* Empty string is not a valid mode specifier so catch it early
* I found this when testing against GNU and OpenBSD versions