### PR TITLE
file: fix magic file escape \v

### DIFF
--- a/bin/file
+++ b/bin/file
@@ -58,7 +58,7 @@ my %ESC = (
     b => "\b",
     t => "\t",
     f => "\f",
-    v => "\v"
+    v => chr(0xb),
     );
 
 # from the BSD names.h, some tokens for hard-coded checks of


### PR DESCRIPTION
* The C escapes handled in magic file are: \n \r \b \t \f \v
* These escapes also are present in the 4.4BSD-Lite version [1]
* Perl does not support "\v" so update the ESC table with the correct value to avoid \v mapping to literal "v"
* This issue was exposed by toggling diagnostics.pm

[1]. https://github.com/dank101/4.4BSD-Lite2/blob/master/contrib/file-3.12/apprentice.c#L382-L406

```
%perl -Mdiagnostics -c file 
Unrecognized escape \v passed through at file line 61 (#1)
    (W misc) You used a backslash-character combination which is not
    recognized by Perl.  The character was understood literally, but this may
    change in a future version of Perl.
    
file syntax OK
```