### PR TITLE
file: fix hex escapes in magic file

### DIFF
--- a/bin/file
+++ b/bin/file
@@ -499,7 +499,7 @@ sub readMagicEntry {
         $$MF[1] = $line;
         return length($thisDepth);
     }
-    elsif (@$entry) {
+    elsif (defined $entry && @{ $entry }) {
         # already have an entry.  this is not a continuation.
         # save this line for the next call and exit.
         $$MF[1] = $line;
@@ -636,7 +636,8 @@ sub readMagicLine {
     $testval = $line;
 
     # do octal/hex conversion
-    $testval =~ s/\\([x0-7][0-7]?[0-7]?)/chr(oct($1))/eg;
+    $testval =~ s/\\x([0-9A-Fa-f]{1,2})/chr(hex($1))/eg;
+    $testval =~ s/\\([0-7][0-7]?[0-7]?)/chr(oct($1))/eg;
 
     # do single char escapes
     $testval =~ s/\\(.)/$ESC{$1}||$1/eg;


### PR DESCRIPTION
A magicfile string can contain common C escapes, defined in the  `%ESC` table, but also hex and octal ones. Octal escapes do not need a leading zero. Hex escapes need a leading "x". Previously the code attempted to handle hex and octal in one hit, but hex values were incorrectly being fed to builtin oct() function.

This PR also contains a fix for an runtime error I sometimes see in readMagicEntry() where the undefined value in $entry is accessed as a list.

Verification steps. Patch applied. Example magic file defined with extended entry for PNG data file. Before applying the patch, \r and \n escapes work properly but \x1a does not.
```
%uname -a
Linux mm-B450M-DS3H 7.0.0-14-generic #14-Ubuntu SMP PREEMPT_DYNAMIC Mon Apr 13 11:09:53 UTC 2026 x86_64 GNU/Linux
%perl hexdump -C ~/Downloads/pbn-filled.png | perl head -n1
00000000  89 50 4e 47 0d 0a 1a 0a  00 00 00 0d 49 48 44 52  |.PNG........IHDR|
%/usr/bin/file ~/Downloads/pbn-filled.png 
/home/mm/Downloads/pbn-filled.png: PNG image data, 1080 x 1440, 8-bit/color RGBA, non-interlaced
%perl cat new.magic 
0       string          =\x89PNG\r\n\x1a\n        PNG image data
>12     string          =IHDR                    with IHDR chunk
%perl file -m new.magic ~/Downloads/pbn-filled.png 
/home/mm/Downloads/pbn-filled.png: PNG image data with IHDR chunk
```