### PR TITLE
uniq: avoid double negative in POD

### DIFF
--- a/bin/uniq
+++ b/bin/uniq
@@ -151,7 +151,7 @@ line occurred in the input, followed by a single space.
 
 =item -d
 
-Don't output lines that are not repeated in the input.
+Print only duplicate lines from the input.
 
 =item -f I<fields>
 


### PR DESCRIPTION
* The existing text is confusing
* Follow the GNU manual and use "duplicate lines" because "duplicate" is how I remember what `uniq -d` does