### PR TITLE
grep: correct Pod that says -f supersedes -e

### DIFF
--- a/bin/grep
+++ b/bin/grep
@@ -599,8 +599,6 @@ Treat I<pattern> as a pattern.  This option is most useful when
 I<pattern> starts with a C<-> and the user wants to avoid confusing
 the option parser.
 
-The B<-f> option supercedes the B<-e> option.
-
 =item B<-F>
 
 B<fgrep> mode.  Disable regular expressions and perform Boyer-Moore
@@ -611,8 +609,6 @@ issue).
 
 Treat I<pattern-file> as a newline-separated list of patterns to use
 as search criteria.
-
-the B<-f> option supercedes the B<-e> option.
 
 =item B<-g>
 


### PR DESCRIPTION
In the past the grep options -e and -f possibly could not be combined but now they can. Remove incorrect POD explanation about one option superseding the other. I only noticed this because aspell flagged "supercedes" as a spelling error.

```
%echo perl > patterns.txt
%perl grep -e pod -f patterns.txt cat
#!/usr/bin/perl
Author: Abigail, perlpowertools@abigail.be
License: perl
=pod
The Perl implementation of I<cat> was written by Abigail, I<perlpowertools@abigail.be>.
```