### PR TITLE
ed: initial edEdit() errors were lost

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -100,7 +100,7 @@ my $UndoLine;
 my $PRINT_NUM = 1;
 my $PRINT_BIN = 2;
 
-our $VERSION = '0.29';
+our $VERSION = '0.30';
 
 my @ESC = (
     '\\000', '\\001', '\\002', '\\003', '\\004', '\\005', '\\006', '\\a',
@@ -217,8 +217,20 @@ $args[0] = shift;
 $args[0] = undef if (defined($args[0]) && $args[0] eq '-');
 Usage() if @ARGV;
 $Scripted = $opt{'s'};
-edEdit(0);
+init_edit();
 input() while 1;
+
+sub init_edit {
+    my $err = edEdit(0);
+    if ($err) {
+        if ($err eq E_OPEN) { # silence warning
+            $Error = $err;
+        } else {
+            edWarn($err);
+        }
+    }
+    return;
+}
 
 sub input {
     $command = $commandsuf = '';


### PR DESCRIPTION
* When the editor starts there is an implicit call to edEdit(), which will either load a named file or start the editor with an empty buffer
* edEdit() is also the handler for the commands E and e
* Starting ed with an empty string file argument is not valid
* Starting ed with a filename ending in '/' is not valid
* edEdit() returns an error string; write a little function to handle the error
* Special case: when starting ed with a non-existent file, a print a warning but not the '?' prompt (this is not a serious error for initial edEdit() because there is no editor buffer yet)

```
%perl ed -p 'ED>' ''
?
ED>h
invalid filename
ED>q
%
%perl ed -p 'ED>' newfile.cxx
newfile.cxx: No such file or directory
ED>h
cannot open file
ED>q
```