### PR TITLE
mail: invalid message number accepted

### DIFF
--- a/bin/mail
+++ b/bin/mail
@@ -473,6 +473,8 @@ sub messagex {
 	my $self=shift;
 	my $num=shift;
 	return if $num <= 0;
+	my $size = @{ $self->{'messages'} };
+	return if $num >= $size;
 	return(${$self->{messages}}[$num]);
 }
 sub replace {
@@ -640,7 +642,7 @@ use Getopt::Std;
 
 use vars qw($opt_f $opt_s $opt_c $opt_b $opt_v);
 
-our $VERSION = '0.05';
+our $VERSION = '0.06';
 our $ROWS = 23;         # Screen Dimensions.  Yeah, this sucks.
 our $COLS = 80;
 our $BUFFERL = 2;	  # Lines needed for "fluff"


### PR DESCRIPTION
* I exported a mailbox with 24 items in mbox format
* The maximum valid message id is 24, but a very long number is interpreted as 24
* Another long message id is rejected, so this made me scratch my head
* perl debugger shows that the invalid message number errors for 0, 25 and 1111111111 are from L842 in main::msg_print()
* mailbox::messagex() takes the very long message id and returns a valid message instead of undef
* mailbox::messagex() has a guard for negative array index, but does not guard against index past end of array
* Adding an index guard fixes the problem on my system
* This was found when testing against the OpenBSD version

```
%perl mail -f mbox0.txt 
Loading the mailfile mbox0.txt
    1    MAILER-DAEMON  Wed Feb 05 11:12   0/5310 Re: patch-2.7.6.200-be8b on H
    2    MAILER-DAEMON  Wed Feb 05 11:57   0/11377 Re: patch-2.7.6.200-be8b on 
    3    MAILER-DAEMON  Wed Feb 05 12:48   0/3791 [PATCH] Fix dodgy assert with
    4    MAILER-DAEMON  Wed Feb 05 15:15   0/7348 Re: patch-2.7.6.200-be8b on H
    5    MAILER-DAEMON  Wed Feb 05 15:49   0/8718 Re: patch-2.7.6.200-be8b on H
    6    MAILER-DAEMON  Wed Feb 05 16:06   0/6183 Re: patch-2.7.6.200-be8b on H
    7    MAILER-DAEMON  Wed Feb 05 16:17   0/5189 Re: patch-2.7.6.200-be8b on H
    8    MAILER-DAEMON  Wed Feb 05 16:21   0/7398 Re: patch-2.7.6.200-be8b on H
    9    MAILER-DAEMON  Wed Feb 05 16:32   0/9946 Re: patch-2.7.6.200-be8b on H
   10    MAILER-DAEMON  Thu Feb 06 15:10   0/4970 Re: patch-2.7.6.200-be8b on H
   11    MAILER-DAEMON  Thu Feb 06 15:19   0/5363 Re: [PATCH] Fix dodgy assert 
   12    MAILER-DAEMON  Thu Feb 06 16:22   0/15234 Re: new snapshot available: 
   13    MAILER-DAEMON  Thu Feb 06 18:59   0/6656 Re: new snapshot available: p
   14    MAILER-DAEMON  Thu Feb 06 19:44   0/5116 Re: new snapshot available: p
   15    MAILER-DAEMON  Sun Feb 16 06:43   0/4674 --no-backup-if-mismatch regre
   16    MAILER-DAEMON  Sun Feb 16 06:48   0/2742 Patch 2.7.6 and deep-director
   17    MAILER-DAEMON  Sun Feb 16 07:30   0/2823 Re: Patch 2.7.6 and deep-dire
   18    MAILER-DAEMON  Sun Feb 16 08:53   0/4171 [PATCH] Regression in commit 
   19    MAILER-DAEMON  Tue Feb 18 05:01   0/5470 Re: patch-2.7.6.200-be8b on H
   20    MAILER-DAEMON  Mon Feb 24 21:05   0/21019 patch -e with dubious ed dif
   21    MAILER-DAEMON  Wed Feb 26 19:56   0/9338 Re: [PATCH] Regression in com
   22    MAILER-DAEMON  Wed Feb 26 19:58   0/12389 Re: --no-backup-if-mismatch

> 0
Invalid message number: 0
> 25
Invalid message number: 25
> 1111111111
Invalid message number: 1111111111
> 1111111111111111111111111111111111111111
Message: 24
<SNIP>
```
