### PR TITLE
patch: fix reversed patch check

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -24,7 +24,7 @@ use constant EX_SUCCESS => 0;
 use constant EX_REJECTS => 1;
 use constant EX_FAILURE => 2;
 
-my $VERSION = '0.35';
+my $VERSION = '0.36';
 
 $|++;
 
@@ -763,6 +763,13 @@ sub apply {
                     }
                 } else {
                     $self->throw('SKIP...ignore this patch') if $self->{forward};
+                }
+            } else {
+                unless ($position || $self->{reverse} || $self->{force}) {
+                    $self->{reverse_check} = 1;
+                    $self->{reverse} = 1;
+                    shift;
+                    return $self->apply(@_);
                 }
             }
         }


### PR DESCRIPTION
When applying the same patch twice I noticed there was no message about a reversed patch being detected. Then when I looked at the code, flag reverse_check was never being set. Restore the missing else-block from an older commit which sets reverse_check. It was likely deleted by mistake.

```
%git diff yes
%perl patch yes yes.diff
Hmm...  Looks like a unified diff to me...
Patching file yes using Plan A...
Hunk #1 succeeded at 13.
done
%perl patch yes yes.diff
Hmm...  Looks like a unified diff to me...
Patching file yes using Plan A...
Reversed (or previously applied) patch detected!  Assume -R? [y] y
Hunk #1 succeeded at 13.
done
```