### PR TITLE
join: fix crash for '(' delimiter

### DIFF
--- a/bin/join
+++ b/bin/join
@@ -155,9 +155,10 @@ sub get_a_line {
   my $not_eof = defined(my $line = <$fh>);
   if ($not_eof) {
     chomp $line;
-    push (@$aref,
-	  defined $delimiter ?
-	  [split $delimiter, $line, -1] : [split ' ', $line, -1]);
+    my $d = $delimiter;
+    $d = ' ' unless defined $d;
+    my @parts = split /\Q$d\E/, $line, -1;
+    push @{ $aref }, [ @parts ];
   }
   else { push @$aref, undef }
   return $not_eof;


### PR DESCRIPTION
* As per commit b345448fb8df200bdb92e4c0be595c18b58f2ac1 for cut(1)
* The -t option expects a literal character to use as a delimiter for reading input files, but it was interpreted as a regex in split()
* Apply the same \Q & \E fix in the match as
* Small re-factor to avoid calling split() in both branches of ternary-operator

Previous crash:
```
%perl -Mdiagnostics join -t '(' join join
Unmatched ( in regex; marked by <-- HERE in m/( <-- HERE / at join line 158,
	<$fh1> line 1 (#1)
    (F) Unbackslashed parentheses must always be balanced in regular
    expressions.  If you're a vi user, the % key is valuable for finding
    the matching parenthesis.  The <-- HERE shows whereabouts in the
    regular expression the problem was discovered.  See perlre.
    
Uncaught exception from user code:
	Unmatched ( in regex; marked by <-- HERE in m/( <-- HERE / at join line 158, <$fh1> line 1.
	main::get_a_line(ARRAY(0x62ea693459f8), GLOB(0x62ea690d6dc0)) called at join line 87
```

Demo after patch:
```
%perl join -t'(' TAB{1,2}
AA(xyz(MR_BOB(thoughtful
XX(asd(MR_FRED(large
%join -t'(' TAB{1,2}
AA(xyz(MR_BOB(thoughtful
XX(asd(MR_FRED(large
%perl cat TAB1
AA(xyz(MR_BOB
XX(asd(MR_FRED
%perl cat TAB2
AA(thoughtful
BB(missing
XX(large
```