### PR TITLE
cal: correct current month value

### DIFF
--- a/bin/cal
+++ b/bin/cal
@@ -28,7 +28,7 @@ $cal::num_args = scalar( @ARGV );
 if( $cal::num_args == 0 ) {
 	my @tm = localtime(time);
 	$cal::year = $tm[5] + 1900;
-	$cal::month = $tm[4] unless $opts{'y'};
+	$cal::month = $tm[4] + 1 unless $opts{'y'};
 } elsif( $cal::num_args == 1 ) {
 	$cal::year = &get_year( $ARGV[ 0 ] );
 } elsif( $cal::num_args == 2 ) {


### PR DESCRIPTION
* When running cal with no arguments the month number is determined from localtime(), which returns 0 for Jan
* Function fmt_month() needs 1 for Jan, so adjust the value passed in
* Patch tested against /usr/bin/cal on ubuntu (from package bsdmainutils)
* test1: ```perl cal 0 2025``` ---> invalid month
* test2: ```perl cal``` ---> now shows current month (5)
* test3: ```perl cal 5 2025```  ---> same output as test2