### PR TITLE
join: fix -1 X and -2 Y explicit field numbers

### DIFF
--- a/bin/join
+++ b/bin/join
@@ -22,7 +22,7 @@ use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
 my $Program = basename($0);
-my $VERSION = '1.1';
+my $VERSION = '1.2';
 
 sub help {
   warn "$Program (Perl Power Tools) $VERSION\n";
@@ -268,12 +268,14 @@ sub get_options {
     }
     elsif (s/^-e//)    { $e_string = get_arg('e') }
     elsif (s/^-(?:j?([12])|j)//) {
+      my $file = $1;
       my $field = get_numeric_arg('j');
       if ($field == 0) {
         warn "fields start at 1\n";
         help();
       }
-      if ($1) { ($1 == 1 ? $j1 : $j2) = $field}
+      $field--; # treat as zero-based
+      if ($file) { ($file == 1 ? $j1 : $j2) = $field}
       else    { $j1 = $j2 = $field }
     }
     elsif (s/^-o//)    { get_field_specs() }


### PR DESCRIPTION
* Default field number is 1 for file1 and file2; this is designated by variable $j1 and $j2 being initialised to zero
* This is meant to be equivalent to `join -j 1`, which sets $j1 and $j2 to the same thing
* This is also supposed to be equivalent to `join -1 1 -2 1`
* Fix off-by-one error where the field number returned by get_numeric_arg() is not decremented (internally the field values are zero based)
* This issue was flagged by MS-365-Copilot analysis of the program, and patched by me
* Save the regex capture into a named variable to help clarify that it's talking about a file number and not a field number
* Bump version
* Tested against GNU coreutils

Test: before patch
```
%perl cat TAB1
AA xyz MR_BOB
XX asd MR_FRED
%perl cat TAB2
AA Friendly
BB Extinct
XX Grumpy
%/usr/bin/join --version
join (uutils coreutils) 0.8.0
%/usr/bin/join TAB{1,2}
AA xyz MR_BOB Friendly
XX asd MR_FRED Grumpy
%perl join TAB{1,2}
AA xyz MR_BOB Friendly
XX asd MR_FRED Grumpy
%/usr/bin/join -1 1 -2 1 TAB{1,2}
AA xyz MR_BOB Friendly
XX asd MR_FRED Grumpy
%perl join  -1 1 -2 1 TAB{1,2}
%perl join  -1 0 -2 0 TAB{1,2}
fields start at 1
join (Perl Power Tools) 1.1
usage: join [-a file_number | -v file_number] [-e string] [-j file_number field]
            [-o list] [-t char] [-1 field] [-2 field] file1 file2
```