### PR TITLE
cut: use error exit-code if a file argument does not open

### DIFF
--- a/bin/cut
+++ b/bin/cut
@@ -47,7 +47,7 @@ elsif (defined $opt{'f'}) {
     handle_f($opt{'f'}, $opt{'d'}, $opt{'s'});
 }
 else {
-    warn "$me: byte, character or field list required\n";
+    warn "byte, character or field list required\n";
     usage();
 }
 exit $rc;
@@ -55,11 +55,11 @@ exit $rc;
 sub checknum {
     my $n = shift;
     if ($n !~ m/\A\-?[0-9]+\Z/) {
-        warn "$me: unexpected byte or field number: '$n'\n";
+        warn "unexpected byte or field number: '$n'\n";
         exit EX_FAILURE;
     }
     if ($n == 0) {
-        warn "$me: bytes and fields are numbered from 1\n";
+        warn "bytes and fields are numbered from 1\n";
         exit EX_FAILURE;
     }
 }
@@ -78,18 +78,18 @@ sub parse_fields {
             $to = $3;
         }
         else {
-                warn "$me: invalid byte list: '$item'\n";
+                warn "invalid byte list: '$item'\n";
                 exit EX_FAILURE;
         }
         checknum($from) if length($from);
         checknum($to)   if length($to);
         if (!length($from) && !length($to)) { # reject lone '-'
-            warn "$me: invalid byte list\n";
+            warn "invalid byte list\n";
             exit EX_FAILURE;
         }
         if (length($from) && length($to)) {
             if ($from > $to) {
-                warn "$me: invalid range $from-$to\n";
+                warn "invalid range $from-$to\n";
                 exit EX_FAILURE;
             }
             $is_range = 0 if $from == $to;

--- a/bin/cut
+++ b/bin/cut
@@ -20,8 +20,17 @@ use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
 my $me = basename($0);
-
+my $rc = EX_SUCCESS;
 my %opt;
+
+$SIG{'__WARN__'} = sub {
+    my $msg = shift;
+    $msg =~ s/\n*\z/\n/;
+    print { *STDERR } "$me: $msg";
+    $rc = EX_FAILURE;
+    return;
+};
+
 getopts('b:c:d:f:ns', \%opt) or usage();
 
 # There's no difference between -b and -c on any unix I
@@ -41,7 +50,7 @@ else {
     warn "$me: byte, character or field list required\n";
     usage();
 }
-exit EX_SUCCESS;
+exit $rc;
 
 sub checknum {
     my $n = shift;


### PR DESCRIPTION
* When testing cut today I discovered that it uses the idiomatic while(<>) loop for reading input in handle_b() and handle_f()
* If file arguments are provided, all should process correctly in order for a success exit-code
* Failure to open a file argument means process-next-file, not terminate-program
* Hijack the WARN signal to set exit code; in future handle_b() and handle_f() could be restructured if necessary
* If a directory is passed as an argument it is ignored; this is consistent with OpenIndiana & OpenBSD, but GNU cut raises a warning for it
* For now, no attempt is made to suppress line numbers in the warning message

Test from "Git-Bash"...
```
$ perl -v | perl grep -F built
This is perl 5, version 42, subversion 2 (v5.42.2) built for x86_64-cygwin-thread-multi
$ echo 'y,a,y' > cheer
$ perl cut.pl -c1,2  nothing .. cheer
cut.pl: Can't open nothing: No such file or directory at cut.pl line 122.
y,
$ echo $?
1
```
