### PR TITLE
head: correct error message for -n

### DIFF
--- a/bin/head
+++ b/bin/head
@@ -32,7 +32,7 @@ unless (getopts('n:', \%opt)) {
 my $count;
 if (defined $opt{'n'}) {
     $count = $opt{'n'};
-    if ($count =~ m/[^0-9]/) {
+    if (length($count) == 0 || $count =~ m/[^0-9]/) {
         warn "$Program: invalid number '$count'\n";
         exit EX_FAILURE;
     }


### PR DESCRIPTION
* If the argument to -n is an empty string, display the "invalid number" error
* Previously comparison with zero resulted in a "too small" error
* Found when testing against GNU version