### PR TITLE
tail: fix bug in rewriting argv

### DIFF
--- a/bin/tail
+++ b/bin/tail
@@ -74,6 +74,7 @@ sub new_argv
 {
     my @new;
     my $end = 0;
+    my $prev = '';
 
     foreach my $arg (@ARGV) {
         if ($arg eq '--' || $arg !~ m/\A[\-\+]/) {
@@ -82,11 +83,12 @@ sub new_argv
             next;
         }
 
-        if (!$end && $arg =~ m/\A([\-\+][0-9]+)\Z/) { # historic
+        if (!$end && $prev ne '-n' && $arg =~ m/\A([\-\+][0-9]+)\Z/) { # historic
             push @new, "-n$1";
         } else {
             push @new, $arg;
         }
+        $prev = $arg;
     }
     return @new;
 }


### PR DESCRIPTION
Function new_argv() handles translation of bare [-+]x option. This failed to identify if the pattern appeared immediately after "-n". This was found when testing against the GNU version.

Tests:
* perl tail -n 2 tail # last 2 lines
* perl tail -n -2 tail # last 2 lines
* perl tail -n +2 tail # show line 2 and all subsequent lines