### PR TITLE
nl: show usage for invalid -b0

### DIFF
--- a/bin/nl
+++ b/bin/nl
@@ -26,10 +26,9 @@ use Pod::Usage qw(pod2usage);
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
-our $VERSION = '1.3';
+our $VERSION = '1.4';
 my $program  = basename($0);
 
-# options
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
 my %options = ();
 getopts('b:d:f:h:i:n:ps:v:w:', \%options) or pod2usage(EX_FAILURE);
@@ -37,10 +36,10 @@ my $file = shift;
 $file = '-' unless defined $file;
 pod2usage(EX_FAILURE) if @ARGV;
 
-my $type_b      = $options{b} || "t";
-my $delim       = $options{d} || '\:';
-my $type_f      = $options{f} || "n";
-my $type_h      = $options{h} || "n";
+my $type_b      = exists $options{'b'} ? $options{'b'} : 't';
+my $delim       = exists $options{'d'} ? $options{'d'} : '\:';
+my $type_f      = exists $options{'f'} ? $options{'f'} : 'n';
+my $type_h      = exists $options{'h'} ? $options{'h'} : 'n';
 my $incr        = $options{i};
 my $format      = $options{n};
 my $single_page = $options{p};


### PR DESCRIPTION
* Truth check was causing nl -b0 to be ignored, but 0 is not an expected value
* Follow the pattern that already existed for option -s, also for other options setting a default value like this