### PR TITLE
tac: don't print version number in usage string

### DIFF
--- a/bin/tac
+++ b/bin/tac
@@ -60,8 +60,12 @@ print while <$fh>;
 exit EX_FAILURE if $fh->get_error;
 exit EX_SUCCESS;
 
-sub usage {
+sub VERSION_MESSAGE {
     warn "$Program version $VERSION\n";
+    exit 0;
+}
+
+sub usage {
     warn "usage: $Program [-Bbr] [-s separator] [-S bytes] [file...]\n";
     exit EX_FAILURE;
 }

--- a/bin/tac
+++ b/bin/tac
@@ -62,7 +62,7 @@ exit EX_SUCCESS;
 
 sub VERSION_MESSAGE {
     warn "$Program version $VERSION\n";
-    exit 0;
+    exit EX_SUCCESS;
 }
 
 sub usage {
@@ -364,9 +364,6 @@ sub CLOSE {
 sub DESTROY {
     shift->CLOSE;
 }
-
-# *readline = \&READLINE;
-# *close    = \&CLOSE;
 
 sub eof {
     my $self = shift;


### PR DESCRIPTION
* If I type a bad option I want to see the correct options, not the program version
* As done in other scripts using getopts(), support --version option by adding a VERSION_MESSAGE() function