### PR TITLE
addbib: raise error for bad option

### DIFF
--- a/bin/addbib
+++ b/bin/addbib
@@ -262,11 +262,7 @@ sub process_options {
 	my $class = shift;
 
 	local @ARGV = @_;
-	{
-	local $SIG{__WARN__} = sub { 1 };
-	Getopt::Std::getopts( 'ap:');
-	}
-
+	Getopt::Std::getopts( 'ap:') or $class->usage();
 	return $ARGV[0];
 	}
 


### PR DESCRIPTION
* As with other scripts in bin/, treat getopts() failure as a fatal error (show usage and exit)
* Don't suppress Getopt warnings, so the user sees feedback on which option was incorrect

I checked that the -a and -p VAL options are consistent with the Sun version. [1]
I installed the heirloom-package on OpenBSD (`pkg_add heirloom-doctools`) and confirmed that a fatal error is raised for an unknown option. [2]

```
C:\Users\hello\PerlPowerTools\bin>perl addbib -x db 
Unknown option: x
usage: addbib [ -a ] [ -p promptfile ] database
```

1. https://docs.oracle.com/cd/E19082-01/819-2239/819-2239.pdf page 34
2. https://n-t-roff.github.io/heirloom/doctools/addbib.1b.html