### PR TITLE
paste: support posix delimiter escapes

### DIFF
--- a/bin/paste
+++ b/bin/paste
@@ -21,16 +21,24 @@ use constant EX_SUCCESS => 0;
 use constant EX_FAILURE => 1;
 
 my $Program = basename($0);
-my ($VERSION) = '1.4';
-my (@fh, @sep, %opt);
+my ($VERSION) = '1.5';
+my (@fh, %opt);
+
+my @sep = ("\t");
+my %DELIM = (
+	'n'  => "\n",
+	't'  => "\t",
+	'\\' => "\\",
+	'0'  => "",
+);
 
 getopts('d:s', \%opt) or usage();
 @ARGV or usage();
 
 if (defined $opt{'d'}) {
-	@sep = split //, eval { "$opt{d}" };
-} else {
-	@sep = ("\t");
+	$opt{'d'} =~ s/\\(.)/delim_esc($1)/eg;
+	@sep = split //, $opt{'d'};
+	@sep = ('') unless @sep;
 }
 
 foreach my $f (@ARGV) {
@@ -85,6 +93,12 @@ while (files_open()) {
 	print "$tline\n";
 }
 exit EX_SUCCESS;
+
+sub delim_esc {
+	my $c = shift;
+	return $c unless exists $DELIM{$c};
+	return $DELIM{$c};
+}
 
 sub files_open {
 	for my $f (@fh) {


### PR DESCRIPTION
* Microsoft-365-Copilot static analysis found a crash in paste when the empty string is used as a delimiter
* POSIX document suggests that -d '\0'  is intended for an empty string delimiter [1]
* Add a function to support the escapes defined in the POSIX document
* GNU paste supports both -d '' and -d '\0' as meaning empty string delimiter; support both here for now
* Bump version

1. https://pubs.opengroup.org/onlinepubs/9799919799/utilities/paste.html

Previous crash:
```
%perl -Mdiagnostics paste -d '' paste paste
Use of uninitialized value $sep[0] in concatenation (.) or string at paste line
	81, <$fil> line 1 (#1)
    (W uninitialized) An undefined value was used as if it were already
    defined.  It was interpreted as a "" or a 0, but maybe it was a mistake.
    To suppress this warning assign a defined value to your variables.
    
    To help you figure out what was undefined, perl will try to tell you
    the name of the variable (if any) that was undefined.  In some cases
    it cannot do this, so it also tells you what operation you used the
    undefined value in.  Note, however, that perl optimizes your program
    and the operation displayed in the warning may not necessarily appear
    literally in your program.  For example, "that $foo" is usually
    optimized into "that " . $foo, and the warning will refer to the
    concatenation (.) operator, even though there is no . in
    your program.
    
Illegal modulus zero at paste line 82, <$fil> line 1 (#2)
    (F) You tried to divide a number by 0 to get the remainder.  Most
    numbers don't take to this kindly.
    
Uncaught exception from user code:
	Illegal modulus zero at paste line 82, <$fil> line 1.
```

	