### PR TITLE
du: correct logic for -s option

### DIFF
--- a/bin/du
+++ b/bin/du
@@ -103,6 +103,7 @@ sub traverse {
   } else {
     warn "$0: could not read directory $fn: $!\n";
     $rc = EX_FAILURE;
+    return 0;
   }
   print "$total\t$fn\n" if $opt_s && $depth == 1;
   return $total;


### PR DESCRIPTION
* The function traverse() takes a directory name param and first does stat() or lstat() depending on other command options
* If stat() fails an error is printed, final exit code is set to 1 and the function returns early to avoid printing a total
* The same error logic should happen for later opendir() failure, otherwise an unhelpful total will be printed after the error message if the -s option is used
* I verified this by forcing opendir to fail