### PR TITLE
cut: correct delimiter usage in regex

### DIFF
--- a/bin/cut
+++ b/bin/cut
@@ -152,8 +152,8 @@ sub handle_f {
         chomp;
 
         # Only waste time on lines with delimiters
-        if (/$delim/) {
-            my @hunk = split /$delim/;
+        if (m/\Q$delim\E/) {
+            my @hunk = split /\Q$delim\E/;
             my $col = 0;
             my @out;
             foreach my $c (@cols) {


### PR DESCRIPTION
* A backslash is a valid field delimiter for cut, but it caused an error here because it was unintentionally interpreted into the regex
* Some existing scripts use \Q & \E pair in the regex to avoid this kind of problem; do it here too
* This was found when testing against other versions

Comparison with Linux system cut(1), before patch.
```
% echo "yo\\1" | cut -d\\ -f 1
yo
% echo "yo\\1" | perl -Mdiagnostics cut -d\\ -f 1
Trailing \ in regex m/\/ at cut line 155, <> line 1 (#1)
    (F) The regular expression ends with an unbackslashed backslash.
    Backslash it.   See perlre.
    
Uncaught exception from user code:
	Trailing \ in regex m/\/ at cut line 155, <> line 1.
	main::handle_f(1, "\\", undef) called at cut line 38
```