### PR TITLE
what: print filenames unconditionally

### DIFF
--- a/bin/what
+++ b/bin/what
@@ -44,7 +44,7 @@ sub printWhat
     my $file_name   = shift;
     my $stop_flag   = shift;
     my $line;
-    print "$file_name:\n" if $file_name ne "";
+    print "$file_name:\n";
     while (defined($line = <$file_handle>))
     {
         next unless $line =~ m/\@\(#\)/;


### PR DESCRIPTION
* Print name once per file argument, including files containing zero matches
* Empty filename '' is generally invalid and would fail earlier in open()

```
%perl what /bin/gcc /bin/gprof ''
/bin/gcc:
/bin/gprof:
	 Copyright (c) 1983 Regents of the University of California.
Unable to open '': No such file or directory
```