### PR TITLE
chmod: show which option is wrong

### DIFF
--- a/bin/chmod
+++ b/bin/chmod
@@ -30,12 +30,12 @@ while (@ARGV && $ARGV [0] =~ /^-/) {
     my $opt = reverse shift;
     chop $opt;
     last if ($opt eq '-');
-    unless ($opt =~ /^[RHLP]+$/) {
-        warn "$Program: invalid option -- $opt\n";
-        usage();
-    }
     local $_;
     while (length ($_ = chop $opt)) {
+        unless (m/\A[RHLP]\Z/) {
+            warn "$Program: invalid option -- '$_'\n";
+            usage();
+        }
         /R/ && do {$options {R} = 1; next};
         usage() unless $options{'R'};
         /H/ && do {$options {L} = $options {P} = 0; $options {H} = 1; next};


### PR DESCRIPTION
* The supported options are -R/-L/-H/-P, and grouping of options is allowed (e.g. -LP)
* When adding an unexpected option letter to a group, the error message was misleading
*  ```perl chmod -Rp``` reported "invalid option -- pR", but R is a valid option
* Fix this by validation the option letters after the option string has been split into a single letters

```
%perl chmod -Rp 0 0 0 0 0 0 0 0 0 0
chmod: invalid option -- 'p'
usage: chmod [-R [-H | -L | -P]] mode file...
```
