### PR TITLE
patch: fix typo "defined"

### DIFF
--- a/bin/patch
+++ b/bin/patch
@@ -375,7 +375,7 @@ sub bless {
     my $class = "Patch::\u$type";
 
     my ($options, $garbage) = @{$_[0]}{'options', 'garbage'};
-    $options = defiend $options ? $options : [];
+    $options = defined $options ? $options : [];
 
     # New hunk, same patch.
     $_[0]{hunk}++, return 1 if $_[0]->isa($class) && ! @$garbage;


### PR DESCRIPTION
I found error today when running patch program on Ubuntu.
I checked that no other files had that same typo.
```
% perl -Mdiagnostics patch ar < ar.diff
Can't call method "defiend" on unblessed reference at patch line 378, <STDIN>
        line 5 (#1)
    (F) A method call must know in what package it's supposed to run.  It
    ordinarily finds this out from the object reference you supply, but you
    didn't supply an object reference in this case.  A reference isn't an
    object reference until it has been blessed.  See perlobj.

Uncaught exception from user code:
        Can't call method "defiend" on unblessed reference at patch line 378, <STDIN> line 5.
        Patch::bless(Patch=HASH(0x614948aec970)) called at patch line 133
```
