### PR TITLE
ls: my_warn() omitted newline

### DIFF
--- a/bin/ls
+++ b/bin/ls
@@ -405,7 +405,7 @@ sub my_warn {
 	my( $class, $message, $prepend ) = @_;
 	$prepend = 1 unless defined $prepend;
 	$message = PROGRAM . ": " . $message if $prepend;
-	$message .= "\n";
+	$message =~ s/\n*\z/\n/;
 	print { $class->warn_fh } $message;
 	}
 


### PR DESCRIPTION
* When providing multiple non-existent file arguments to ls, the warnings for each file were all printed on one line
* Message strings passed to my_warn() don't include a newline terminator, so terminate the line within my_warn()
* Bump version & remove unused Data::Dumper import

```
%perl ls a b c 
ls: can't access 'a': No such file or directoryls: can't access 'b': No such file or directoryls: can't access 'c': No such file or directory
```