### PR TITLE
addbib: use literal EOF line to end abstract input

### DIFF
--- a/bin/addbib
+++ b/bin/addbib
@@ -58,7 +58,8 @@ my $inst = <<_EOINST;
 	If you have to continue a field or add an unusual field,
 		a trailing backslash will allow a temporary escape.
 	Finally, (without -a) you will be prompted for an abstract.
-	Type in as many lines as you need, and end with a ctrl-d.
+	Type in as many lines as you need. Input is terminated when
+                a line containing only EOF is entered.
 	To quit, type `q' or `n' when asked if you want to continue.
 	To edit the database, type `edit', `vi', or `ex' instead.
 
@@ -99,6 +100,7 @@ while (1) {
 		next if (/^$/);
 		print $DATABASE "%X\t$_";
 		while (<>) {
+			last if /^EOF$/;
 			print $DATABASE $_;
 		}
 	}


### PR DESCRIPTION
Brian,

I found that `addbib` cannot terminate abstract input with Ctrl-D as described in the instructions:

> Finally, (without -a) you will be prompted for an abstract.
> Type in as many lines as you need, and end with a ctrl-d.

In practice, pressing `Ctrl-D` causes the program to enter an infinite loop.
I was able to reproduce this behavior on **Cygwin**, **WSL**, and **Debian**.

I am not entirely sure why this happens; based on a reading of the code, it does not seem like Ctrl-D should lead to this behavior.

To address this, this PR changes the termination condition to require a line containing only EOF, which avoids reliance on EOF signals and prevents the infinite loop. The instructions and the implementation are updated accordingly.

Please let me know if this approach makes sense to you, or if you would prefer a different solution.