### PR TITLE
patch: explicit eof check

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -867,6 +867,10 @@ sub index {
             my $fail;
             for (1..$#$match) {
                 my $line = <$in>;
+                unless (defined $line) {
+                    $fail++;
+                    last;
+                }
                 $line =~ s/\s+/ /g if $self->{'ignore-whitespace'};
                 $line eq $match->[$_] or $fail++, last;
             }


### PR DESCRIPTION
When patching a file that has already been patched, the line loop contains a nested "readline" which needs to terminate the inner loop if EOF is detected. This is in a new commit so the last commit was more obvious that it was only restoring old code.
```
%perl patch yes yes.diff 
Hmm...  Looks like a unified diff to me...
Patching file yes using Plan A...
Use of uninitialized value $line in string eq at patch line 873, <$in_fh> line
	111 (#1)
    (W uninitialized) An undefined value was used as if it were already
    defined.  It was interpreted as a "" or a 0, but maybe it was a mistake.
    To suppress this warning assign a defined value to your variables.
    
    To help you figure out what was undefined, perl will try to tell you
    the name of the variable (if any) that was undefined.  In some cases
    it cannot do this, so it also tells you what operation you used the
    undefined value in.  Note, however, that perl optimizes your program
    and the operation displayed in the warning may not necessarily appear
    literally in your program.  For example, "that $foo" is usually
    optimized into "that " . $foo, and the warning will refer to the
    concatenation (.) operator, even though there is no . in
    your program.
    
Use of uninitialized value $line in string eq at patch line 873, <$in_fh> line
	283 (#1)
Reversed (or previously applied) patch detected!  Assume -R? [y] ^C
```