### PR TITLE
spell: suffix() is not needed for batch mode

### DIFF
--- a/bin/spell
+++ b/bin/spell
@@ -22,6 +22,8 @@ use constant EX_FAILURE => 1;
 
 use constant DICT_FILE => '/usr/dict/words';
 
+my $VERSION = '1.0';
+
 my $Program = basename($0);
 
 my (
@@ -105,17 +107,20 @@ unless ( $inter ) {
 
 exit EX_SUCCESS;  # end of main program, below are subroutines.
 
+sub VERSION_MESSAGE {
+    print "$Program version $VERSION\n";
+    exit EX_SUCCESS;
+}
+
 sub check_words {
 
   my @check = sort grep { !exists($words{$_}) } @_ ;
   my @suffs;
-  my $temp;
 
-  for my $orig ( @check ) {
-    $temp = suffix($orig);
-    if ($temp) {
-      push @suffs, $temp;
-      undef $orig;
+  if ($suff) {
+    for my $orig ( @check ) {
+      my $temp = suffix($orig);
+      push @suffs, $temp if $temp;
     }
   }
 


### PR DESCRIPTION
* The output for verbose mode (-v flag) contains Found, Not Found and Close Matches sections
* Close Matches are generated by the suffix() function
* Default (non-v) mode does not show Close Matches, but suffix() was being called anyway; add missing condition to avoid this
* Also give this script a $VERSION for consistency with other scripts
* I tested this with a dictionary file containing ace but not ace's
```
%perl  spell -d wordlist.txt -i
Word(s): ace's
Found: 

Not Found:

   ace's.
Word(s): 
%perl  spell -v -d wordlist.txt -i
Word(s): ace's
Found: 

Close Matches:
  "ace's" = "ace"  +  "'s"


Not Found:

   ace's.
Word(s): 
```