### PR TITLE
strings: broken -n NUM validation

### DIFF
--- a/bin/strings
+++ b/bin/strings
@@ -72,7 +72,7 @@ sub usage {
 
 getopts( 'afon:t:' ) or usage();
 if (defined $opt_n) {
-    if ($opt_n !~ m/\A[0-9]\Z/ || $opt_n == 0) {
+    if ($opt_n !~ m/\A[0-9]+\Z/ || $opt_n == 0) {
         warn "$Program: invalid minimum string length '$opt_n'\n";
         exit EX_FAILURE;
     }


### PR DESCRIPTION
The number passed to -n can be more than one digit.
```
%/usr/bin/strings -n150 /bin/bash | md5sum && perl strings -n150 /bin/bash | md5sum 18cf22fcd75586ea1c6e5411c338c11d  -
18cf22fcd75586ea1c6e5411c338c11d  -
```