### PR TITLE
tac: fix crash on empty file

### DIFF
--- a/bin/tac
+++ b/bin/tac
@@ -237,7 +237,8 @@ sub get_lines {
             my $tell = sysseek $fh, 0, 1;
             unless ($tell > $size) {
                 sysseek $fh, 0, 0       or confess "Bad seek on [$file]: $!";
-                sysread $fh, $_, $tell  or confess "Bad read on [$file]: $!";
+                my $n = sysread $fh, $_, $tell;
+                confess("Bad read on [$file]: $!") unless defined $n;
                 *$self->{EOF}++, last CHUNK;
             }
             sysseek $fh, -$size, 1      or confess "Bad seek on [$file]: $!";


### PR DESCRIPTION
* If the file argument refers to an empty file, tac failed with a "bad read" error
* Technically the read did not fail so the error is a false positive
* Address this by differentiating between 0 and undef return value of sysread (in this case we got 0, but both had the same result)