### PR TITLE
tail incorrectly reads stdin for single directory arg

### DIFF
--- a/bin/tail
+++ b/bin/tail
@@ -396,25 +396,27 @@ sub handle_args
     my @files;
     my @dirs;
 
-    for my $f (@$files_) {
-        if (-d $f) {
-            if ($opt_f) {
+    if ($opt_f) {
+        for my $f (@$files_) {
+            if (-d $f) {
                 push @dirs, $f;
             } else {
-                warn "$me: '$f' is a directory\n";
-                $rc = EX_FAILURE;
+                push @files, $f;
             }
-        } else {
-            push @files, $f;
         }
+    } else {
+        @files = @$files_;
     }
 
     if(scalar @files >= 1 or scalar @dirs >= 1) {
     my $i = 0;
 
-    # Ignore the directories
     for my $file (@files) {
-
+        if (!$opt_f && -d $file) {
+            warn "$me: '$file' is a directory\n";
+            $rc = EX_FAILURE;
+            next;
+        }
         # do not die if the file does not exist, when -f is used
         next if(!-e $file and ($opt_f or $me eq "xtail"));
 


### PR DESCRIPTION
Hello,

Happy new year. Recently I've been helping to upgrade and test the perl port on the Sortix OS. The Sortix maintainer was stuck with an issue upgrading perl past v5.30 but that has now been resolved. Sortix/perl is still kind of broken because of some missing floating point formatting code in libc. That will be resolved soon. To me, the main improvement after that would be supporting dynamic linking. Currently perl is built statically. When that is fixed, CPAN modules can be built quickly without needing to rebuild a whole new static-perl.

When debugging this issue I used `perl -d` on Sortix and used the trace facility `t` to show that it was reaching `print_tail(\*STDIN, ...)`. I also tested the patch on Linux.

* The old code to exit(1) for directory arguments was incorrect
* If the -f flag is provided, arguments are split into file and directory lists; this should not happen for regular operation
* Previously the logic for not-f displayed a warning for directory args, but if there were zero non-directory args it would cause incorrect behaviour because the files-list would be empty

```
linux$ perl tail x . . . ls
tail: 'x' is a directory
tail: '.' is a directory
tail: '.' is a directory
tail: '.' is a directory
==> ls <==

=head1 COPYRIGHT and LICENSE

This program is free and open software. You may use, modify,
distribute, and sell this program (and any modified variants) in any
way you wish, provided you do not restrict others from doing the same.

=cut



linux$ echo $?
1
```