### PR TITLE
units: avoid division by zero

### DIFF
--- a/bin/units
+++ b/bin/units
@@ -223,7 +223,7 @@ sub unit_want {
 
     my $wu = $class->parse_unit($want);
 
-    if (is_Zero($wu)) {
+    if (is_Zero($wu) && defined($PARSE_ERROR)) {
       print $PARSE_ERROR, "\n";
     }
     return { want => $want, wu => $wu };
@@ -243,6 +243,7 @@ sub unit_convert {
     debug_t('have unit', dumper($hu));
     debug_t('want unit', dumper($wu));
 
+    exit(1) if is_Zero($hu) or is_Zero($wu);
     my $is_temperature = 0;
     $is_temperature++ if $hu->{Temperature};
     $is_temperature++ if $wu->{Temperature};


### PR DESCRIPTION
* The code was too simple-minded because it assumed it was OK to proceed with division when a unit name is not recognised
* unit_convert() is called after an "unknown unit" error is printed, so just exit the program before delegating to unit_divide() which causes the division error
* In case $PARSE_ERROR is not set, don't bother printing it

Tests:
*  `perl units cm ca` ---> arg2 unknown
* `perl units yo 0` ---> arg1 unknown

Old trace:
```
%perl units h 00000000
Unknown unit 'h'
Uncaught exception from user code:
	Division by zero error at units line 392.
	PerlPowerTools::units::unit_divide(HASH(0x555c5d9032f0), HASH(0x555c5cdba5b0)) called at units line 251
	PerlPowerTools::units::unit_convert("PerlPowerTools::units", undef, HASH(0x555c5d8fdbe8)) called at units line 92
	PerlPowerTools::units::run("PerlPowerTools::units", "h", 00000000) called at units line 79
```