### PR TITLE
enable wildcards in ls and rm

### DIFF
--- a/bin/ls
+++ b/bin/ls
@@ -529,6 +529,7 @@ sub run {
 	my $Options;
 	( $Options, @args ) = $class->process_options(@args);
 	@args = qw(.) unless @args; # current directory if nothing else
+	@args = map {glob} @args if $^O =~ m{Win}msx;
 
 	my $ArgCount = -1;  # file/directory argument count
 	my %Attributes;     # File::stat directory entry attributes

--- a/bin/rm
+++ b/bin/rm
@@ -198,6 +198,7 @@ sub process_options {
 
 	$self->{options} = { map { defined $_ ? $_ : 0 } %opts };
 	$self->{files}   = $self->{args};
+	$self->{files}   = [ map { glob } @{$self->{files}} ] if $^O =~ m{Win}msx;
 
 	return $self;
 	}


### PR DESCRIPTION
Hi Brian, 

I recently discovered that [rename](https://metacpan.org/dist/File-Rename) works with wildcards on Windows. So I looked into its code and found it uses a very simple method. I've integrated it into `ls` and `rm`, and it seems to perfectly meet my needs.

Have a nice day!