### PR TITLE
asa: allow -- for designating end of options

### DIFF
--- a/bin/asa
+++ b/bin/asa
@@ -15,16 +15,17 @@ License: perl
 use strict;
 
 use File::Basename qw(basename);
+use Getopt::Std qw(getopts);
 
 use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
 my $Program = basename($0);
 
-if (grep /\A\-/, @ARGV) {
+getopts('') or do {
 	warn "usage: $Program [file ...]\n";
 	exit EX_FAILURE;
-}
+};
 my $rc = EX_SUCCESS;
 foreach my $file (@ARGV) {
 	next if (-d $file);


### PR DESCRIPTION
I found this when testing against the FreeBSD version [1]. The C getopt() is being used [2], which accepts "--" as option-terminator. Perl's getopts() does the same thing so use that here. Since this program does not take any options, the main benefit I see is for filenames starting with a dash character.

With this change...
* `perl asa --` is the same as `perl asa` (read stdin)
* `perl asa -- -hello` reads the file "-hello" instead of raising an error

1. https://copy.sh/v86/?profile=freebsd
2. https://github.com/freebsd/freebsd-src/blob/main/usr.bin/asa/asa.c#L51