### PR TITLE
glob: terminate error strings with newline

### DIFF
--- a/bin/glob
+++ b/bin/glob
@@ -90,7 +90,7 @@ sub run {
 
 sub exit {
 	my( $class, $code, $message ) = @_;
-
+	chomp $message;
 	print { *STDERR } "$message\n" if defined $message;
 	exit( defined $code ? $code : 0 );
 	}

--- a/bin/glob
+++ b/bin/glob
@@ -91,7 +91,7 @@ sub run {
 sub exit {
 	my( $class, $code, $message ) = @_;
 
-	print STDERR $message if defined $message;
+	print { *STDERR } "$message\n" if defined $message;
 	exit( defined $code ? $code : 0 );
 	}
 


### PR DESCRIPTION
* Message strings passed into $class->exit() did not include a newline---print one here instead of updating all the strings
* This was found when testing on Linux