### PR TITLE
date: too much whitespace for %e format

### DIFF
--- a/bin/date
+++ b/bin/date
@@ -103,7 +103,7 @@ sub select_format {
 
 sub setup_specifiers {
 	my %specifiers = (
-		'e'  => sprintf( '% 2d', (core_time)[3] ),
+		'e'  => sprintf( '%2d', (core_time)[3] ),
 		'P'  => lc(POSIX::strftime('%p', core_time())),
 		'q'  => quarter(),
 		'T'  => sprintf( '%02d:%02d:%02d', (core_time)[2,1,0] ),


### PR DESCRIPTION
* I was tracking why the Perl date command separated Mar and 14 with 2 spaces instead of one
* The default strftime() format string is "%a %b %e %T %Z %Y"
* The Linux manual for strftime() says %e is the same as %d, except that a leading zero is replaced with a leading space
* So day 1 would be "01" and " 1", but day 10 would have no leading space or zero
* Formatting the day number with "%2d" is good enough for %e specifier; previously day 14 was formatted as " 14" in setup_specifiers()

```
%perl date # with patch
Fri Mar 14 09:11:30 AWST 2025
%date # GNU
Fri Mar 14 09:11:31 AM AWST 2025
```