### PR TITLE
tail: make -r do what the manual says

### DIFF
--- a/bin/tail
+++ b/bin/tail
@@ -146,6 +146,15 @@ sub print_tail
     my $i=0;
     my @buf;
 
+    # Show all of input for -r by default
+    if ($opt_r && !defined($opt_b) && !defined($opt_c) && !defined($opt_n)) {
+        @buf = <$fh>;
+        for (reverse (0 .. $#buf)) {
+            print $buf[$_];
+        }
+        return;
+    }
+
     if($type eq "n") {  # line
 
     if($p > 0) { # start from the beginning of the file


### PR DESCRIPTION
* This version of tail has the -r flag, which is a BSD extension
* The POD for -r says that the default for -r will show the entire input; this is consistent with NetBSD/FreeBSD/OpenBSD
* The default $point value of -10 was being used incorrectly in this case, but it should have no bearing here
* With this patch, `tac f` and `tail -r f` become equivalent (historical BSD did not have tac)