### PR TITLE
env: empty string is invalid argument for -u

### DIFF
--- a/bin/env
+++ b/bin/env
@@ -29,7 +29,7 @@ while ( @ARGV && $ARGV[0] =~ /^-/ ) {
 		%ENV = ();
 	} elsif ( $arg =~ /^-u(.*)/ ) {
 		my $val = length $1 ? $1 : shift;
-		if ($val =~ m/=/) {
+		if (length($val) == 0 || $val =~ m/=/) {
 			warn "$Program: bad unset argument: '$val'\n";
 			exit 2;
 		}


### PR DESCRIPTION
* Standard env utility doesn't have -u for unsetting, but GNU has it [1]
* GNU env raises an error if empty string was passed to -u, so do that here too
* test1: `perl env -u'' ls` ---> attempts to unset variable "ls" then prints environment; not an error
* test2: `perl env -u '' ls` ---> this will fail now

1. https://pubs.opengroup.org/onlinepubs/9799919799/utilities/env.html